### PR TITLE
Added ability to set titlePositionPercentageOffset for individual RadarChartTitle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * **IMPROVEMENT** (by @imaNNeoFighT) Add some screenshots in `pubspec.yaml` to support new [pub.dev](pub.dev) feature. Read more about it [here](https://dart.dev/tools/pub/pubspec#screenshots) and [here](https://medium.com/dartlang/screenshots-and-automated-publishing-for-pub-dev-9bceb19edf79).
 * **IMPROVEMENT** (by @imaNNeo) Update the homepage url in `pubspec.yaml` (I just renamed my username)
 * **FEATURE** (by @JoshMart) Add ability to draw extra horizontal lines on BarChart, #476
+* * **FEATURE** (by @soraef) Add a `positionPercentageOffset` optional property to RadarChartTitle to allow individual title positioning
 
 ## 0.55.2
 * **BUGFIX** (by @imaNNeoFighT): Fix inner border of pieChart with single section, #1089

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -18,13 +18,23 @@ enum RadarShape {
 }
 
 class RadarChartTitle {
-  const RadarChartTitle({required this.text, this.angle = 0});
+  const RadarChartTitle({
+    required this.text,
+    this.angle = 0,
+    this.positionPercentageOffset,
+  });
 
   /// [text] is used to draw titles outside the [RadarChart]
   final String text;
 
   /// [angle] is used to rotate the title
   final double angle;
+
+  /// [positionPercentageOffset] is the place of showing title on the [RadarChart]
+  /// The higher the value of this field, the more titles move away from the chart.
+  /// The value of [positionPercentageOffset] takes precedence over the value of
+  /// [RadarChartData.titlePositionPercentageOffset], even if it is set.
+  final double? positionPercentageOffset;
 }
 
 /// [RadarChart] needs this class to render itself.

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -235,7 +235,9 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
         ..text = span
         ..layout();
       final angle = diffAngle * index - pi / 2;
-      final threshold = 1.0 + data.titlePositionPercentageOffset;
+      final threshold = 1.0 +
+          (title.positionPercentageOffset ??
+              data.titlePositionPercentageOffset);
       final titleX = centerX +
           cos(angle) * (radius * threshold + (_titleTextPaint.height / 2));
       final titleY = centerY +

--- a/repo_files/documentations/radar_chart.md
+++ b/repo_files/documentations/radar_chart.md
@@ -74,6 +74,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |:-------|:----------|:------------|
 |text|the text of the title|required|
 |angle|the angle used to rotate the title (in degree)|0|
+|positionPercentageOffset|this field is the place of showing title. The higher the value of this field, the more titles move away from the chart. this field should be between 0 and 1|null|
 
 ### some samples
 ----


### PR DESCRIPTION
Hello.
We are using your wonderful project.

When using RadarChart in our project, we had a request to set the titlePositionPercentageOffset per Title.

When we have long titles in RadarChart, we had a problem with too much space between the top and bottom titles and RadarChart, as shown in the attached image.

<img width="379" alt="スクリーンショット 2023-01-25 12 13 54" src="https://user-images.githubusercontent.com/17955947/214474722-08fa1888-b4c1-455c-8bd3-9aaefd77b438.png">


Therefore, we added a positionPercentageOffset parameter to RadarChartTitle to allow setting the titlePositionPercentageOffset individually.

By doing so, the title position can now be adjusted individually, as shown in the following image.

<img width="380" alt="スクリーンショット 2023-01-25 12 13 31" src="https://user-images.githubusercontent.com/17955947/214474732-96e88020-e3c1-4ebd-a30f-3bf0547dc7c6.png">
