### PR TITLE
refactor: add some features to BarChart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 * **BUGFIX** (by @JoshMart) Fix extra lines not painting when at chart min or max, #1255.
 * **BUGFIX** (by @imaNNeo) Check if mounted before calling setState in _handleBuiltInTouch methods in bar, line and scatter charts, #1101
 * **FEATURE** (by @MagdyYacoub1): Added gradient color to [RangeAnnotations](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#rangeannotations) by adding gradient attribute to [horizontalRangeAnnotations](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#horizontalrangeannotation) and [VerticalRangeAnnotation](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#verticalrangeannotation), #1195.
+* **BUGFIX** (by @Motionz-Von)Fix windows build for example app
+* **FEATURE** (by @Motionz-Von)BarChart groupSpace also takes effect when alignment is BarChartAlignment.end or BarChartAlignment.start.
+* **FEATURE** (by @Motionz-Von) supports setting line StrokeCap on HorizontalLine/VerticalLine
 
 ## 0.61.0
 * **IMPROVEMENT** (by @imaNNeo) Remove assertion to check to provide only one of `color` or `gradient` property in the [BarChartRodData](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/bar_chart.md#barchartroddata) and [BackgroundBarChartRodData](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/bar_chart.md#backgroundbarchartroddata), #1121.

--- a/example/.metadata
+++ b/example/.metadata
@@ -4,7 +4,7 @@
 # This file should be version controlled.
 
 version:
-  revision: 135454af32477f815a7525073027a3ff9eff1bfd
+  revision: 90c64ed42ba53a52d18f0cb3b17666c8662ed2a0
   channel: stable
 
 project_type: app
@@ -13,26 +13,11 @@ project_type: app
 migration:
   platforms:
     - platform: root
-      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-    - platform: android
-      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-    - platform: ios
-      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-    - platform: linux
-      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-    - platform: macos
-      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-    - platform: web
-      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
+      create_revision: 90c64ed42ba53a52d18f0cb3b17666c8662ed2a0
+      base_revision: 90c64ed42ba53a52d18f0cb3b17666c8662ed2a0
     - platform: windows
-      create_revision: 135454af32477f815a7525073027a3ff9eff1bfd
-      base_revision: 135454af32477f815a7525073027a3ff9eff1bfd
+      create_revision: 90c64ed42ba53a52d18f0cb3b17666c8662ed2a0
+      base_revision: 90c64ed42ba53a52d18f0cb3b17666c8662ed2a0
 
   # User provided section
 

--- a/example/windows/CMakeLists.txt
+++ b/example/windows/CMakeLists.txt
@@ -4,7 +4,7 @@ project(fl_chart_app LANGUAGES CXX)
 
 # The name of the executable created for the application. Change this to change
 # the on-disk name of your application.
-set(BINARY_NAME "FL Chart App")
+set(BINARY_NAME "fl_chart_app")
 
 # Explicitly opt in to modern CMake behaviors to avoid warnings with recent
 # versions of CMake.

--- a/example/windows/runner/CMakeLists.txt
+++ b/example/windows/runner/CMakeLists.txt
@@ -33,6 +33,7 @@ target_compile_definitions(${BINARY_NAME} PRIVATE "NOMINMAX")
 # Add dependency libraries and include directories. Add any application-specific
 # dependencies here.
 target_link_libraries(${BINARY_NAME} PRIVATE flutter flutter_wrapper_app)
+target_link_libraries(${BINARY_NAME} PRIVATE "dwmapi.lib")
 target_include_directories(${BINARY_NAME} PRIVATE "${CMAKE_SOURCE_DIR}")
 
 # Run the Flutter tool portions of the build. This must not be removed.

--- a/example/windows/runner/flutter_window.cpp
+++ b/example/windows/runner/flutter_window.cpp
@@ -26,6 +26,11 @@ bool FlutterWindow::OnCreate() {
   }
   RegisterPlugins(flutter_controller_->engine());
   SetChildContent(flutter_controller_->view()->GetNativeWindow());
+
+  flutter_controller_->engine()->SetNextFrameCallback([&]() {
+    this->Show();
+  });
+
   return true;
 }
 

--- a/example/windows/runner/main.cpp
+++ b/example/windows/runner/main.cpp
@@ -27,7 +27,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   FlutterWindow window(project);
   Win32Window::Point origin(10, 10);
   Win32Window::Size size(1280, 720);
-  if (!window.CreateAndShow(L"FL Chart App", origin, size)) {
+  if (!window.Create(L"FL Chart App", origin, size)) {
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);

--- a/example/windows/runner/win32_window.cpp
+++ b/example/windows/runner/win32_window.cpp
@@ -1,12 +1,30 @@
 #include "win32_window.h"
 
+#include <dwmapi.h>
 #include <flutter_windows.h>
 
 #include "resource.h"
 
 namespace {
 
+/// Window attribute that enables dark mode window decorations.
+///
+/// Redefined in case the developer's machine has a Windows SDK older than
+/// version 10.0.22000.0.
+/// See: https://docs.microsoft.com/windows/win32/api/dwmapi/ne-dwmapi-dwmwindowattribute
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+
 constexpr const wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
+
+/// Registry key for app theme preference.
+///
+/// A value of 0 indicates apps should use dark mode. A non-zero or missing
+/// value indicates apps should use light mode.
+constexpr const wchar_t kGetPreferredBrightnessRegKey[] =
+  L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize";
+constexpr const wchar_t kGetPreferredBrightnessRegValue[] = L"AppsUseLightTheme";
 
 // The number of Win32Window objects that currently exist.
 static int g_active_window_count = 0;
@@ -31,8 +49,8 @@ void EnableFullDpiSupportIfAvailable(HWND hwnd) {
           GetProcAddress(user32_module, "EnableNonClientDpiScaling"));
   if (enable_non_client_dpi_scaling != nullptr) {
     enable_non_client_dpi_scaling(hwnd);
-    FreeLibrary(user32_module);
   }
+  FreeLibrary(user32_module);
 }
 
 }  // namespace
@@ -102,9 +120,9 @@ Win32Window::~Win32Window() {
   Destroy();
 }
 
-bool Win32Window::CreateAndShow(const std::wstring& title,
-                                const Point& origin,
-                                const Size& size) {
+bool Win32Window::Create(const std::wstring& title,
+                         const Point& origin,
+                         const Size& size) {
   Destroy();
 
   const wchar_t* window_class =
@@ -117,7 +135,7 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
   double scale_factor = dpi / 96.0;
 
   HWND window = CreateWindow(
-      window_class, title.c_str(), WS_OVERLAPPEDWINDOW | WS_VISIBLE,
+      window_class, title.c_str(), WS_OVERLAPPEDWINDOW,
       Scale(origin.x, scale_factor), Scale(origin.y, scale_factor),
       Scale(size.width, scale_factor), Scale(size.height, scale_factor),
       nullptr, nullptr, GetModuleHandle(nullptr), this);
@@ -126,7 +144,13 @@ bool Win32Window::CreateAndShow(const std::wstring& title,
     return false;
   }
 
+  UpdateTheme(window);
+
   return OnCreate();
+}
+
+bool Win32Window::Show() {
+  return ShowWindow(window_handle_, SW_SHOWNORMAL);
 }
 
 // static
@@ -188,6 +212,10 @@ Win32Window::MessageHandler(HWND hwnd,
         SetFocus(child_content_);
       }
       return 0;
+
+    case WM_DWMCOLORIZATIONCOLORCHANGED:
+      UpdateTheme(hwnd);
+      return 0;
   }
 
   return DefWindowProc(window_handle_, message, wparam, lparam);
@@ -242,4 +270,19 @@ bool Win32Window::OnCreate() {
 
 void Win32Window::OnDestroy() {
   // No-op; provided for subclasses.
+}
+
+void Win32Window::UpdateTheme(HWND const window) {
+  DWORD light_mode;
+  DWORD light_mode_size = sizeof(light_mode);
+  LSTATUS result = RegGetValue(HKEY_CURRENT_USER, kGetPreferredBrightnessRegKey,
+                               kGetPreferredBrightnessRegValue,
+                               RRF_RT_REG_DWORD, nullptr, &light_mode,
+                               &light_mode_size);
+
+  if (result == ERROR_SUCCESS) {
+    BOOL enable_dark_mode = light_mode == 0;
+    DwmSetWindowAttribute(window, DWMWA_USE_IMMERSIVE_DARK_MODE,
+                          &enable_dark_mode, sizeof(enable_dark_mode));
+  }
 }

--- a/example/windows/runner/win32_window.h
+++ b/example/windows/runner/win32_window.h
@@ -28,15 +28,16 @@ class Win32Window {
   Win32Window();
   virtual ~Win32Window();
 
-  // Creates and shows a win32 window with |title| and position and size using
+  // Creates a win32 window with |title| that is positioned and sized using
   // |origin| and |size|. New windows are created on the default monitor. Window
   // sizes are specified to the OS in physical pixels, hence to ensure a
-  // consistent size to will treat the width height passed in to this function
-  // as logical pixels and scale to appropriate for the default monitor. Returns
-  // true if the window was created successfully.
-  bool CreateAndShow(const std::wstring& title,
-                     const Point& origin,
-                     const Size& size);
+  // consistent size this function will scale the inputted width and height as
+  // as appropriate for the default monitor. The window is invisible until
+  // |Show| is called. Returns true if the window was created successfully.
+  bool Create(const std::wstring& title, const Point& origin, const Size& size);
+
+  // Show the current window. Returns true if the window was successfully shown.
+  bool Show();
 
   // Release OS resources associated with window.
   void Destroy();
@@ -85,6 +86,9 @@ class Win32Window {
 
   // Retrieves a class instance pointer for |window|
   static Win32Window* GetThisFromHandle(HWND const window) noexcept;
+
+  // Update the window frame's theme to match the system theme.
+  static void UpdateTheme(HWND const window);
 
   bool quit_on_close_ = false;
 

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -982,6 +982,7 @@ class HorizontalLine extends FlLine with EquatableMixin {
     super.dashArray,
     this.image,
     this.sizedPicture,
+    this.strokeCap = StrokeCap.butt,
   })  : label = label ?? HorizontalLineLabel(),
         super(
           color: color ?? Colors.black,
@@ -1000,6 +1001,10 @@ class HorizontalLine extends FlLine with EquatableMixin {
   /// Draws a text label over the line.
   final HorizontalLineLabel label;
 
+  /// if not drawing dash line, then this is the Strokecap for the line.
+  /// i.e. if the two ends of the line is round or butt or square.
+  final StrokeCap strokeCap;
+
   /// Lerps a [HorizontalLine] based on [t] value, check [Tween.lerp].
   static HorizontalLine lerp(HorizontalLine a, HorizontalLine b, double t) {
     return HorizontalLine(
@@ -1010,6 +1015,7 @@ class HorizontalLine extends FlLine with EquatableMixin {
       dashArray: lerpIntList(a.dashArray, b.dashArray, t),
       image: b.image,
       sizedPicture: b.sizedPicture,
+      strokeCap: b.strokeCap,
     );
   }
 
@@ -1023,6 +1029,7 @@ class HorizontalLine extends FlLine with EquatableMixin {
         dashArray,
         image,
         sizedPicture,
+        strokeCap,
       ];
 }
 
@@ -1049,6 +1056,7 @@ class VerticalLine extends FlLine with EquatableMixin {
     super.dashArray,
     this.image,
     this.sizedPicture,
+    this.strokeCap = StrokeCap.butt,
   })  : label = label ?? VerticalLineLabel(),
         super(
           color: color ?? Colors.black,
@@ -1067,6 +1075,10 @@ class VerticalLine extends FlLine with EquatableMixin {
   /// Draws a text label over the line.
   final VerticalLineLabel label;
 
+  /// if not drawing dash line, then this is the Strokecap for the line.
+  /// i.e. if the two ends of the line is round or butt or square.
+  final StrokeCap strokeCap;
+
   /// Lerps a [VerticalLine] based on [t] value, check [Tween.lerp].
   static VerticalLine lerp(VerticalLine a, VerticalLine b, double t) {
     return VerticalLine(
@@ -1077,6 +1089,7 @@ class VerticalLine extends FlLine with EquatableMixin {
       dashArray: lerpIntList(a.dashArray, b.dashArray, t),
       image: b.image,
       sizedPicture: b.sizedPicture,
+      strokeCap: b.strokeCap,
     );
   }
 
@@ -1090,6 +1103,7 @@ class VerticalLine extends FlLine with EquatableMixin {
     List<int>? dashArray,
     Image? image,
     SizedPicture? sizedPicture,
+    StrokeCap? strokeCap,
   }) {
     return VerticalLine(
       x: x ?? this.x,
@@ -1099,6 +1113,7 @@ class VerticalLine extends FlLine with EquatableMixin {
       dashArray: dashArray ?? this.dashArray,
       image: image ?? this.image,
       sizedPicture: sizedPicture ?? this.sizedPicture,
+      strokeCap: strokeCap ?? this.strokeCap,
     );
   }
 
@@ -1112,6 +1127,7 @@ class VerticalLine extends FlLine with EquatableMixin {
         dashArray,
         image,
         sizedPicture,
+        strokeCap,
       ];
 }
 

--- a/lib/src/chart/base/axis_chart/axis_chart_painter.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_painter.dart
@@ -231,7 +231,8 @@ abstract class AxisChartPainter<D extends AxisChartData>
         _extraLinesPaint
           ..color = line.color
           ..strokeWidth = line.strokeWidth
-          ..transparentIfWidthIsZero();
+          ..transparentIfWidthIsZero()
+          ..strokeCap = line.strokeCap;
 
         canvasWrapper.drawDashedLine(
           from,
@@ -317,7 +318,8 @@ abstract class AxisChartPainter<D extends AxisChartData>
         _extraLinesPaint
           ..color = line.color
           ..strokeWidth = line.strokeWidth
-          ..transparentIfWidthIsZero();
+          ..transparentIfWidthIsZero()
+          ..strokeCap = line.strokeCap;
 
         canvasWrapper.drawDashedLine(
           from,

--- a/lib/src/extensions/bar_chart_data_extension.dart
+++ b/lib/src/extensions/bar_chart_data_extension.dart
@@ -7,18 +7,28 @@ extension BarChartDataExtension on BarChartData {
     switch (alignment) {
       case BarChartAlignment.start:
         var tempX = 0.0;
-        barGroups.asMap().forEach((i, group) {
+        for (var i = 0; i < barGroups.length; i++) {
+          final group = barGroups[i];
           groupsX[i] = tempX + group.width / 2;
-          tempX += group.width;
-        });
+
+          final groupSpace = i == barGroups.length - 1 ? 0 : groupsSpace;
+          tempX += group.width + groupSpace;
+        }
         break;
 
       case BarChartAlignment.end:
+        var sumWidth =
+            barGroups.map((group) => group.width).reduce((a, b) => a + b);
+        sumWidth += groupsSpace * (barGroups.length - 1);
+        final horizontalMargin = viewWidth - sumWidth;
+
         var tempX = 0.0;
-        for (var i = barGroups.length - 1; i >= 0; i--) {
+        for (var i = 0; i < barGroups.length; i++) {
           final group = barGroups[i];
-          groupsX[i] = viewWidth - tempX - group.width / 2;
-          tempX += group.width;
+          groupsX[i] = horizontalMargin + tempX + group.width / 2;
+
+          final groupSpace = i == barGroups.length - 1 ? 0 : groupsSpace;
+          tempX += group.width + groupSpace;
         }
         break;
 

--- a/repo_files/documentations/base_chart.md
+++ b/repo_files/documentations/base_chart.md
@@ -135,6 +135,7 @@ Base class for all supported touch/pointer events.
 |y|draw straight line from left to right of the chart with dynamic y value|null|
 |color|color of the line|Colors.black|
 |strokeWidth|strokeWidth of the line|2|
+|strokeCap|strokeCap of the line,e.g. Setting to StrokeCap.round will draw the tow ends of line rounded. NOTE: this might not work on dash lines.|StrokeCap.butt|
 |image|image to annotate the line. the Future must be complete at the time this is received by the chart|null|
 |sizedPicture|[SizedPicture](#Sizedpicture) uses an svg to annotate the line with a picture. the Future must be complete at the time this is received by the chart|null|
 |label|a [HorizontalLineLabel](#HorizontalLineLabel) object with label parameters|null
@@ -145,6 +146,7 @@ Base class for all supported touch/pointer events.
 |x|draw straight line from bottom to top of the chart with dynamic x value|null|
 |color|color of the line|Colors.black|
 |strokeWidth|strokeWidth of the line|2|
+|strokeCap|strokeCap of the line,e.g. Setting to StrokeCap.round will draw the tow ends of line rounded. NOTE: this might not work on dash lines.|StrokeCap.butt|
 |image|image to annotate the line. the Future must be complete at the time this is received by the chart|null|
 |sizedPicture|[SizedPicture](#SizedPicture) uses an svg to annotate the line with a picture. the Future must be complete at the time this is received by the chart|null|
 |label|a [VerticalLineLabel](#VerticalLineLabel) object with label parameters|null

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -124,8 +124,8 @@ void main() {
       }
 
       expect(callWithAlignment(BarChartAlignment.center), [50, 92.5, 142.5]);
-      expect(callWithAlignment(BarChartAlignment.start), [20, 52.5, 92.5]);
-      expect(callWithAlignment(BarChartAlignment.end), [100, 132.5, 172.5]);
+      expect(callWithAlignment(BarChartAlignment.start), [20, 62.5, 112.5]);
+      expect(callWithAlignment(BarChartAlignment.end), [80.0, 122.5, 172.5]);
       expect(
         callWithAlignment(BarChartAlignment.spaceEvenly),
         [40, 92.5, 152.5],
@@ -252,10 +252,10 @@ void main() {
       expect(centerResult[2].barsX, [120, 135, 150, 165]);
 
       final startResult = callWithAlignment(BarChartAlignment.start);
-      expect(startResult.map((e) => e.groupX).toList(), [20, 52.5, 92.5]);
+      expect(startResult.map((e) => e.groupX).toList(), [20.0, 62.5, 112.5]);
       expect(startResult[0].barsX, [5, 20, 35]);
-      expect(startResult[1].barsX, [45, 60]);
-      expect(startResult[2].barsX, [70, 85, 100, 115]);
+      expect(startResult[1].barsX, [55, 70]);
+      expect(startResult[2].barsX, [90, 105, 120, 135]);
     });
   });
 

--- a/test/extensions/bar_chart_data_extensions_test.dart
+++ b/test/extensions/bar_chart_data_extensions_test.dart
@@ -9,14 +9,14 @@ void main() {
       MockData.barChartData1
           .copyWith(alignment: BarChartAlignment.start)
           .calculateGroupsX(100),
-      [9.0, 27.0, 45.0],
+      [9.0, 43.0, 77.0],
     );
 
     expect(
       MockData.barChartData1
           .copyWith(alignment: BarChartAlignment.end)
           .calculateGroupsX(100),
-      [55.0, 73.0, 91.0],
+      [23.0, 57.0, 91.0],
     );
 
     expect(


### PR DESCRIPTION
1. fix windows build for example app
2. groupSpace also takes effect when alignment is BarChartAlignment.end or BarChartAlignment.start
	these aliment would not automatically adjust group spacing, compare to BarChartAlignment.spaceBetween and the like.
3. supports setting line StrokeCap on HorizontalLine/VerticalLine