### PR TITLE
Fix get nearest touched spot

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1518,11 +1518,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
 
   /// find the nearest spot base on the touched offset
   LineBarSpot? _getNearestTouchedSpot(
-      Size viewSize,
-      Offset touchedPoint,
-      LineChartBarData barData,
-      int barDataPosition,
-      PaintHolder<LineChartData> holder) {
+    Size viewSize,
+    Offset touchedPoint,
+    LineChartBarData barData,
+    int barDataPosition,
+    PaintHolder<LineChartData> holder,
+  ) {
     final data = holder.data;
     if (!barData.show) {
       return null;
@@ -1531,17 +1532,21 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     final chartViewSize = getChartUsableDrawSize(viewSize, holder);
 
     /// Find the nearest spot (on X axis)
-    for (var i = 0; i < barData.spots.length; i++) {
-      final spot = barData.spots[i];
+    var nearestDistance = double.infinity;
+    LineBarSpot? nearestSpot;
+    for (final spot in barData.spots) {
       if (spot.isNotNull()) {
-        if ((touchedPoint.dx - getPixelX(spot.x, chartViewSize, holder))
-                .abs() <=
-            data.lineTouchData.touchSpotThreshold) {
-          return LineBarSpot(barData, barDataPosition, spot);
+        final distance =
+            (touchedPoint.dx - getPixelX(spot.x, chartViewSize, holder)).abs();
+
+        if (distance <= data.lineTouchData.touchSpotThreshold &&
+            distance <= nearestDistance) {
+          nearestDistance = distance;
+          nearestSpot = LineBarSpot(barData, barDataPosition, spot);
         }
       }
     }
 
-    return null;
+    return nearestSpot;
   }
 }


### PR DESCRIPTION
When user touch on chart, the most left (founded first) point in threshold is selected now, but it should be nearest point in threshold range.

↓ See this gif for details (`touchSpotThreshold` is set to 100 for the sake of clarity)
| before | after |
| -- | -- |
| ![ezgif com-gif-maker (3)](https://user-images.githubusercontent.com/24409457/138819650-1405ff48-a3d6-425f-a989-05018a3d11dd.gif) | ![ezgif com-gif-maker (4)](https://user-images.githubusercontent.com/24409457/138819678-25330b8d-69ff-4b35-8178-44be7483e7bc.gif) |