### PR TITLE
FEATURE: Fit SideTitle inside axis bounding box (prevent title overflow on edge)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ example/android/app/.project
 example/android/app/.settings/org.eclipse.buildship.core.prefs
 example/macos/Flutter/ephemeral/
 coverage/
+.fvm/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * **IMPROVEMENT** (by @imaNNeo) Make `drawBehindEverything` property default to `true` in [AxisTitles](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#axistitle) class, #1097.
 * **BUGFIX** (by @imaNNeo) Show `0` instead of `-0` in some edge-cases in the default titles 
 * **FEATURE** (by @tamasapps): Add `tooltipHorizontalAlignment` and `tooltipHorizontalOffset` property in [LineTouchTooltipData], [BarTouchTooltipData], [ScatterTouchTooltipData].
+* **FEATURE** (by @dhiyaaulauliyaa) Add ability to force SideTitle to be placed inside its corresponding axis bounding box, #603.
 
 ## 0.60.0
 * **IMPROVEMENT** (by @lsaudon) Replace flutter_lints by very_good_analysis

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -56,6 +56,9 @@ class LineChartSample3 extends StatefulWidget {
 class _LineChartSample3State extends State<LineChartSample3> {
   late double touchedValue;
 
+  bool fitInsideBottomTitle = true;
+  bool fitInsideLeftTitle = false;
+
   @override
   void initState() {
     touchedValue = -1;
@@ -91,6 +94,9 @@ class _LineChartSample3State extends State<LineChartSample3> {
     return SideTitleWidget(
       axisSide: meta.axisSide,
       space: 6,
+      fitInside: fitInsideLeftTitle
+          ? SideTitleFitInsideData.fromTitleMeta(meta)
+          : SideTitleFitInsideData.disable(),
       child: Text(text, style: style, textAlign: TextAlign.center),
     );
   }
@@ -108,6 +114,9 @@ class _LineChartSample3State extends State<LineChartSample3> {
     return SideTitleWidget(
       space: 4,
       axisSide: meta.axisSide,
+      fitInside: fitInsideBottomTitle
+          ? SideTitleFitInsideData.fromTitleMeta(meta, distanceFromEdge: 0)
+          : SideTitleFitInsideData.disable(),
       child: Text(
         widget.weekDays[value.toInt()],
         style: style,
@@ -120,6 +129,7 @@ class _LineChartSample3State extends State<LineChartSample3> {
     return Column(
       mainAxisSize: MainAxisSize.min,
       children: <Widget>[
+        const SizedBox(height: 10),
         Row(
           mainAxisSize: MainAxisSize.min,
           children: <Widget>[
@@ -409,6 +419,31 @@ class _LineChartSample3State extends State<LineChartSample3> {
               ),
             ),
           ),
+        ),
+        Column(
+          children: [
+            const Text('Fit Inside Title Option'),
+            const Divider(),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.center,
+              children: [
+                const Text('Left Title'),
+                Switch(
+                  value: fitInsideLeftTitle,
+                  onChanged: (value) => setState(() {
+                    fitInsideLeftTitle = value;
+                  }),
+                ),
+                const Text('Bottom Title'),
+                Switch(
+                  value: fitInsideBottomTitle,
+                  onChanged: (value) => setState(() {
+                    fitInsideBottomTitle = value;
+                  }),
+                )
+              ],
+            ),
+          ],
         ),
       ],
     );

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -107,7 +107,7 @@ class TitleMeta {
   /// parent axis max width/height
   final double parentAxisSize;
 
-  /// The position (in pixel) that applied to 
+  /// The position (in pixel) that applied to
   /// this drawing title along its axis.
   final double axisPosition;
 
@@ -217,6 +217,78 @@ class SideTitles with EquatableMixin {
         getTitlesWidget,
         reservedSize,
         interval,
+      ];
+}
+
+/// Force child widget to be positioned inside its
+/// corresponding axis bounding box
+///
+/// To makes things simpler, it's recommended to use
+/// [SideTitleFitInsideData.fromTitleMeta] and pass the
+/// TitleMeta provided from [SideTitles.getTitlesWidget]
+class SideTitleFitInsideData with EquatableMixin {
+  /// Force child widget to be positioned inside its
+  /// corresponding axis bounding box
+  ///
+  /// To makes things simpler, it's recommended to use
+  /// [SideTitleFitInsideData.fromTitleMeta] and pass the
+  /// TitleMeta provided from [SideTitles.getTitlesWidget]
+  ///
+  /// Some translations will be applied to force
+  /// children to be positioned inside the parent axis bounding box.
+  ///
+  /// Will override the [SideTitleWidget.space] and caused
+  /// spacing between [SideTitles] children might be not equal.
+  const SideTitleFitInsideData({
+    required this.enabled,
+    required this.axisPosition,
+    required this.parentAxisSize,
+    required this.distanceFromEdge,
+  });
+
+  /// Create a disabled [SideTitleFitInsideData].
+  /// If used, the child widget wouldn't be fitted
+  /// inside its corresponding axis bounding box
+  factory SideTitleFitInsideData.disable() => const SideTitleFitInsideData(
+        enabled: false,
+        distanceFromEdge: 0,
+        parentAxisSize: 0,
+        axisPosition: 0,
+      );
+
+  /// Help to Create [SideTitleFitInsideData] from [TitleMeta].
+  /// [TitleMeta] is provided by [SideTitles.getTitlesWidget] function.
+  factory SideTitleFitInsideData.fromTitleMeta(
+    TitleMeta meta, {
+    bool enabled = true,
+    double distanceFromEdge = 0,
+  }) =>
+      SideTitleFitInsideData(
+        enabled: enabled,
+        distanceFromEdge: distanceFromEdge,
+        parentAxisSize: meta.parentAxisSize,
+        axisPosition: meta.axisPosition,
+      );
+
+  /// Whether to enable fit inside to SideTitleWidget
+  final bool enabled;
+
+  /// Distance between child widget and its closest corresponding axis edge
+  final double distanceFromEdge;
+
+  /// Parent axis max width/height
+  final double parentAxisSize;
+
+  /// The position (in pixel) that applied to
+  /// the child widget along its corresponding axis.
+  final double axisPosition;
+
+  @override
+  List<Object?> get props => [
+        enabled,
+        distanceFromEdge,
+        parentAxisSize,
+        axisPosition,
       ];
 }
 

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -90,6 +90,8 @@ class TitleMeta {
   TitleMeta({
     required this.min,
     required this.max,
+    required this.parentAxisSize,
+    required this.axisPosition,
     required this.appliedInterval,
     required this.sideTitles,
     required this.formattedValue,
@@ -101,6 +103,13 @@ class TitleMeta {
 
   /// max axis value
   final double max;
+
+  /// parent axis max width/height
+  final double parentAxisSize;
+
+  /// The position (in pixel) that applied to 
+  /// this drawing title along its axis.
+  final double axisPosition;
 
   /// The interval that applied to this drawing title
   final double appliedInterval;

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -261,7 +261,7 @@ class SideTitleFitInsideData with EquatableMixin {
   factory SideTitleFitInsideData.fromTitleMeta(
     TitleMeta meta, {
     bool enabled = true,
-    double distanceFromEdge = 0,
+    double distanceFromEdge = 6,
   }) =>
       SideTitleFitInsideData(
         enabled: enabled,

--- a/lib/src/chart/base/axis_chart/axis_chart_helper.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_helper.dart
@@ -69,13 +69,13 @@ class AxisChartHelper {
 
     // Find title alignment along its axis
     final axisMid = parentAxisSize / 2;
-    final mainAxisAligment = (axisPosition - axisMid).isNegative
+    final mainAxisAlignment = (axisPosition - axisMid).isNegative
         ? MainAxisAlignment.start
         : MainAxisAlignment.end;
 
     // Find if child widget overflowed outside the chart
     late bool isOverflowed;
-    if (mainAxisAligment == MainAxisAlignment.start) {
+    if (mainAxisAlignment == MainAxisAlignment.start) {
       isOverflowed = (axisPosition - (childSize / 2)).isNegative;
     } else {
       isOverflowed = (axisPosition + (childSize / 2)) > parentAxisSize;
@@ -85,7 +85,7 @@ class AxisChartHelper {
 
     // Calc offset if child overflowed
     late double offset;
-    if (mainAxisAligment == MainAxisAlignment.start) {
+    if (mainAxisAlignment == MainAxisAlignment.start) {
       offset = (childSize / 2) - axisPosition + distanceFromEdge;
     } else {
       offset =

--- a/lib/src/chart/base/axis_chart/axis_chart_helper.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_helper.dart
@@ -1,4 +1,6 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/utils/utils.dart';
+import 'package:flutter/material.dart';
 
 class AxisChartHelper {
   factory AxisChartHelper() {
@@ -49,6 +51,54 @@ class AxisChartHelper {
     }
     if (maxIncluded && !lastPositionOverlapsWithMax) {
       yield max;
+    }
+  }
+
+  /// Calculate translate offset to keep [SideTitle] child
+  /// placed inside its corresponding axis.
+  /// The offset will translate the child to the closest edge inside
+  /// of the corresponding axis bounding box
+  Offset calcFitInsideOffset({
+    required AxisSide axisSide,
+    required double? childSize,
+    required double parentAxisSize,
+    required double axisPosition,
+    required double distanceFromEdge,
+  }) {
+    if (childSize == null) return Offset.zero;
+
+    // Find title alignment along its axis
+    final axisMid = parentAxisSize / 2;
+    final mainAxisAligment = (axisPosition - axisMid).isNegative
+        ? MainAxisAlignment.start
+        : MainAxisAlignment.end;
+
+    // Find if child widget overflowed outside the chart
+    late bool isOverflowed;
+    if (mainAxisAligment == MainAxisAlignment.start) {
+      isOverflowed = (axisPosition - (childSize / 2)).isNegative;
+    } else {
+      isOverflowed = (axisPosition + (childSize / 2)) > parentAxisSize;
+    }
+
+    if (isOverflowed == false) return Offset.zero;
+
+    // Calc offset if child overflowed
+    late double offset;
+    if (mainAxisAligment == MainAxisAlignment.start) {
+      offset = (childSize / 2) - axisPosition + distanceFromEdge;
+    } else {
+      offset =
+          -(childSize / 2) + (parentAxisSize - axisPosition) - distanceFromEdge;
+    }
+
+    switch (axisSide) {
+      case AxisSide.left:
+      case AxisSide.right:
+        return Offset(0, offset);
+      case AxisSide.top:
+      case AxisSide.bottom:
+        return Offset(offset, 0);
     }
   }
 }

--- a/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
@@ -1,5 +1,6 @@
 import 'package:fl_chart/fl_chart.dart';
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
 
 /// Wraps a [child] widget and applies some default behaviours
 ///
@@ -9,17 +10,33 @@ import 'package:flutter/widgets.dart';
 /// It also applies a [space] to the chart.
 /// You can also fill [angle] in radians if you need to rotate your widget.
 class SideTitleWidget extends StatelessWidget {
-  const SideTitleWidget({
+  SideTitleWidget({
     super.key,
     required this.child,
     required this.axisSide,
     this.space = 8.0,
     this.angle = 0.0,
-  });
+    this.fitInside = false,
+    this.titleMeta,
+  }) : assert(fitInside && titleMeta != null || !fitInside);
+
   final AxisSide axisSide;
   final double space;
   final Widget child;
   final double angle;
+  final TitleMeta? titleMeta;
+
+  /// If true, the widget will be placed
+  /// inside the parent axis bounding box.
+  ///
+  /// Some translations will be applied to force
+  /// children to be positioned inside the parent axis bounding box.
+  ///
+  /// Will override the [SideTitleWidget.space] and spacing between
+  /// [SideTitles] children might be not equal.
+  ///
+  /// If set to true, [SideTitleWidget.titleMeta] shouldn't be null.
+  final bool fitInside;
 
   Alignment _getAlignment() {
     switch (axisSide) {
@@ -51,14 +68,106 @@ class SideTitleWidget extends StatelessWidget {
     }
   }
 
+  /// Calculate translate offset to keep child 
+  /// placed inside its corresponding axis.
+  /// The offset will translate the child to the closest edge inside
+  /// of the parent
+  Offset _getOffset() {
+    if (!fitInside || _childSize.value == null) return Offset.zero;
+
+    final meta = titleMeta!;
+
+    // Find title alignment along its axis
+    final axisMid = meta.parentAxisSize / 2;
+    final mainAxisAligment = (meta.axisPosition - axisMid).isNegative
+        ? MainAxisAlignment.start
+        : MainAxisAlignment.end;
+
+    // Find if child widget overflowed outside the chart
+    final childSize = _childSize.value!;
+    late bool isOverflowed;
+    if (mainAxisAligment == MainAxisAlignment.start) {
+      isOverflowed = (meta.axisPosition - (childSize / 2)).isNegative;
+    } else {
+      isOverflowed =
+          (meta.axisPosition + (childSize / 2)) > meta.parentAxisSize;
+    }
+
+    if (isOverflowed == false) return Offset.zero;
+
+    // Calc offset if child overflowed
+    late double offset;
+    if (mainAxisAligment == MainAxisAlignment.start) {
+      offset = (childSize / 2) - meta.axisPosition;
+    } else {
+      offset = -(childSize / 2) + meta.parentAxisSize - meta.axisPosition;
+    }
+
+    switch (axisSide) {
+      case AxisSide.left:
+      case AxisSide.right:
+        return Offset(0, offset);
+      case AxisSide.top:
+      case AxisSide.bottom:
+        return Offset(offset, 0);
+    }
+  }
+
+  /// Calculate child width/height
+  final GlobalKey widgetKey = GlobalKey();
+  final ValueNotifier<double?> _childSize = ValueNotifier(null);
+  void _getChildSize(_) {
+    // If fitInside is false, no need to find child size
+    if (!fitInside) return;
+
+    // If childSize is not null, no need to find the size anymore
+    if (_childSize.value != null) return;
+
+    final context = widgetKey.currentContext;
+    if (context == null) return;
+
+    // Set size based on its axis side
+    late double size;
+    switch (axisSide) {
+      case AxisSide.left:
+      case AxisSide.right:
+        size = context.size?.height ?? 0;
+        break;
+      case AxisSide.top:
+      case AxisSide.bottom:
+        size = context.size?.width ?? 0;
+        break;
+    }
+
+    // If childSize is the same, no need to set new value
+    if (_childSize.value == size) return;
+
+    _childSize.value = size;
+  }
+
   @override
   Widget build(BuildContext context) {
-    return Transform.rotate(
-      angle: angle,
-      child: Container(
-        margin: _getMargin(),
-        alignment: _getAlignment(),
-        child: child,
+    SchedulerBinding.instance.addPostFrameCallback(_getChildSize);
+
+    return ValueListenableBuilder(
+      valueListenable: _childSize,
+      builder: (_, double? size, Widget? child) {
+        return Transform.translate(
+          offset: _getOffset(),
+          child: Opacity(
+            opacity: fitInside && size == null ? 0 : 1,
+            child: child,
+          ),
+        );
+      },
+      child: Transform.rotate(
+        angle: angle,
+        child: Container(
+          key: widgetKey,
+          margin: _getMargin(),
+          alignment: _getAlignment(),
+          child: child,
+        ),
       ),
     );
   }

--- a/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
@@ -10,7 +10,7 @@ import 'package:flutter/scheduler.dart';
 /// It also applies a [space] to the chart.
 /// You can also fill [angle] in radians if you need to rotate your widget.
 /// To force widget to be positioned within its axis bounding box,
-/// define [fitInside] by passing [SideTitleFitInsideData] 
+/// define [fitInside] by passing [SideTitleFitInsideData]
 class SideTitleWidget extends StatelessWidget {
   SideTitleWidget({
     super.key,
@@ -107,9 +107,11 @@ class SideTitleWidget extends StatelessWidget {
     // Calc offset if child overflowed
     late double offset;
     if (mainAxisAligment == MainAxisAlignment.start) {
-      offset = (childSize / 2) - axisPosition;
+      offset = (childSize / 2) - axisPosition + fitInside.distanceFromEdge;
     } else {
-      offset = -(childSize / 2) + parentAxisSize - axisPosition;
+      offset = -(childSize / 2) +
+          (parentAxisSize - axisPosition) -
+          fitInside.distanceFromEdge;
     }
 
     switch (axisSide) {

--- a/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_widgets.dart
@@ -1,4 +1,5 @@
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_helper.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
@@ -62,8 +63,6 @@ class _SideTitleWidgetState extends State<SideTitleWidget> {
         return Alignment.centerLeft;
       case AxisSide.bottom:
         return Alignment.topCenter;
-      default:
-        throw StateError('Invalid side');
     }
   }
 
@@ -77,64 +76,12 @@ class _SideTitleWidgetState extends State<SideTitleWidget> {
         return EdgeInsets.only(left: widget.space);
       case AxisSide.bottom:
         return EdgeInsets.only(top: widget.space);
-      default:
-        throw StateError('Invalid side');
-    }
-  }
-
-  /// Calculate translate offset to keep child
-  /// placed inside its corresponding axis.
-  /// The offset will translate the child to the closest edge inside
-  /// of the parent
-  Offset _getOffset() {
-    if (!widget.fitInside.enabled || _childSize == null) return Offset.zero;
-
-    final parentAxisSize = widget.fitInside.parentAxisSize;
-    final axisPosition = widget.fitInside.axisPosition;
-
-    // Find title alignment along its axis
-    final axisMid = parentAxisSize / 2;
-    final mainAxisAligment = (axisPosition - axisMid).isNegative
-        ? MainAxisAlignment.start
-        : MainAxisAlignment.end;
-
-    // Find if child widget overflowed outside the chart
-    final childSize = _childSize!;
-    late bool isOverflowed;
-    if (mainAxisAligment == MainAxisAlignment.start) {
-      isOverflowed = (axisPosition - (childSize / 2)).isNegative;
-    } else {
-      isOverflowed = (axisPosition + (childSize / 2)) > parentAxisSize;
-    }
-
-    if (isOverflowed == false) return Offset.zero;
-
-    // Calc offset if child overflowed
-    late double offset;
-    if (mainAxisAligment == MainAxisAlignment.start) {
-      offset =
-          (childSize / 2) - axisPosition + widget.fitInside.distanceFromEdge;
-    } else {
-      offset = -(childSize / 2) +
-          (parentAxisSize - axisPosition) -
-          widget.fitInside.distanceFromEdge;
-    }
-
-    switch (widget.axisSide) {
-      case AxisSide.left:
-      case AxisSide.right:
-        return Offset(0, offset);
-      case AxisSide.top:
-      case AxisSide.bottom:
-        return Offset(offset, 0);
     }
   }
 
   /// Calculate child width/height
   final GlobalKey widgetKey = GlobalKey();
-
   double? _childSize;
-
   void _getChildSize(_) {
     // If fitInside is false, no need to find child size
     if (!widget.fitInside.enabled) return;
@@ -179,7 +126,15 @@ class _SideTitleWidgetState extends State<SideTitleWidget> {
   @override
   Widget build(BuildContext context) {
     return Transform.translate(
-      offset: _getOffset(),
+      offset: !widget.fitInside.enabled
+          ? Offset.zero
+          : AxisChartHelper().calcFitInsideOffset(
+              axisSide: widget.axisSide,
+              childSize: _childSize,
+              parentAxisSize: widget.fitInside.parentAxisSize,
+              axisPosition: widget.fitInside.axisPosition,
+              distanceFromEdge: widget.fitInside.distanceFromEdge,
+            ),
       child: Transform.rotate(
         angle: widget.angle,
         child: Container(

--- a/lib/src/chart/base/axis_chart/side_titles/side_titles_widget.dart
+++ b/lib/src/chart/base/axis_chart/side_titles/side_titles_widget.dart
@@ -162,6 +162,8 @@ class SideTitlesWidget extends StatelessWidget {
               sideTitles: sideTitles,
               formattedValue: Utils().formatNumber(metaData.axisValue),
               axisSide: side,
+              parentAxisSize: axisViewSize,
+              axisPosition: metaData.axisPixelLocation,
             ),
           ),
         );

--- a/repo_files/documentations/base_chart.md
+++ b/repo_files/documentations/base_chart.md
@@ -32,6 +32,14 @@
 |reservedSize| It determines the maximum space that your titles need, |22|
 |interval| Texts are showing with provided `interval`. If you don't provide anything, we try to find a suitable value to set as `interval` under the hood. | null |
 
+### SideTitleFitInsideData
+|PropName		|Description	|default value|
+|:---------------|:---------------|:-------|
+|enabled| determines whether to enable fit inside to SideTitleWidget |true|
+|axisPosition| position (in pixel) that applied to the center of child widget along its corresponding axis |null|
+|parentAxisSize| child widget's corresponding axis maximum width/height |null|
+|distanceFromEdge| distance between child widget and its closest corresponding axis edge | 6 |
+
 ### FlGridData
 |PropName|Description|default value|
 |:-------|:----------|:------------|

--- a/test/chart/base/axis_chart/axis_chart_data_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_data_test.dart
@@ -31,6 +31,34 @@ void main() {
       expect(MockData.sideTitles1 == MockData.sideTitles6, false);
     });
 
+    test('SideTitleFitInsideData equality test', () {
+      expect(
+        MockData.sideTitleFitInsideData1 ==
+            MockData.sideTitleFitInsideData1Clone,
+        true,
+      );
+      expect(
+        MockData.sideTitleFitInsideData1 == MockData.sideTitleFitInsideData2,
+        false,
+      );
+      expect(
+        MockData.sideTitleFitInsideData1 == MockData.sideTitleFitInsideData3,
+        false,
+      );
+      expect(
+        MockData.sideTitleFitInsideData1 == MockData.sideTitleFitInsideData4,
+        false,
+      );
+      expect(
+        MockData.sideTitleFitInsideData1 == MockData.sideTitleFitInsideData5,
+        false,
+      );
+      expect(
+        MockData.sideTitleFitInsideData1 == MockData.sideTitleFitInsideData6,
+        false,
+      );
+    });
+
     test('FlSpot equality test', () {
       expect(flSpot1 == flSpot1Clone, true);
 

--- a/test/chart/base/axis_chart/axis_chart_helper_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_helper_test.dart
@@ -1,3 +1,4 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_helper.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -110,6 +111,94 @@ void main() {
       expect(results[1], 50);
       expect(results[2], 100);
       expect(results[3], 130);
+    });
+  });
+
+  group('calcFitInsideOffset', () {
+    group('not overflowed', () {
+      test('vertical axis', () {
+        const result = Offset.zero;
+
+        final offset = AxisChartHelper().calcFitInsideOffset(
+          axisSide: AxisSide.left,
+          childSize: 10,
+          parentAxisSize: 100,
+          axisPosition: 20,
+          distanceFromEdge: 0,
+        );
+
+        expect(offset, result);
+      });
+
+      test('horizontal axis', () {
+        const result = Offset.zero;
+
+        final offset = AxisChartHelper().calcFitInsideOffset(
+          axisSide: AxisSide.bottom,
+          childSize: 10,
+          parentAxisSize: 100,
+          axisPosition: 20,
+          distanceFromEdge: 0,
+        );
+
+        expect(offset, result);
+      });
+    });
+
+    group('overflowed', () {
+      test('vertical axis at start', () {
+        const result = Offset(0, 5);
+
+        final offset = AxisChartHelper().calcFitInsideOffset(
+          axisSide: AxisSide.left,
+          childSize: 10,
+          parentAxisSize: 100,
+          axisPosition: 0,
+          distanceFromEdge: 0,
+        );
+
+        expect(offset, result);
+      });
+      test('vertical axis at end', () {
+        const result = Offset(0, -5);
+
+        final offset = AxisChartHelper().calcFitInsideOffset(
+          axisSide: AxisSide.left,
+          childSize: 10,
+          parentAxisSize: 100,
+          axisPosition: 100,
+          distanceFromEdge: 0,
+        );
+
+        expect(offset, result);
+      });
+
+      test('horizontal axis at start', () {
+        const result = Offset(5, 0);
+
+        final offset = AxisChartHelper().calcFitInsideOffset(
+          axisSide: AxisSide.bottom,
+          childSize: 10,
+          parentAxisSize: 100,
+          axisPosition: 0,
+          distanceFromEdge: 0,
+        );
+
+        expect(offset, result);
+      });
+      test('horizontal axis at end', () {
+        const result = Offset(-5, 0);
+
+        final offset = AxisChartHelper().calcFitInsideOffset(
+          axisSide: AxisSide.bottom,
+          childSize: 10,
+          parentAxisSize: 100,
+          axisPosition: 100,
+          distanceFromEdge: 0,
+        );
+
+        expect(offset, result);
+      });
     });
   });
 }

--- a/test/chart/base/axis_chart/axis_chart_widgets_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_widgets_test.dart
@@ -3,75 +3,245 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
-  testWidgets(
-    'SideTitleWidget left',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: SideTitleWidget(
-              axisSide: AxisSide.left,
-              child: Text('1s'),
+  group(
+    'SideTitle without FitInside enabled',
+    () {
+      testWidgets(
+        'SideTitleWidget left',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: SideTitleWidget(
+                  axisSide: AxisSide.left,
+                  child: Text('1s'),
+                ),
+              ),
             ),
-          ),
-        ),
+          );
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('1s'), findsOneWidget);
+        },
       );
-      expect(find.byType(Container), findsOneWidget);
-      expect(find.text('1s'), findsOneWidget);
+
+      testWidgets(
+        'SideTitleWidget top',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: SideTitleWidget(
+                  axisSide: AxisSide.top,
+                  child: Text('1s'),
+                ),
+              ),
+            ),
+          );
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('1s'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'SideTitleWidget right',
+        (WidgetTester tester) async {
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: SideTitleWidget(
+                  axisSide: AxisSide.right,
+                  child: Text('1s'),
+                ),
+              ),
+            ),
+          );
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('1s'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'SideTitleWidget bottom',
+        (WidgetTester tester) async {
+          const widgetKey = Key('SideTitleWidget');
+          const sideTitleWidget = SideTitleWidget(
+            key: widgetKey,
+            axisSide: AxisSide.bottom,
+            child: Text('1s'),
+          );
+
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: sideTitleWidget,
+              ),
+            ),
+          );
+
+          final element =
+              tester.element(find.byKey(widgetKey)) as StatefulElement;
+          final state = element.state as State<SideTitleWidget>;
+          expect(state.widget, equals(sideTitleWidget));
+          expect(element.renderObject!.attached, isTrue);
+
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('1s'), findsOneWidget);
+
+          await tester.pump();
+        },
+      );
     },
   );
-
-  testWidgets(
-    'SideTitleWidget top',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: SideTitleWidget(
-              axisSide: AxisSide.top,
-              child: Text('1s'),
+  group(
+    'SideTitle with FitInside enabled',
+    () {
+      testWidgets(
+        'SideTitleWidget left with FitInsideEnabled on Top Side',
+        (WidgetTester tester) async {
+          const widgetKey = Key('SideTitleWidget');
+          const sideTitleWidget = SideTitleWidget(
+            key: widgetKey,
+            axisSide: AxisSide.left,
+            fitInside: SideTitleFitInsideData(
+              enabled: true,
+              axisPosition: 0,
+              parentAxisSize: 100,
+              distanceFromEdge: 0,
             ),
-          ),
-        ),
-      );
-      expect(find.byType(Container), findsOneWidget);
-      expect(find.text('1s'), findsOneWidget);
-    },
-  );
+            child: Text('A Long Text'),
+          );
 
-  testWidgets(
-    'SideTitleWidget right',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: SideTitleWidget(
-              axisSide: AxisSide.right,
-              child: Text('1s'),
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: sideTitleWidget,
+              ),
             ),
-          ),
-        ),
-      );
-      expect(find.byType(Container), findsOneWidget);
-      expect(find.text('1s'), findsOneWidget);
-    },
-  );
+          );
 
-  testWidgets(
-    'SideTitleWidget bottom',
-    (WidgetTester tester) async {
-      await tester.pumpWidget(
-        const MaterialApp(
-          home: Scaffold(
-            body: SideTitleWidget(
-              axisSide: AxisSide.bottom,
-              child: Text('1s'),
-            ),
-          ),
-        ),
+          final element =
+              tester.element(find.byKey(widgetKey)) as StatefulElement;
+          final state = element.state as State<SideTitleWidget>;
+          expect(state.widget, equals(sideTitleWidget));
+          expect(element.renderObject!.attached, isTrue);
+
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('A Long Text'), findsOneWidget);
+        },
       );
-      expect(find.byType(Container), findsOneWidget);
-      expect(find.text('1s'), findsOneWidget);
+
+      testWidgets(
+        'SideTitleWidget left with FitInsideEnabled on Bottom Side',
+        (WidgetTester tester) async {
+          const widgetKey = Key('SideTitleWidget');
+          const sideTitleWidget = SideTitleWidget(
+            key: widgetKey,
+            axisSide: AxisSide.left,
+            fitInside: SideTitleFitInsideData(
+              enabled: true,
+              axisPosition: 100,
+              parentAxisSize: 100,
+              distanceFromEdge: 0,
+            ),
+            child: Text('A Long Text'),
+          );
+
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: sideTitleWidget,
+              ),
+            ),
+          );
+
+          final element =
+              tester.element(find.byKey(widgetKey)) as StatefulElement;
+          final state = element.state as State<SideTitleWidget>;
+          expect(state.widget, equals(sideTitleWidget));
+          expect(element.renderObject!.attached, isTrue);
+
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('A Long Text'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'SideTitleWidget bottom with FitInsideEnabled on Left Side',
+        (WidgetTester tester) async {
+          const widgetKey = Key('SideTitleWidget');
+          const sideTitleWidget = SideTitleWidget(
+            key: widgetKey,
+            axisSide: AxisSide.bottom,
+            fitInside: SideTitleFitInsideData(
+              enabled: true,
+              axisPosition: 0,
+              parentAxisSize: 100,
+              distanceFromEdge: 0,
+            ),
+            child: Text('A Long Text'),
+          );
+
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: sideTitleWidget,
+              ),
+            ),
+          );
+
+          final element =
+              tester.element(find.byKey(widgetKey)) as StatefulElement;
+          final state = element.state as State<SideTitleWidget>;
+          expect(state.widget, equals(sideTitleWidget));
+          expect(element.renderObject!.attached, isTrue);
+
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('A Long Text'), findsOneWidget);
+        },
+      );
+
+      testWidgets(
+        'SideTitleWidget bottom with FitInsideEnabled on Right Side',
+        (WidgetTester tester) async {
+          const widgetKey = Key('SideTitleWidget');
+          const sideTitleWidget = SideTitleWidget(
+            key: widgetKey,
+            axisSide: AxisSide.bottom,
+            fitInside: SideTitleFitInsideData(
+              enabled: true,
+              axisPosition: 100,
+              parentAxisSize: 100,
+              distanceFromEdge: 0,
+            ),
+            child: Text('A Long Text'),
+          );
+
+          await tester.pumpWidget(
+            const MaterialApp(
+              home: Scaffold(
+                body: sideTitleWidget,
+              ),
+            ),
+          );
+
+          final element =
+              tester.element(find.byKey(widgetKey)) as StatefulElement;
+          final state = element.state as State<SideTitleWidget>;
+          expect(state.widget, equals(sideTitleWidget));
+          expect(element.renderObject!.attached, isTrue);
+
+          expect(find.byType(Transform), findsAtLeastNWidgets(2));
+          expect(find.byType(Container), findsOneWidget);
+          expect(find.text('A Long Text'), findsOneWidget);
+        },
+      );
     },
   );
 }

--- a/test/chart/base/axis_chart/axis_chart_widgets_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_widgets_test.dart
@@ -7,11 +7,11 @@ void main() {
     'SideTitleWidget left',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.left,
-              child: const Text('1s'),
+              child: Text('1s'),
             ),
           ),
         ),
@@ -25,11 +25,11 @@ void main() {
     'SideTitleWidget top',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.top,
-              child: const Text('1s'),
+              child: Text('1s'),
             ),
           ),
         ),
@@ -43,11 +43,11 @@ void main() {
     'SideTitleWidget right',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.right,
-              child: const Text('1s'),
+              child: Text('1s'),
             ),
           ),
         ),
@@ -61,11 +61,11 @@ void main() {
     'SideTitleWidget bottom',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.bottom,
-              child: const Text('1s'),
+              child: Text('1s'),
             ),
           ),
         ),

--- a/test/chart/base/axis_chart/axis_chart_widgets_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_widgets_test.dart
@@ -7,11 +7,11 @@ void main() {
     'SideTitleWidget left',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.left,
-              child: Text('1s'),
+              child: const Text('1s'),
             ),
           ),
         ),
@@ -25,11 +25,11 @@ void main() {
     'SideTitleWidget top',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.top,
-              child: Text('1s'),
+              child: const Text('1s'),
             ),
           ),
         ),
@@ -43,11 +43,11 @@ void main() {
     'SideTitleWidget right',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.right,
-              child: Text('1s'),
+              child: const Text('1s'),
             ),
           ),
         ),
@@ -61,11 +61,11 @@ void main() {
     'SideTitleWidget bottom',
     (WidgetTester tester) async {
       await tester.pumpWidget(
-        const MaterialApp(
+        MaterialApp(
           home: Scaffold(
             body: SideTitleWidget(
               axisSide: AxisSide.bottom,
-              child: Text('1s'),
+              child: const Text('1s'),
             ),
           ),
         ),

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -425,7 +425,7 @@ class MockData {
     distanceFromEdge: 0,
   );
   static const sideTitleFitInsideData5 = SideTitleFitInsideData(
-   enabled: true,
+    enabled: true,
     axisPosition: 200,
     parentAxisSize: 200,
     distanceFromEdge: 10,

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -394,6 +394,49 @@ class MockData {
     interval: 22,
   );
 
+  static const sideTitleFitInsideData1 = SideTitleFitInsideData(
+    enabled: true,
+    axisPosition: 0,
+    parentAxisSize: 100,
+    distanceFromEdge: 0,
+  );
+  static const sideTitleFitInsideData1Clone = SideTitleFitInsideData(
+    enabled: true,
+    axisPosition: 0,
+    parentAxisSize: 100,
+    distanceFromEdge: 0,
+  );
+  static const sideTitleFitInsideData2 = SideTitleFitInsideData(
+    enabled: true,
+    axisPosition: 0,
+    parentAxisSize: 100,
+    distanceFromEdge: 10,
+  );
+  static const sideTitleFitInsideData3 = SideTitleFitInsideData(
+    enabled: false,
+    axisPosition: 0,
+    parentAxisSize: 100,
+    distanceFromEdge: 0,
+  );
+  static const sideTitleFitInsideData4 = SideTitleFitInsideData(
+    enabled: true,
+    axisPosition: 200,
+    parentAxisSize: 200,
+    distanceFromEdge: 0,
+  );
+  static const sideTitleFitInsideData5 = SideTitleFitInsideData(
+   enabled: true,
+    axisPosition: 200,
+    parentAxisSize: 200,
+    distanceFromEdge: 10,
+  );
+  static const sideTitleFitInsideData6 = SideTitleFitInsideData(
+    enabled: false,
+    axisPosition: 200,
+    parentAxisSize: 200,
+    distanceFromEdge: 0,
+  );
+
   static const widget1 = Text('axis1');
   static const widget2 = Text('axis2');
   static const widget3 = Text('axis3');


### PR DESCRIPTION
Hi All!

I'm adding a feature to add an option for SideTitle to be fitted inside its corresponding axis bounding box.
This will fix #603. Below is the illustration:
- Before Using FitInside (SideTitle is overflowed): 
![Screenshot_1675854250](https://user-images.githubusercontent.com/20693268/217512793-d1c54030-a5a9-4d63-afed-86c93add8794.png)
- After Using FitInside (SideTitle is translated, hence not overflowed):
![Screenshot_1675854231](https://user-images.githubusercontent.com/20693268/217512828-2aeaf7a8-ccd7-409e-980a-da516e5ebd32.png)

What is added:
- FitInside data class (SideTitleFitInsideData) in lib/src/chart/base/axis_chart/axis_chart_data.dart
- FitInside parameter on SideTitleWidget
- Test for data class (SideTitleFitInsideData)
- Sample usage in example/lib/presentation/samples/line/line_chart_sample3.dart
