### PR TITLE
Fix lineChartSample11 two line titles issue

### DIFF
--- a/example/lib/presentation/samples/line/line_chart_sample11.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample11.dart
@@ -159,7 +159,7 @@ class _Chart extends StatelessWidget {
             sideTitles: SideTitles(
               showTitles: true,
               getTitlesWidget: getVerticalTitles,
-              reservedSize: 28,
+              reservedSize: 36,
             ),
           ),
           topTitles: AxisTitles(
@@ -172,7 +172,7 @@ class _Chart extends StatelessWidget {
             sideTitles: SideTitles(
               showTitles: true,
               getTitlesWidget: getVerticalTitles,
-              reservedSize: 28,
+              reservedSize: 36,
             ),
           ),
           bottomTitles: AxisTitles(


### PR DESCRIPTION
<img width="480" alt="image" src="https://user-images.githubusercontent.com/7009300/215473922-a5276d1b-4d5f-45a2-94d3-35444c1c46b9.png">
