### PR TITLE
added gradient color to range annotations, issue #1195.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## newRelease
 * **BUGFIX** (by @JoshMart) Fix extra lines not painting when at chart min or max, #1255.
 * **BUGFIX** (by @imaNNeo) Check if mounted before calling setState in _handleBuiltInTouch methods in bar, line and scatter charts, #1101
+* **FEATURE** (by @MagdyYacoub1): Added gradient color to [RangeAnnotations](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#rangeannotations) by adding gradient attribute to [horizontalRangeAnnotations](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#horizontalrangeannotation) and [VerticalRangeAnnotation](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#verticalrangeannotation), #1195.
 
 ## 0.61.0
 * **IMPROVEMENT** (by @imaNNeo) Remove assertion to check to provide only one of `color` or `gradient` property in the [BarChartRodData](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/bar_chart.md#barchartroddata) and [BackgroundBarChartRodData](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/bar_chart.md#backgroundbarchartroddata), #1121.

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -827,7 +827,9 @@ class HorizontalRangeAnnotation with EquatableMixin {
     required this.y1,
     required this.y2,
     Color? color,
-  }) : color = color ?? Colors.white;
+    this.gradient,
+  }) : color = color ??
+            ((color == null && gradient == null) ? Colors.white : null);
 
   /// Determines starting point in vertical (y) axis.
   final double y1;
@@ -836,7 +838,10 @@ class HorizontalRangeAnnotation with EquatableMixin {
   final double y2;
 
   /// Fills the area with this color.
-  final Color color;
+  final Color? color;
+
+  /// Fills the area with gradient color.
+  final Gradient? gradient;
 
   /// Lerps a [HorizontalRangeAnnotation] based on [t] value, check [Tween.lerp].
   static HorizontalRangeAnnotation lerp(
@@ -848,6 +853,7 @@ class HorizontalRangeAnnotation with EquatableMixin {
       y1: lerpDouble(a.y1, b.y1, t)!,
       y2: lerpDouble(a.y2, b.y2, t)!,
       color: Color.lerp(a.color, b.color, t),
+      gradient: Gradient.lerp(a.gradient, b.gradient, t),
     );
   }
 
@@ -857,11 +863,13 @@ class HorizontalRangeAnnotation with EquatableMixin {
     double? y1,
     double? y2,
     Color? color,
+    Gradient? gradient,
   }) {
     return HorizontalRangeAnnotation(
       y1: y1 ?? this.y1,
       y2: y2 ?? this.y2,
       color: color ?? this.color,
+      gradient: gradient ?? this.gradient,
     );
   }
 
@@ -871,6 +879,7 @@ class HorizontalRangeAnnotation with EquatableMixin {
         y1,
         y2,
         color,
+        gradient,
       ];
 }
 
@@ -882,7 +891,9 @@ class VerticalRangeAnnotation with EquatableMixin {
     required this.x1,
     required this.x2,
     Color? color,
-  }) : color = color ?? Colors.white;
+    this.gradient,
+  }) : color = color ??
+            ((color == null && gradient == null) ? Colors.white : null);
 
   /// Determines starting point in horizontal (x) axis.
   final double x1;
@@ -891,7 +902,10 @@ class VerticalRangeAnnotation with EquatableMixin {
   final double x2;
 
   /// Fills the area with this color.
-  final Color color;
+  final Color? color;
+
+  /// Fills the area with gradient color.
+  final Gradient? gradient;
 
   /// Lerps a [VerticalRangeAnnotation] based on [t] value, check [Tween.lerp].
   static VerticalRangeAnnotation lerp(
@@ -903,6 +917,7 @@ class VerticalRangeAnnotation with EquatableMixin {
       x1: lerpDouble(a.x1, b.x1, t)!,
       x2: lerpDouble(a.x2, b.x2, t)!,
       color: Color.lerp(a.color, b.color, t),
+      gradient: Gradient.lerp(a.gradient, b.gradient, t),
     );
   }
 
@@ -912,11 +927,13 @@ class VerticalRangeAnnotation with EquatableMixin {
     double? x1,
     double? x2,
     Color? color,
+    Gradient? gradient,
   }) {
     return VerticalRangeAnnotation(
       x1: x1 ?? this.x1,
       x2: x2 ?? this.x2,
       color: color ?? this.color,
+      gradient: gradient ?? this.gradient,
     );
   }
 
@@ -926,6 +943,7 @@ class VerticalRangeAnnotation with EquatableMixin {
         x1,
         x2,
         color,
+        gradient,
       ];
 }
 

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -822,7 +822,7 @@ class RangeAnnotations with EquatableMixin {
 /// Defines an annotation region in y (vertical) axis.
 class HorizontalRangeAnnotation with EquatableMixin {
   /// Annotates a horizontal region from most left to most right point of the chart, and
-  /// from [y1] to [y2], and fills the area with [color].
+  /// from [y1] to [y2], and fills the area with [color] or [gradient].
   HorizontalRangeAnnotation({
     required this.y1,
     required this.y2,
@@ -837,10 +837,16 @@ class HorizontalRangeAnnotation with EquatableMixin {
   /// Determines ending point in vertical (y) axis.
   final double y2;
 
-  /// Fills the area with this color.
+  /// If provided, this [HorizontalRangeAnnotation] draws with this [color]
+  /// Otherwise we use [gradient] to draw the background.
+  /// It draws with [gradient] if you provide both [color] and [gradient].
+  /// If none is provided, it draws with a white color.
   final Color? color;
 
-  /// Fills the area with gradient color.
+  /// If provided, this [HorizontalRangeAnnotation] draws with this [gradient]
+  /// Otherwise we use [color] to draw the background.
+  /// It draws with [gradient] if you provide both [color] and [gradient].
+  /// If none is provided, it draws with a white color.
   final Gradient? gradient;
 
   /// Lerps a [HorizontalRangeAnnotation] based on [t] value, check [Tween.lerp].
@@ -886,7 +892,7 @@ class HorizontalRangeAnnotation with EquatableMixin {
 /// Defines an annotation region in x (horizontal) axis.
 class VerticalRangeAnnotation with EquatableMixin {
   /// Annotates a vertical region from most bottom to most top point of the chart, and
-  /// from [x1] to [x2], and fills the area with [color].
+  /// from [x1] to [x2], and fills the area with [color] or [gradient].
   VerticalRangeAnnotation({
     required this.x1,
     required this.x2,
@@ -901,10 +907,16 @@ class VerticalRangeAnnotation with EquatableMixin {
   /// Determines ending point in horizontal (x) axis.
   final double x2;
 
-  /// Fills the area with this color.
+  /// If provided, this [VerticalRangeAnnotation] draws with this [color]
+  /// Otherwise we use [gradient] to draw the background.
+  /// It draws with [gradient] if you provide both [color] and [gradient].
+  /// If none is provided, it draws with a white color.
   final Color? color;
 
-  /// Fills the area with gradient color.
+  /// If provided, this [VerticalRangeAnnotation] draws with this [gradient]
+  /// Otherwise we use [color] to draw the background.
+  /// It draws with [gradient] if you provide both [color] and [gradient].
+  /// If none is provided, it draws with a white color.
   final Gradient? gradient;
 
   /// Lerps a [VerticalRangeAnnotation] based on [t] value, check [Tween.lerp].

--- a/lib/src/chart/base/axis_chart/axis_chart_painter.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_painter.dart
@@ -162,7 +162,11 @@ abstract class AxisChartPainter<D extends AxisChartData>
 
         final rect = Rect.fromPoints(from, to);
 
-        _rangeAnnotationPaint.color = annotation.color;
+        _rangeAnnotationPaint.setColorOrGradient(
+          annotation.color,
+          annotation.gradient,
+          rect,
+        );
 
         canvasWrapper.drawRect(rect, _rangeAnnotationPaint);
       }
@@ -179,7 +183,11 @@ abstract class AxisChartPainter<D extends AxisChartData>
 
         final rect = Rect.fromPoints(from, to);
 
-        _rangeAnnotationPaint.color = annotation.color;
+        _rangeAnnotationPaint.setColorOrGradient(
+          annotation.color,
+          annotation.gradient,
+          rect,
+        );
 
         canvasWrapper.drawRect(rect, _rangeAnnotationPaint);
       }

--- a/repo_files/documentations/base_chart.md
+++ b/repo_files/documentations/base_chart.md
@@ -90,6 +90,7 @@
 |y1|start interval of horizontal rectangle|null|
 |y2|end interval of horizontal rectangle|null|
 |color|color of the rectangle|Colors.white|
+|gradient|gradient of the rectangle|null|
 
 
 ### VerticalRangeAnnotation
@@ -98,6 +99,7 @@
 |x1|start interval of vertical rectangle|null|
 |x2|end interval of vertical rectangle|null|
 |color|color of the rectangle|Colors.white|
+|gradient|gradient of the rectangle|null|
 
 ### FlTouchEvent
 Base class for all supported touch/pointer events.


### PR DESCRIPTION
Resolving issue #1195 

Added gradient attribute to [horizontalRangeAnnotations](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#horizontalrangeannotation) and [VerticalRangeAnnotation](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#verticalrangeannotation).

This will help specify gradient or solid color to range annotations. If none were identified, it would use a solid whit color.