### PR TITLE
refactor: Put constructors to const 

### DIFF
--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -226,10 +226,10 @@ class BarChartSample1State extends State<BarChartSample1> {
       ),
       titlesData: FlTitlesData(
         show: true,
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
         bottomTitles: AxisTitles(
@@ -239,7 +239,7 @@ class BarChartSample1State extends State<BarChartSample1> {
             reservedSize: 38,
           ),
         ),
-        leftTitles: AxisTitles(
+        leftTitles: const AxisTitles(
           sideTitles: SideTitles(
             showTitles: false,
           ),
@@ -249,7 +249,7 @@ class BarChartSample1State extends State<BarChartSample1> {
         show: false,
       ),
       barGroups: showingGroups(),
-      gridData: FlGridData(show: false),
+      gridData: const FlGridData(show: false),
     );
   }
 
@@ -307,17 +307,17 @@ class BarChartSample1State extends State<BarChartSample1> {
             reservedSize: 38,
           ),
         ),
-        leftTitles: AxisTitles(
+        leftTitles: const AxisTitles(
           sideTitles: SideTitles(
             showTitles: false,
           ),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(
             showTitles: false,
           ),
         ),
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(
             showTitles: false,
           ),
@@ -381,7 +381,7 @@ class BarChartSample1State extends State<BarChartSample1> {
             return throw Error();
         }
       }),
-      gridData: FlGridData(show: false),
+      gridData: const FlGridData(show: false),
     );
   }
 

--- a/example/lib/presentation/samples/bar/bar_chart_sample2.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample2.dart
@@ -132,10 +132,10 @@ class BarChartSample2State extends State<BarChartSample2> {
                   ),
                   titlesData: FlTitlesData(
                     show: true,
-                    rightTitles: AxisTitles(
+                    rightTitles: const AxisTitles(
                       sideTitles: SideTitles(showTitles: false),
                     ),
-                    topTitles: AxisTitles(
+                    topTitles: const AxisTitles(
                       sideTitles: SideTitles(showTitles: false),
                     ),
                     bottomTitles: AxisTitles(
@@ -158,7 +158,7 @@ class BarChartSample2State extends State<BarChartSample2> {
                     show: false,
                   ),
                   barGroups: showingBarGroups,
-                  gridData: FlGridData(show: false),
+                  gridData: const FlGridData(show: false),
                 ),
               ),
             ),

--- a/example/lib/presentation/samples/bar/bar_chart_sample3.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample3.dart
@@ -14,7 +14,7 @@ class _BarChart extends StatelessWidget {
         titlesData: titlesData,
         borderData: borderData,
         barGroups: barGroups,
-        gridData: FlGridData(show: false),
+        gridData: const FlGridData(show: false),
         alignment: BarChartAlignment.spaceAround,
         maxY: 20,
       ),
@@ -93,13 +93,13 @@ class _BarChart extends StatelessWidget {
             getTitlesWidget: getTitles,
           ),
         ),
-        leftTitles: AxisTitles(
+        leftTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
       );

--- a/example/lib/presentation/samples/bar/bar_chart_sample4.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample4.dart
@@ -92,10 +92,10 @@ class BarChartSample4State extends State<BarChartSample4> {
                       getTitlesWidget: leftTitles,
                     ),
                   ),
-                  topTitles: AxisTitles(
+                  topTitles: const AxisTitles(
                     sideTitles: SideTitles(showTitles: false),
                   ),
-                  rightTitles: AxisTitles(
+                  rightTitles: const AxisTitles(
                     sideTitles: SideTitles(showTitles: false),
                   ),
                 ),

--- a/example/lib/presentation/samples/bar/bar_chart_sample6.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample6.dart
@@ -123,9 +123,9 @@ class BarChartSample6 extends StatelessWidget {
               BarChartData(
                 alignment: BarChartAlignment.spaceBetween,
                 titlesData: FlTitlesData(
-                  leftTitles: AxisTitles(),
-                  rightTitles: AxisTitles(),
-                  topTitles: AxisTitles(),
+                  leftTitles: const AxisTitles(),
+                  rightTitles: const AxisTitles(),
+                  topTitles: const AxisTitles(),
                   bottomTitles: AxisTitles(
                     sideTitles: SideTitles(
                       showTitles: true,
@@ -136,7 +136,7 @@ class BarChartSample6 extends StatelessWidget {
                 ),
                 barTouchData: BarTouchData(enabled: false),
                 borderData: FlBorderData(show: false),
-                gridData: FlGridData(show: false),
+                gridData: const FlGridData(show: false),
                 barGroups: [
                   generateGroupData(0, 2, 3, 2),
                   generateGroupData(1, 2, 5, 1.7),

--- a/example/lib/presentation/samples/bar/bar_chart_sample7.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample7.dart
@@ -68,7 +68,7 @@ class _BarChartSample7State extends State<BarChartSample7> {
             titlesData: FlTitlesData(
               show: true,
               leftTitles: AxisTitles(
-                drawBehindEverything: true,
+                drawBelowEverything: true,
                 sideTitles: SideTitles(
                   showTitles: true,
                   reservedSize: 30,
@@ -96,8 +96,8 @@ class _BarChartSample7State extends State<BarChartSample7> {
                   },
                 ),
               ),
-              rightTitles: AxisTitles(),
-              topTitles: AxisTitles(),
+              rightTitles: const AxisTitles(),
+              topTitles: const AxisTitles(),
             ),
             gridData: FlGridData(
               show: true,

--- a/example/lib/presentation/samples/line/line_chart_sample1.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample1.dart
@@ -11,7 +11,7 @@ class _LineChart extends StatelessWidget {
   Widget build(BuildContext context) {
     return LineChart(
       isShowingMainData ? sampleData1 : sampleData2,
-      swapAnimationDuration: const Duration(milliseconds: 250),
+      duration: const Duration(milliseconds: 250),
     );
   }
 
@@ -50,10 +50,10 @@ class _LineChart extends StatelessWidget {
         bottomTitles: AxisTitles(
           sideTitles: bottomTitles,
         ),
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
         leftTitles: AxisTitles(
@@ -67,7 +67,7 @@ class _LineChart extends StatelessWidget {
         lineChartBarData1_3,
       ];
 
-  LineTouchData get lineTouchData2 => LineTouchData(
+  LineTouchData get lineTouchData2 => const LineTouchData(
         enabled: false,
       );
 
@@ -75,10 +75,10 @@ class _LineChart extends StatelessWidget {
         bottomTitles: AxisTitles(
           sideTitles: bottomTitles,
         ),
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
         leftTitles: AxisTitles(
@@ -163,7 +163,7 @@ class _LineChart extends StatelessWidget {
         getTitlesWidget: bottomTitleWidgets,
       );
 
-  FlGridData get gridData => FlGridData(show: false);
+  FlGridData get gridData => const FlGridData(show: false);
 
   FlBorderData get borderData => FlBorderData(
         show: true,
@@ -181,7 +181,7 @@ class _LineChart extends StatelessWidget {
         color: AppColors.contentColorGreen,
         barWidth: 8,
         isStrokeCapRound: true,
-        dotData: FlDotData(show: false),
+        dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(show: false),
         spots: const [
           FlSpot(1, 1),
@@ -199,7 +199,7 @@ class _LineChart extends StatelessWidget {
         color: AppColors.contentColorPink,
         barWidth: 8,
         isStrokeCapRound: true,
-        dotData: FlDotData(show: false),
+        dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(
           show: false,
           color: AppColors.contentColorPink.withOpacity(0),
@@ -219,7 +219,7 @@ class _LineChart extends StatelessWidget {
         color: AppColors.contentColorCyan,
         barWidth: 8,
         isStrokeCapRound: true,
-        dotData: FlDotData(show: false),
+        dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(show: false),
         spots: const [
           FlSpot(1, 2.8),
@@ -236,7 +236,7 @@ class _LineChart extends StatelessWidget {
         color: AppColors.contentColorGreen.withOpacity(0.5),
         barWidth: 4,
         isStrokeCapRound: true,
-        dotData: FlDotData(show: false),
+        dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(show: false),
         spots: const [
           FlSpot(1, 1),
@@ -254,7 +254,7 @@ class _LineChart extends StatelessWidget {
         color: AppColors.contentColorPink.withOpacity(0.5),
         barWidth: 4,
         isStrokeCapRound: true,
-        dotData: FlDotData(show: false),
+        dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(
           show: true,
           color: AppColors.contentColorPink.withOpacity(0.2),
@@ -275,7 +275,7 @@ class _LineChart extends StatelessWidget {
         color: AppColors.contentColorCyan.withOpacity(0.5),
         barWidth: 2,
         isStrokeCapRound: true,
-        dotData: FlDotData(show: true),
+        dotData: const FlDotData(show: true),
         belowBarData: BarAreaData(show: false),
         spots: const [
           FlSpot(1, 3.8),

--- a/example/lib/presentation/samples/line/line_chart_sample10.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample10.dart
@@ -85,9 +85,9 @@ class _LineChartSample10State extends State<LineChartSample10> {
                       maxY: 1,
                       minX: sinPoints.first.x,
                       maxX: sinPoints.last.x,
-                      lineTouchData: LineTouchData(enabled: false),
-                      clipData: FlClipData.all(),
-                      gridData: FlGridData(
+                      lineTouchData: const LineTouchData(enabled: false),
+                      clipData: const FlClipData.all(),
+                      gridData: const FlGridData(
                         show: true,
                         drawVerticalLine: false,
                       ),
@@ -96,7 +96,7 @@ class _LineChartSample10State extends State<LineChartSample10> {
                         sinLine(sinPoints),
                         cosLine(cosPoints),
                       ],
-                      titlesData: FlTitlesData(
+                      titlesData: const FlTitlesData(
                         show: false,
                       ),
                     ),
@@ -111,7 +111,7 @@ class _LineChartSample10State extends State<LineChartSample10> {
   LineChartBarData sinLine(List<FlSpot> points) {
     return LineChartBarData(
       spots: points,
-      dotData: FlDotData(
+      dotData: const FlDotData(
         show: false,
       ),
       gradient: LinearGradient(
@@ -126,7 +126,7 @@ class _LineChartSample10State extends State<LineChartSample10> {
   LineChartBarData cosLine(List<FlSpot> points) {
     return LineChartBarData(
       spots: points,
-      dotData: FlDotData(
+      dotData: const FlDotData(
         show: false,
       ),
       gradient: LinearGradient(

--- a/example/lib/presentation/samples/line/line_chart_sample11.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample11.dart
@@ -115,13 +115,13 @@ class _Chart extends StatelessWidget {
 
   FlLine getHorizontalVerticalLine(double value) {
     if ((value - baselineY).abs() <= 0.1) {
-      return FlLine(
+      return const FlLine(
         color: Colors.white70,
         strokeWidth: 1,
         dashArray: [8, 4],
       );
     } else {
-      return FlLine(
+      return const FlLine(
         color: Colors.blueGrey,
         strokeWidth: 0.4,
         dashArray: [8, 4],
@@ -131,13 +131,13 @@ class _Chart extends StatelessWidget {
 
   FlLine getVerticalVerticalLine(double value) {
     if ((value - baselineX).abs() <= 0.1) {
-      return FlLine(
+      return const FlLine(
         color: Colors.white70,
         strokeWidth: 1,
         dashArray: [8, 4],
       );
     } else {
-      return FlLine(
+      return const FlLine(
         color: Colors.blueGrey,
         strokeWidth: 0.4,
         dashArray: [8, 4],
@@ -196,7 +196,7 @@ class _Chart extends StatelessWidget {
         maxX: 10,
         baselineX: baselineX,
       ),
-      swapAnimationDuration: Duration.zero,
+      duration: Duration.zero,
     );
   }
 }

--- a/example/lib/presentation/samples/line/line_chart_sample2.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample2.dart
@@ -115,13 +115,13 @@ class _LineChartSample2State extends State<LineChartSample2> {
         horizontalInterval: 1,
         verticalInterval: 1,
         getDrawingHorizontalLine: (value) {
-          return FlLine(
+          return const FlLine(
             color: AppColors.mainGridLineColor,
             strokeWidth: 1,
           );
         },
         getDrawingVerticalLine: (value) {
-          return FlLine(
+          return const FlLine(
             color: AppColors.mainGridLineColor,
             strokeWidth: 1,
           );
@@ -129,10 +129,10 @@ class _LineChartSample2State extends State<LineChartSample2> {
       ),
       titlesData: FlTitlesData(
         show: true,
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
         bottomTitles: AxisTitles(
@@ -177,7 +177,7 @@ class _LineChartSample2State extends State<LineChartSample2> {
           ),
           barWidth: 5,
           isStrokeCapRound: true,
-          dotData: FlDotData(
+          dotData: const FlDotData(
             show: false,
           ),
           belowBarData: BarAreaData(
@@ -195,21 +195,21 @@ class _LineChartSample2State extends State<LineChartSample2> {
 
   LineChartData avgData() {
     return LineChartData(
-      lineTouchData: LineTouchData(enabled: false),
+      lineTouchData: const LineTouchData(enabled: false),
       gridData: FlGridData(
         show: true,
         drawHorizontalLine: true,
         verticalInterval: 1,
         horizontalInterval: 1,
         getDrawingVerticalLine: (value) {
-          return FlLine(
-            color: const Color(0xff37434d),
+          return const FlLine(
+            color: Color(0xff37434d),
             strokeWidth: 1,
           );
         },
         getDrawingHorizontalLine: (value) {
-          return FlLine(
-            color: const Color(0xff37434d),
+          return const FlLine(
+            color: Color(0xff37434d),
             strokeWidth: 1,
           );
         },
@@ -232,10 +232,10 @@ class _LineChartSample2State extends State<LineChartSample2> {
             interval: 1,
           ),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
       ),
@@ -269,7 +269,7 @@ class _LineChartSample2State extends State<LineChartSample2> {
           ),
           barWidth: 5,
           isStrokeCapRound: true,
-          dotData: FlDotData(
+          dotData: const FlDotData(
             show: false,
           ),
           belowBarData: BarAreaData(

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -368,12 +368,12 @@ class _LineChartSample3State extends State<LineChartSample3> {
                   checkToShowVerticalLine: (value) => value % 1 == 0,
                   getDrawingHorizontalLine: (value) {
                     if (value == 0) {
-                      return FlLine(
+                      return const FlLine(
                         color: AppColors.contentColorOrange,
                         strokeWidth: 2,
                       );
                     } else {
-                      return FlLine(
+                      return const FlLine(
                         color: AppColors.mainGridLineColor,
                         strokeWidth: 0.5,
                       );
@@ -381,12 +381,12 @@ class _LineChartSample3State extends State<LineChartSample3> {
                   },
                   getDrawingVerticalLine: (value) {
                     if (value == 0) {
-                      return FlLine(
+                      return const FlLine(
                         color: Colors.redAccent,
                         strokeWidth: 10,
                       );
                     } else {
-                      return FlLine(
+                      return const FlLine(
                         color: AppColors.mainGridLineColor,
                         strokeWidth: 0.5,
                       );
@@ -395,10 +395,10 @@ class _LineChartSample3State extends State<LineChartSample3> {
                 ),
                 titlesData: FlTitlesData(
                   show: true,
-                  topTitles: AxisTitles(
+                  topTitles: const AxisTitles(
                     sideTitles: SideTitles(showTitles: false),
                   ),
-                  rightTitles: AxisTitles(
+                  rightTitles: const AxisTitles(
                     sideTitles: SideTitles(showTitles: false),
                   ),
                   leftTitles: AxisTitles(

--- a/example/lib/presentation/samples/line/line_chart_sample4.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample4.dart
@@ -102,7 +102,7 @@ class LineChartSample4 extends StatelessWidget {
         ),
         child: LineChart(
           LineChartData(
-            lineTouchData: LineTouchData(enabled: false),
+            lineTouchData: const LineTouchData(enabled: false),
             lineBarsData: [
               LineChartBarData(
                 spots: const [
@@ -134,7 +134,7 @@ class LineChartSample4 extends StatelessWidget {
                   cutOffY: cutOffYValue,
                   applyCutOffY: true,
                 ),
-                dotData: FlDotData(
+                dotData: const FlDotData(
                   show: false,
                 ),
               ),
@@ -142,10 +142,10 @@ class LineChartSample4 extends StatelessWidget {
             minY: 0,
             titlesData: FlTitlesData(
               show: true,
-              topTitles: AxisTitles(
+              topTitles: const AxisTitles(
                 sideTitles: SideTitles(showTitles: false),
               ),
-              rightTitles: AxisTitles(
+              rightTitles: const AxisTitles(
                 sideTitles: SideTitles(showTitles: false),
               ),
               bottomTitles: AxisTitles(

--- a/example/lib/presentation/samples/line/line_chart_sample5.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample5.dart
@@ -97,7 +97,7 @@ class _LineChartSample5State extends State<LineChartSample5> {
             ],
           ),
         ),
-        dotData: FlDotData(show: false),
+        dotData: const FlDotData(show: false),
         gradient: LinearGradient(
           colors: [
             widget.gradientColor1,
@@ -160,7 +160,7 @@ class _LineChartSample5State extends State<LineChartSample5> {
                     (LineChartBarData barData, List<int> spotIndexes) {
                   return spotIndexes.map((index) {
                     return TouchedSpotIndicatorData(
-                      FlLine(
+                      const FlLine(
                         color: Colors.pink,
                       ),
                       FlDotData(
@@ -199,8 +199,8 @@ class _LineChartSample5State extends State<LineChartSample5> {
               lineBarsData: lineBarsData,
               minY: 0,
               titlesData: FlTitlesData(
-                leftTitles: AxisTitles(
-                  axisNameWidget: const Text('count'),
+                leftTitles: const AxisTitles(
+                  axisNameWidget: Text('count'),
                   axisNameSize: 24,
                   sideTitles: SideTitles(
                     showTitles: false,
@@ -221,15 +221,15 @@ class _LineChartSample5State extends State<LineChartSample5> {
                     reservedSize: 30,
                   ),
                 ),
-                rightTitles: AxisTitles(
-                  axisNameWidget: const Text('count'),
+                rightTitles: const AxisTitles(
+                  axisNameWidget: Text('count'),
                   sideTitles: SideTitles(
                     showTitles: false,
                     reservedSize: 0,
                   ),
                 ),
-                topTitles: AxisTitles(
-                  axisNameWidget: const Text(
+                topTitles: const AxisTitles(
+                  axisNameWidget: Text(
                     'Wall clock',
                     textAlign: TextAlign.left,
                   ),
@@ -240,7 +240,7 @@ class _LineChartSample5State extends State<LineChartSample5> {
                   ),
                 ),
               ),
-              gridData: FlGridData(show: false),
+              gridData: const FlGridData(show: false),
               borderData: FlBorderData(
                 show: true,
                 border: Border.all(

--- a/example/lib/presentation/samples/line/line_chart_sample6.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample6.dart
@@ -123,7 +123,7 @@ class LineChartSample6 extends StatelessWidget {
         aspectRatio: 2,
         child: LineChart(
           LineChartData(
-            lineTouchData: LineTouchData(enabled: false),
+            lineTouchData: const LineTouchData(enabled: false),
             lineBarsData: [
               LineChartBarData(
                 gradient: LinearGradient(
@@ -191,7 +191,7 @@ class LineChartSample6 extends StatelessWidget {
                   reservedSize: 30,
                 ),
               ),
-              bottomTitles: AxisTitles(
+              bottomTitles: const AxisTitles(
                 sideTitles: SideTitles(showTitles: false),
               ),
               topTitles: AxisTitles(

--- a/example/lib/presentation/samples/line/line_chart_sample7.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample7.dart
@@ -96,7 +96,7 @@ class LineChartSample7 extends StatelessWidget {
         ),
         child: LineChart(
           LineChartData(
-            lineTouchData: LineTouchData(enabled: false),
+            lineTouchData: const LineTouchData(enabled: false),
             lineBarsData: [
               LineChartBarData(
                 spots: const [
@@ -116,7 +116,7 @@ class LineChartSample7 extends StatelessWidget {
                 isCurved: true,
                 barWidth: 2,
                 color: line1Color,
-                dotData: FlDotData(
+                dotData: const FlDotData(
                   show: false,
                 ),
               ),
@@ -138,7 +138,7 @@ class LineChartSample7 extends StatelessWidget {
                 isCurved: false,
                 barWidth: 2,
                 color: line2Color,
-                dotData: FlDotData(
+                dotData: const FlDotData(
                   show: false,
                 ),
               ),
@@ -170,10 +170,10 @@ class LineChartSample7 extends StatelessWidget {
                   reservedSize: 36,
                 ),
               ),
-              topTitles: AxisTitles(
+              topTitles: const AxisTitles(
                 sideTitles: SideTitles(showTitles: false),
               ),
-              rightTitles: AxisTitles(
+              rightTitles: const AxisTitles(
                 sideTitles: SideTitles(showTitles: false),
               ),
             ),

--- a/example/lib/presentation/samples/line/line_chart_sample8.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample8.dart
@@ -188,7 +188,7 @@ class _LineChartSample8State extends State<LineChartSample8> {
           )
         ],
       ),
-      gridData: FlGridData(
+      gridData: const FlGridData(
         show: true,
         drawVerticalLine: false,
         drawHorizontalLine: false,
@@ -205,7 +205,7 @@ class _LineChartSample8State extends State<LineChartSample8> {
           ),
         ),
         leftTitles: AxisTitles(
-          drawBehindEverything: true,
+          drawBelowEverything: true,
           sideTitles: SideTitles(
             interval: 2,
             showTitles: true,
@@ -213,10 +213,10 @@ class _LineChartSample8State extends State<LineChartSample8> {
             reservedSize: 40,
           ),
         ),
-        rightTitles: AxisTitles(
+        rightTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
-        topTitles: AxisTitles(
+        topTitles: const AxisTitles(
           sideTitles: SideTitles(showTitles: false),
         ),
       ),
@@ -226,7 +226,7 @@ class _LineChartSample8State extends State<LineChartSample8> {
             (LineChartBarData barData, List<int> spotIndexes) {
           return spotIndexes.map((spotIndex) {
             return TouchedSpotIndicatorData(
-              FlLine(color: AppColors.contentColorOrange, strokeWidth: 3),
+              const FlLine(color: AppColors.contentColorOrange, strokeWidth: 3),
               FlDotData(
                 getDotPainter: (spot, percent, barData, index) =>
                     FlDotCirclePainter(
@@ -237,7 +237,7 @@ class _LineChartSample8State extends State<LineChartSample8> {
             );
           }).toList();
         },
-        touchTooltipData: LineTouchTooltipData(
+        touchTooltipData: const LineTouchTooltipData(
           tooltipBgColor: AppColors.contentColorBlue,
         ),
       ),
@@ -270,7 +270,7 @@ class _LineChartSample8State extends State<LineChartSample8> {
           color: AppColors.contentColorRed,
           barWidth: 4,
           isStrokeCapRound: true,
-          dotData: FlDotData(
+          dotData: const FlDotData(
             show: false,
           ),
         ),

--- a/example/lib/presentation/samples/line/line_chart_sample9.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample9.dart
@@ -88,7 +88,7 @@ class LineChartSample9 extends StatelessWidget {
                     belowBarData: BarAreaData(
                       show: false,
                     ),
-                    dotData: FlDotData(show: false),
+                    dotData: const FlDotData(show: false),
                   ),
                 ],
                 minY: -1.5,
@@ -101,9 +101,9 @@ class LineChartSample9 extends StatelessWidget {
                           leftTitleWidgets(value, meta, constraints.maxWidth),
                       reservedSize: 56,
                     ),
-                    drawBehindEverything: true,
+                    drawBelowEverything: true,
                   ),
-                  rightTitles: AxisTitles(
+                  rightTitles: const AxisTitles(
                     sideTitles: SideTitles(showTitles: false),
                   ),
                   bottomTitles: AxisTitles(
@@ -114,9 +114,9 @@ class LineChartSample9 extends StatelessWidget {
                       reservedSize: 36,
                       interval: 1,
                     ),
-                    drawBehindEverything: true,
+                    drawBelowEverything: true,
                   ),
-                  topTitles: AxisTitles(
+                  topTitles: const AxisTitles(
                     sideTitles: SideTitles(showTitles: false),
                   ),
                 ),

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample1.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample1.dart
@@ -41,10 +41,10 @@ class ScatterChartSample1State extends State<ScatterChartSample1> {
             borderData: FlBorderData(
               show: false,
             ),
-            gridData: FlGridData(
+            gridData: const FlGridData(
               show: false,
             ),
-            titlesData: FlTitlesData(
+            titlesData: const FlTitlesData(
               show: false,
             ),
             scatterTouchData: ScatterTouchData(

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -98,16 +98,16 @@ class _ScatterChartSample2State extends State {
             show: true,
             drawHorizontalLine: true,
             checkToShowHorizontalLine: (value) => true,
-            getDrawingHorizontalLine: (value) => FlLine(
+            getDrawingHorizontalLine: (value) => const FlLine(
               color: AppColors.gridLinesColor,
             ),
             drawVerticalLine: true,
             checkToShowVerticalLine: (value) => true,
-            getDrawingVerticalLine: (value) => FlLine(
+            getDrawingVerticalLine: (value) => const FlLine(
               color: AppColors.gridLinesColor,
             ),
           ),
-          titlesData: FlTitlesData(
+          titlesData: const FlTitlesData(
             show: false,
           ),
           showingTooltipIndicators: selectedSpots,

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -54,17 +54,13 @@ class BarChartData extends AxisChartData with EquatableMixin {
         barTouchData = barTouchData ?? BarTouchData(),
         super(
           titlesData: titlesData ??
-              FlTitlesData(
-                topTitles: AxisTitles(
-                  sideTitles: SideTitles(
-                    showTitles: false,
-                  ),
-                ),
+              const FlTitlesData(
+                topTitles: AxisTitles(),
               ),
-          gridData: gridData ?? FlGridData(),
-          rangeAnnotations: rangeAnnotations ?? RangeAnnotations(),
+          gridData: gridData ?? const FlGridData(),
+          rangeAnnotations: rangeAnnotations ?? const RangeAnnotations(),
           touchData: barTouchData ?? BarTouchData(),
-          extraLinesData: extraLinesData ?? ExtraLinesData(),
+          extraLinesData: extraLinesData ?? const ExtraLinesData(),
           minX: 0,
           maxX: 1,
           maxY: maxY ??

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -29,13 +29,13 @@ abstract class AxisChartData extends BaseChartData with EquatableMixin {
     super.borderData,
     required super.touchData,
     ExtraLinesData? extraLinesData,
-  })  : gridData = gridData ?? FlGridData(),
-        rangeAnnotations = rangeAnnotations ?? RangeAnnotations(),
+  })  : gridData = gridData ?? const FlGridData(),
+        rangeAnnotations = rangeAnnotations ?? const RangeAnnotations(),
         baselineX = baselineX ?? 0,
         baselineY = baselineY ?? 0,
-        clipData = clipData ?? FlClipData.none(),
+        clipData = clipData ?? const FlClipData.none(),
         backgroundColor = backgroundColor ?? Colors.transparent,
-        extraLinesData = extraLinesData ?? ExtraLinesData();
+        extraLinesData = extraLinesData ?? const ExtraLinesData();
   final FlGridData gridData;
   final FlTitlesData titlesData;
   final RangeAnnotations rangeAnnotations;
@@ -156,18 +156,12 @@ class SideTitles with EquatableMixin {
   ///
   /// Texts are showing with provided [interval]. If you don't provide anything,
   /// we try to find a suitable value to set as [interval] under the hood.
-  SideTitles({
-    bool? showTitles,
-    GetTitleWidgetFunction? getTitlesWidget,
-    double? reservedSize,
+  const SideTitles({
+    this.showTitles = false,
+    this.getTitlesWidget = defaultGetTitle,
+    this.reservedSize = 22,
     this.interval,
-  })  : showTitles = showTitles ?? false,
-        getTitlesWidget = getTitlesWidget ?? defaultGetTitle,
-        reservedSize = reservedSize ?? 22 {
-    if (interval == 0) {
-      throw ArgumentError("SideTitles.interval couldn't be zero");
-    }
-  }
+  }) : assert(interval != 0, "SideTitles.interval couldn't be zero");
 
   /// Determines showing or hiding this side titles
   final bool showTitles;
@@ -189,7 +183,7 @@ class SideTitles with EquatableMixin {
     return SideTitles(
       showTitles: b.showTitles,
       getTitlesWidget: b.getTitlesWidget,
-      reservedSize: lerpDouble(a.reservedSize, b.reservedSize, t),
+      reservedSize: lerpDouble(a.reservedSize, b.reservedSize, t)!,
       interval: lerpDouble(a.interval, b.interval, t),
     );
   }
@@ -300,14 +294,12 @@ class AxisTitles with EquatableMixin {
   /// [axisNameSize] determines the maximum size that [axisName] can use
   ///
   /// [sideTitles] property is responsible to show your axis side labels
-  AxisTitles({
+  const AxisTitles({
     this.axisNameWidget,
-    double? axisNameSize,
-    SideTitles? sideTitles,
-    bool? drawBehindEverything,
-  })  : axisNameSize = axisNameSize ?? 16,
-        sideTitles = sideTitles ?? SideTitles(),
-        drawBelowEverything = drawBehindEverything ?? true;
+    this.axisNameSize = 16,
+    this.sideTitles = const SideTitles(),
+    this.drawBelowEverything = true,
+  });
 
   /// Determines the size of [axisName]
   final double axisNameSize;
@@ -335,9 +327,9 @@ class AxisTitles with EquatableMixin {
   static AxisTitles lerp(AxisTitles a, AxisTitles b, double t) {
     return AxisTitles(
       axisNameWidget: b.axisNameWidget,
-      axisNameSize: lerpDouble(a.axisNameSize, b.axisNameSize, t),
+      axisNameSize: lerpDouble(a.axisNameSize, b.axisNameSize, t)!,
       sideTitles: SideTitles.lerp(a.sideTitles, b.sideTitles, t),
-      drawBehindEverything: b.drawBelowEverything,
+      drawBelowEverything: b.drawBelowEverything,
     );
   }
 
@@ -353,7 +345,7 @@ class AxisTitles with EquatableMixin {
       axisNameWidget: axisNameWidget ?? this.axisNameWidget,
       axisNameSize: axisNameSize ?? this.axisNameSize,
       sideTitles: sideTitles ?? this.sideTitles,
-      drawBehindEverything: drawBelowEverything ?? this.drawBelowEverything,
+      drawBelowEverything: drawBelowEverything ?? this.drawBelowEverything,
     );
   }
 
@@ -372,43 +364,35 @@ class FlTitlesData with EquatableMixin {
   /// [show] determines showing or hiding all titles,
   /// [leftTitles], [topTitles], [rightTitles], [bottomTitles] defines
   /// side titles of left, top, right, bottom sides respectively.
-  FlTitlesData({
-    bool? show,
-    AxisTitles? leftTitles,
-    AxisTitles? topTitles,
-    AxisTitles? rightTitles,
-    AxisTitles? bottomTitles,
-  })  : show = show ?? true,
-        leftTitles = leftTitles ??
-            AxisTitles(
-              sideTitles: SideTitles(
-                reservedSize: 44,
-                showTitles: true,
-              ),
-            ),
-        topTitles = topTitles ??
-            AxisTitles(
-              sideTitles: SideTitles(
-                reservedSize: 30,
-                showTitles: true,
-              ),
-            ),
-        rightTitles = rightTitles ??
-            AxisTitles(
-              sideTitles: SideTitles(
-                reservedSize: 44,
-                showTitles: true,
-              ),
-            ),
-        bottomTitles = bottomTitles ??
-            AxisTitles(
-              sideTitles: SideTitles(
-                reservedSize: 30,
-                showTitles: true,
-              ),
-            );
-  final bool show;
+  const FlTitlesData({
+    this.show = true,
+    this.leftTitles = const AxisTitles(
+      sideTitles: SideTitles(
+        reservedSize: 44,
+        showTitles: true,
+      ),
+    ),
+    this.topTitles = const AxisTitles(
+      sideTitles: SideTitles(
+        reservedSize: 30,
+        showTitles: true,
+      ),
+    ),
+    this.rightTitles = const AxisTitles(
+      sideTitles: SideTitles(
+        reservedSize: 44,
+        showTitles: true,
+      ),
+    ),
+    this.bottomTitles = const AxisTitles(
+      sideTitles: SideTitles(
+        reservedSize: 30,
+        showTitles: true,
+      ),
+    ),
+  });
 
+  final bool show;
   final AxisTitles leftTitles;
   final AxisTitles topTitles;
   final AxisTitles rightTitles;
@@ -541,30 +525,24 @@ class FlGridData with EquatableMixin {
   /// it gives you a double value (in the x axis), and you should return a boolean that determines
   /// showing or hiding specified line.
   /// or you can hide all vertical lines by setting [drawVerticalLine] false.
-  FlGridData({
-    bool? show,
-    bool? drawHorizontalLine,
+  const FlGridData({
+    this.show = true,
+    this.drawHorizontalLine = true,
     this.horizontalInterval,
-    GetDrawingGridLine? getDrawingHorizontalLine,
-    CheckToShowGrid? checkToShowHorizontalLine,
-    bool? drawVerticalLine,
+    this.getDrawingHorizontalLine = defaultGridLine,
+    this.checkToShowHorizontalLine = showAllGrids,
+    this.drawVerticalLine = true,
     this.verticalInterval,
-    GetDrawingGridLine? getDrawingVerticalLine,
-    CheckToShowGrid? checkToShowVerticalLine,
-  })  : show = show ?? true,
-        drawHorizontalLine = drawHorizontalLine ?? true,
-        getDrawingHorizontalLine = getDrawingHorizontalLine ?? defaultGridLine,
-        checkToShowHorizontalLine = checkToShowHorizontalLine ?? showAllGrids,
-        drawVerticalLine = drawVerticalLine ?? true,
-        getDrawingVerticalLine = getDrawingVerticalLine ?? defaultGridLine,
-        checkToShowVerticalLine = checkToShowVerticalLine ?? showAllGrids {
-    if (horizontalInterval == 0) {
-      throw ArgumentError("FlGridData.horizontalInterval couldn't be zero");
-    }
-    if (verticalInterval == 0) {
-      throw ArgumentError("FlGridData.verticalInterval couldn't be zero");
-    }
-  }
+    this.getDrawingVerticalLine = defaultGridLine,
+    this.checkToShowVerticalLine = showAllGrids,
+  })  : assert(
+          horizontalInterval != 0,
+          "FlGridData.horizontalInterval couldn't be zero",
+        ),
+        assert(
+          verticalInterval != 0,
+          "FlGridData.verticalInterval couldn't be zero",
+        );
 
   /// Determines showing or hiding all horizontal and vertical lines.
   final bool show;
@@ -670,7 +648,7 @@ typedef GetDrawingGridLine = FlLine Function(double value);
 
 /// Returns a grey line for all values.
 FlLine defaultGridLine(double value) {
-  return FlLine(
+  return const FlLine(
     color: Colors.blueGrey,
     strokeWidth: 0.4,
     dashArray: [8, 4],
@@ -685,12 +663,11 @@ class FlLine with EquatableMixin {
   /// it is a circular array of dash offsets and lengths.
   /// For example, the array `[5, 10]` would result in dashes 5 pixels long
   /// followed by blank spaces 10 pixels long.
-  FlLine({
-    Color? color,
-    double? strokeWidth,
+  const FlLine({
+    this.color = Colors.black,
+    this.strokeWidth = 2,
     this.dashArray,
-  })  : color = color ?? Colors.black,
-        strokeWidth = strokeWidth ?? 2;
+  });
 
   /// Defines color of the line.
   final Color color;
@@ -708,8 +685,8 @@ class FlLine with EquatableMixin {
   /// Lerps a [FlLine] based on [t] value, check [Tween.lerp].
   static FlLine lerp(FlLine a, FlLine b, double t) {
     return FlLine(
-      color: Color.lerp(a.color, b.color, t),
-      strokeWidth: lerpDouble(a.strokeWidth, b.strokeWidth, t),
+      color: Color.lerp(a.color, b.color, t)!,
+      strokeWidth: lerpDouble(a.strokeWidth, b.strokeWidth, t)!,
       dashArray: lerpIntList(a.dashArray, b.dashArray, t),
     );
   }
@@ -769,11 +746,11 @@ abstract class TouchedSpot with EquatableMixin {
 class RangeAnnotations with EquatableMixin {
   /// Axis based charts can annotate some horizontal and vertical regions,
   /// using [horizontalRangeAnnotations], and [verticalRangeAnnotations] respectively.
-  RangeAnnotations({
-    List<HorizontalRangeAnnotation>? horizontalRangeAnnotations,
-    List<VerticalRangeAnnotation>? verticalRangeAnnotations,
-  })  : horizontalRangeAnnotations = horizontalRangeAnnotations ?? const [],
-        verticalRangeAnnotations = verticalRangeAnnotations ?? const [];
+  const RangeAnnotations({
+    this.horizontalRangeAnnotations = const [],
+    this.verticalRangeAnnotations = const [],
+  });
+
   final List<HorizontalRangeAnnotation> horizontalRangeAnnotations;
   final List<VerticalRangeAnnotation> verticalRangeAnnotations;
 
@@ -788,12 +765,12 @@ class RangeAnnotations with EquatableMixin {
         a.horizontalRangeAnnotations,
         b.horizontalRangeAnnotations,
         t,
-      ),
+      )!,
       verticalRangeAnnotations: lerpVerticalRangeAnnotationList(
         a.verticalRangeAnnotations,
         b.verticalRangeAnnotations,
         t,
-      ),
+      )!,
     );
   }
 
@@ -1298,16 +1275,14 @@ class ExtraLinesData with EquatableMixin {
   ///
   /// If [extraLinesOnTop] sets true, it draws the line above the main bar lines, otherwise
   /// it draws them below the main bar lines.
-  ExtraLinesData({
-    List<HorizontalLine>? horizontalLines,
-    List<VerticalLine>? verticalLines,
-    bool? extraLinesOnTop,
-  })  : horizontalLines = horizontalLines ?? const [],
-        verticalLines = verticalLines ?? const [],
-        extraLinesOnTop = extraLinesOnTop ?? true;
+  const ExtraLinesData({
+    this.horizontalLines = const [],
+    this.verticalLines = const [],
+    this.extraLinesOnTop = true,
+  });
+
   final List<HorizontalLine> horizontalLines;
   final List<VerticalLine> verticalLines;
-
   final bool extraLinesOnTop;
 
   /// Lerps a [ExtraLinesData] based on [t] value, check [Tween.lerp].
@@ -1315,8 +1290,8 @@ class ExtraLinesData with EquatableMixin {
     return ExtraLinesData(
       extraLinesOnTop: b.extraLinesOnTop,
       horizontalLines:
-          lerpHorizontalLineList(a.horizontalLines, b.horizontalLines, t),
-      verticalLines: lerpVerticalLineList(a.verticalLines, b.verticalLines, t),
+          lerpHorizontalLineList(a.horizontalLines, b.horizontalLines, t)!,
+      verticalLines: lerpVerticalLineList(a.verticalLines, b.verticalLines, t)!,
     );
   }
 

--- a/lib/src/chart/base/axis_chart/axis_chart_painter.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_painter.dart
@@ -15,7 +15,7 @@ import 'package:flutter/material.dart';
 /// [targetData] is the target data, that animation is going to show (if animating)
 abstract class AxisChartPainter<D extends AxisChartData>
     extends BaseChartPainter<D> {
-  AxisChartPainter() : super() {
+  AxisChartPainter() {
     _gridPaint = Paint()..style = PaintingStyle.stroke;
 
     _backgroundPaint = Paint()..style = PaintingStyle.fill;

--- a/lib/src/chart/base/base_chart/base_chart_data.dart
+++ b/lib/src/chart/base/base_chart/base_chart_data.dart
@@ -85,7 +85,7 @@ class FlBorderData with EquatableMixin {
 /// to the painter, and gets touched spot, and wraps it into a concrete [BaseTouchResponse].
 abstract class FlTouchData<R extends BaseTouchResponse> with EquatableMixin {
   /// You can disable or enable the touch system using [enabled] flag,
-  FlTouchData(
+  const FlTouchData(
     this.enabled,
     this.touchCallback,
     this.mouseCursorResolver,
@@ -122,7 +122,7 @@ abstract class FlTouchData<R extends BaseTouchResponse> with EquatableMixin {
 /// Holds data to clipping chart around its borders.
 class FlClipData with EquatableMixin {
   /// Creates data that clips specified sides
-  FlClipData({
+  const FlClipData({
     required this.top,
     required this.bottom,
     required this.left,
@@ -130,19 +130,21 @@ class FlClipData with EquatableMixin {
   });
 
   /// Creates data that clips all sides
-  FlClipData.all() : this(top: true, bottom: true, left: true, right: true);
+  const FlClipData.all()
+      : this(top: true, bottom: true, left: true, right: true);
 
   /// Creates data that clips only top and bottom side
-  FlClipData.vertical()
+  const FlClipData.vertical()
       : this(top: true, bottom: true, left: false, right: false);
 
   /// Creates data that clips only left and right side
-  FlClipData.horizontal()
+  const FlClipData.horizontal()
       : this(top: false, bottom: false, left: true, right: true);
 
   /// Creates data that doesn't clip any side
-  FlClipData.none()
+  const FlClipData.none()
       : this(top: false, bottom: false, left: false, right: false);
+
   final bool top;
   final bool bottom;
   final bool left;
@@ -188,7 +190,7 @@ typedef MouseCursorResolver<R extends BaseTouchResponse> = MouseCursor Function(
 
 /// This class holds the touch response details of charts.
 abstract class BaseTouchResponse {
-  BaseTouchResponse();
+  const BaseTouchResponse();
 }
 
 /// Controls an element horizontal alignment to given point.

--- a/lib/src/chart/base/base_chart/base_chart_painter.dart
+++ b/lib/src/chart/base/base_chart/base_chart_painter.dart
@@ -6,7 +6,7 @@ import 'package:flutter/material.dart';
 /// Base class of our painters.
 class BaseChartPainter<D extends BaseChartData> {
   /// Draws some basic elements
-  BaseChartPainter();
+  const BaseChartPainter();
 
   // Paints [BaseChartData] into the provided canvas.
   void paint(
@@ -19,7 +19,7 @@ class BaseChartPainter<D extends BaseChartData> {
 /// Holds data for painting on canvas
 class PaintHolder<Data extends BaseChartData> {
   /// Holds data for painting on canvas
-  PaintHolder(this.data, this.targetData, this.textScale);
+  const PaintHolder(this.data, this.targetData, this.textScale);
 
   /// [data] is what we need to show frame by frame (it might be changed by an animator)
   final Data data;

--- a/lib/src/chart/base/base_chart/fl_touch_event.dart
+++ b/lib/src/chart/base/base_chart/fl_touch_event.dart
@@ -5,6 +5,8 @@ import 'package:flutter/services.dart';
 
 /// Parent class for several kind of touch/pointer events (like tap, panMode, longPressStart, ...)
 abstract class FlTouchEvent {
+  const FlTouchEvent();
+
   /// Represents the position of happened touch/pointer event
   ///
   /// Some events such as [FlPanCancelEvent] and [FlTapCancelEvent]
@@ -41,7 +43,7 @@ abstract class FlTouchEvent {
 /// The [details] object provides the position of the touch.
 /// Inspired from [GestureDragDownCallback]
 class FlPanDownEvent extends FlTouchEvent {
-  FlPanDownEvent(this.details);
+  const FlPanDownEvent(this.details);
 
   /// Contains information of happened touch gesture
   final DragDownDetails details;
@@ -58,7 +60,7 @@ class FlPanDownEvent extends FlTouchEvent {
 /// Inspired from [GestureDragStartCallback].
 class FlPanStartEvent extends FlTouchEvent {
   /// Creates
-  FlPanStartEvent(this.details);
+  const FlPanStartEvent(this.details);
 
   /// Contains information of happened touch gesture
   final DragStartDetails details;
@@ -75,7 +77,7 @@ class FlPanStartEvent extends FlTouchEvent {
 /// has traveled since the last update.
 /// Inspired from [GestureDragUpdateCallback]
 class FlPanUpdateEvent extends FlTouchEvent {
-  FlPanUpdateEvent(this.details);
+  const FlPanUpdateEvent(this.details);
 
   /// Contains information of happened touch gesture
   final DragUpdateDetails details;
@@ -87,7 +89,9 @@ class FlPanUpdateEvent extends FlTouchEvent {
 
 /// When the pointer that previously triggered a [FlPanStartEvent] did not complete.
 /// Inspired from [GestureDragCancelCallback]
-class FlPanCancelEvent extends FlTouchEvent {}
+class FlPanCancelEvent extends FlTouchEvent {
+  const FlPanCancelEvent();
+}
 
 /// When a pointer that was previously in contact with the screen
 /// and moving is no longer in contact with the screen.
@@ -96,7 +100,7 @@ class FlPanCancelEvent extends FlTouchEvent {}
 /// the screen is available in the [details].
 /// Inspired from [GestureDragEndCallback]
 class FlPanEndEvent extends FlTouchEvent {
-  FlPanEndEvent(this.details);
+  const FlPanEndEvent(this.details);
 
   /// Contains information of happened touch gesture
   final DragEndDetails details;
@@ -109,7 +113,7 @@ class FlPanEndEvent extends FlTouchEvent {
 /// [details].
 /// Inspired from [GestureTapDownCallback]
 class FlTapDownEvent extends FlTouchEvent {
-  FlTapDownEvent(this.details);
+  const FlTapDownEvent(this.details);
 
   /// Contains information of happened touch gesture
   final TapDownDetails details;
@@ -121,7 +125,9 @@ class FlTapDownEvent extends FlTouchEvent {
 
 /// When the pointer that previously triggered a [FlTapDownEvent] will not end up causing a tap.
 /// Inspired from [GestureTapCancelCallback]
-class FlTapCancelEvent extends FlTouchEvent {}
+class FlTapCancelEvent extends FlTouchEvent {
+  const FlTapCancelEvent();
+}
 
 /// When a pointer that will trigger a tap has stopped contacting
 /// the screen.
@@ -130,7 +136,7 @@ class FlTapCancelEvent extends FlTouchEvent {}
 /// in the [details].
 /// Inspired from [GestureTapUpCallback]
 class FlTapUpEvent extends FlTouchEvent {
-  FlTapUpEvent(this.details);
+  const FlTapUpEvent(this.details);
 
   /// Contains information of happened touch gesture
   final TapUpDetails details;
@@ -147,7 +153,7 @@ class FlTapUpEvent extends FlTouchEvent {
 ///
 /// Inspired from [GestureLongPressStartCallback]
 class FlLongPressStart extends FlTouchEvent {
-  FlLongPressStart(this.details);
+  const FlLongPressStart(this.details);
 
   /// Contains information of happened touch gesture
   final LongPressStartDetails details;
@@ -165,7 +171,7 @@ class FlLongPressStart extends FlTouchEvent {
 ///
 /// Inspired from [GestureLongPressMoveUpdateCallback]
 class FlLongPressMoveUpdate extends FlTouchEvent {
-  FlLongPressMoveUpdate(this.details);
+  const FlLongPressMoveUpdate(this.details);
 
   /// Contains information of happened touch gesture
   final LongPressMoveUpdateDetails details;
@@ -183,7 +189,7 @@ class FlLongPressMoveUpdate extends FlTouchEvent {
 ///
 /// Inspired from [GestureLongPressEndCallback]
 class FlLongPressEnd extends FlTouchEvent {
-  FlLongPressEnd(this.details);
+  const FlLongPressEnd(this.details);
 
   /// Contains information of happened touch gesture
   final LongPressEndDetails details;
@@ -200,7 +206,7 @@ class FlLongPressEnd extends FlTouchEvent {
 ///
 /// Inspired from [PointerEnterEventListener]
 class FlPointerEnterEvent extends FlTouchEvent {
-  FlPointerEnterEvent(this.event);
+  const FlPointerEnterEvent(this.event);
 
   /// Contains information of happened pointer event
   final PointerEnterEvent event;
@@ -217,7 +223,7 @@ class FlPointerEnterEvent extends FlTouchEvent {
 ///
 /// Inspired from [PointerHoverEventListener]
 class FlPointerHoverEvent extends FlTouchEvent {
-  FlPointerHoverEvent(this.event);
+  const FlPointerHoverEvent(this.event);
 
   /// Contains information of happened pointer event
   final PointerHoverEvent event;
@@ -232,7 +238,7 @@ class FlPointerHoverEvent extends FlTouchEvent {
 ///
 /// Inspired from [PointerExitEventListener] which contains [PointerExitEvent]
 class FlPointerExitEvent extends FlTouchEvent {
-  FlPointerExitEvent(this.event);
+  const FlPointerExitEvent(this.event);
 
   /// Contains information of happened pointer event
   final PointerExitEvent event;

--- a/lib/src/chart/base/base_chart/render_base_chart.dart
+++ b/lib/src/chart/base/base_chart/render_base_chart.dart
@@ -62,7 +62,7 @@ abstract class RenderBaseChart<R extends BaseTouchResponse> extends RenderBox
         _notifyTouchEvent(FlPanUpdateEvent(dragUpdateDetails));
       }
       ..onCancel = () {
-        _notifyTouchEvent(FlPanCancelEvent());
+        _notifyTouchEvent(const FlPanCancelEvent());
       }
       ..onEnd = (dragEndDetails) {
         _notifyTouchEvent(FlPanEndEvent(dragEndDetails));
@@ -74,7 +74,7 @@ abstract class RenderBaseChart<R extends BaseTouchResponse> extends RenderBox
         _notifyTouchEvent(FlTapDownEvent(tapDownDetails));
       }
       ..onTapCancel = () {
-        _notifyTouchEvent(FlTapCancelEvent());
+        _notifyTouchEvent(const FlTapCancelEvent());
       }
       ..onTapUp = (tapUpDetails) {
         _notifyTouchEvent(FlTapUpEvent(tapUpDetails));

--- a/lib/src/chart/base/line.dart
+++ b/lib/src/chart/base/line.dart
@@ -4,7 +4,7 @@ import 'package:flutter/painting.dart';
 
 /// Describes a line model (contains [from], and end [to])
 class Line {
-  Line(this.from, this.to);
+  const Line(this.from, this.to);
 
   /// Start of the line
   final Offset from;

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -15,12 +15,9 @@ class LineChart extends ImplicitlyAnimatedWidget {
     this.data, {
     this.chartRendererKey,
     super.key,
-    Duration swapAnimationDuration = const Duration(milliseconds: 150),
-    Curve swapAnimationCurve = Curves.linear,
-  }) : super(
-          duration: swapAnimationDuration,
-          curve: swapAnimationCurve,
-        );
+    super.duration = const Duration(milliseconds: 150),
+    super.curve = Curves.linear,
+  });
 
   /// Determines how the [LineChart] should be look like.
   final LineChartData data;

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -42,46 +42,33 @@ class LineChartData extends AxisChartData with EquatableMixin {
   ///
   /// [clipData] forces the [LineChart] to draw lines inside the chart bounding box.
   LineChartData({
-    List<LineChartBarData>? lineBarsData,
-    List<BetweenBarsData>? betweenBarsData,
-    FlTitlesData? titlesData,
-    ExtraLinesData? extraLinesData,
-    LineTouchData? lineTouchData,
-    List<ShowingTooltipIndicators>? showingTooltipIndicators,
-    FlGridData? gridData,
+    this.lineBarsData = const [],
+    this.betweenBarsData = const [],
+    super.titlesData = const FlTitlesData(),
+    super.extraLinesData = const ExtraLinesData(),
+    this.lineTouchData = const LineTouchData(),
+    this.showingTooltipIndicators = const [],
+    super.gridData = const FlGridData(),
     super.borderData,
-    RangeAnnotations? rangeAnnotations,
+    super.rangeAnnotations = const RangeAnnotations(),
     double? minX,
     double? maxX,
     super.baselineX,
     double? minY,
     double? maxY,
     super.baselineY,
-    FlClipData? clipData,
+    super.clipData = const FlClipData.none(),
     super.backgroundColor,
-  })  : lineBarsData = lineBarsData ?? const [],
-        betweenBarsData = betweenBarsData ?? const [],
-        lineTouchData = lineTouchData ?? LineTouchData(),
-        showingTooltipIndicators = showingTooltipIndicators ?? const [],
-        super(
-          gridData: gridData ?? FlGridData(),
-          touchData: lineTouchData ?? LineTouchData(),
-          titlesData: titlesData ?? FlTitlesData(),
-          rangeAnnotations: rangeAnnotations ?? RangeAnnotations(),
-          clipData: clipData ?? FlClipData.none(),
-          extraLinesData: extraLinesData = extraLinesData ?? ExtraLinesData(),
-          minX: minX ??
-              LineChartHelper.calculateMaxAxisValues(lineBarsData ?? const [])
-                  .minX,
-          maxX: maxX ??
-              LineChartHelper.calculateMaxAxisValues(lineBarsData ?? const [])
-                  .maxX,
-          minY: minY ??
-              LineChartHelper.calculateMaxAxisValues(lineBarsData ?? const [])
-                  .minY,
-          maxY: maxY ??
-              LineChartHelper.calculateMaxAxisValues(lineBarsData ?? const [])
-                  .maxY,
+  }) : super(
+          touchData: lineTouchData,
+          minX:
+              minX ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).minX,
+          maxX:
+              maxX ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).maxX,
+          minY:
+              minY ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).minY,
+          maxY:
+              maxY ?? LineChartHelper.calculateMaxAxisValues(lineBarsData).maxY,
         );
 
   /// [LineChart] draws some lines in various shapes and overlaps them.
@@ -119,9 +106,9 @@ class LineChartData extends AxisChartData with EquatableMixin {
         rangeAnnotations:
             RangeAnnotations.lerp(a.rangeAnnotations, b.rangeAnnotations, t),
         lineBarsData:
-            lerpLineChartBarDataList(a.lineBarsData, b.lineBarsData, t),
+            lerpLineChartBarDataList(a.lineBarsData, b.lineBarsData, t)!,
         betweenBarsData:
-            lerpBetweenBarsDataList(a.betweenBarsData, b.betweenBarsData, t),
+            lerpBetweenBarsDataList(a.betweenBarsData, b.betweenBarsData, t)!,
         lineTouchData: b.lineTouchData,
         showingTooltipIndicators: b.showingTooltipIndicators,
       );
@@ -240,44 +227,29 @@ class LineChartBarData with EquatableMixin {
   /// If you want to have a Step Line Chart style, just set [isStepLineChart] true,
   /// also you can tweak the [LineChartBarData.lineChartStepData].
   LineChartBarData({
-    List<FlSpot>? spots,
-    bool? show,
+    this.spots = const [],
+    this.show = true,
     Color? color,
     this.gradient,
-    double? barWidth,
-    bool? isCurved,
-    double? curveSmoothness,
-    bool? preventCurveOverShooting,
-    double? preventCurveOvershootingThreshold,
-    bool? isStrokeCapRound,
-    bool? isStrokeJoinRound,
+    this.barWidth = 2.0,
+    this.isCurved = false,
+    this.curveSmoothness = 0.35,
+    this.preventCurveOverShooting = false,
+    this.preventCurveOvershootingThreshold = 10.0,
+    this.isStrokeCapRound = false,
+    this.isStrokeJoinRound = false,
     BarAreaData? belowBarData,
     BarAreaData? aboveBarData,
-    FlDotData? dotData,
-    List<int>? showingIndicators,
+    this.dotData = const FlDotData(),
+    this.showingIndicators = const [],
     this.dashArray,
-    Shadow? shadow,
-    bool? isStepLineChart,
-    LineChartStepData? lineChartStepData,
-  })  : spots = spots ?? const [],
-        show = show ?? true,
-        color =
+    this.shadow = const Shadow(color: Colors.transparent),
+    this.isStepLineChart = false,
+    this.lineChartStepData = const LineChartStepData(),
+  })  : color =
             color ?? ((color == null && gradient == null) ? Colors.cyan : null),
-        barWidth = barWidth ?? 2.0,
-        isCurved = isCurved ?? false,
-        curveSmoothness = curveSmoothness ?? 0.35,
-        preventCurveOverShooting = preventCurveOverShooting ?? false,
-        preventCurveOvershootingThreshold =
-            preventCurveOvershootingThreshold ?? 10.0,
-        isStrokeCapRound = isStrokeCapRound ?? false,
-        isStrokeJoinRound = isStrokeJoinRound ?? false,
         belowBarData = belowBarData ?? BarAreaData(),
-        aboveBarData = aboveBarData ?? BarAreaData(),
-        dotData = dotData ?? FlDotData(),
-        showingIndicators = showingIndicators ?? const [],
-        shadow = shadow ?? const Shadow(color: Colors.transparent),
-        isStepLineChart = isStepLineChart ?? false,
-        lineChartStepData = lineChartStepData ?? LineChartStepData() {
+        aboveBarData = aboveBarData ?? BarAreaData() {
     FlSpot? mostLeft;
     FlSpot? mostTop;
     FlSpot? mostRight;
@@ -286,12 +258,12 @@ class LineChartBarData with EquatableMixin {
     FlSpot? firstValidSpot;
     try {
       firstValidSpot =
-          this.spots.firstWhere((element) => element != FlSpot.nullSpot);
+          spots.firstWhere((element) => element != FlSpot.nullSpot);
     } catch (e) {
       // There is no valid spot
     }
     if (firstValidSpot != null) {
-      for (final spot in this.spots) {
+      for (final spot in spots) {
         if (spot.isNull()) {
           continue;
         }
@@ -404,7 +376,7 @@ class LineChartBarData with EquatableMixin {
   ) {
     return LineChartBarData(
       show: b.show,
-      barWidth: lerpDouble(a.barWidth, b.barWidth, t),
+      barWidth: lerpDouble(a.barWidth, b.barWidth, t)!,
       belowBarData: BarAreaData.lerp(a.belowBarData, b.belowBarData, t),
       aboveBarData: BarAreaData.lerp(a.aboveBarData, b.aboveBarData, t),
       curveSmoothness: b.curveSmoothness,
@@ -416,14 +388,14 @@ class LineChartBarData with EquatableMixin {
         a.preventCurveOvershootingThreshold,
         b.preventCurveOvershootingThreshold,
         t,
-      ),
+      )!,
       dotData: FlDotData.lerp(a.dotData, b.dotData, t),
       dashArray: lerpIntList(a.dashArray, b.dashArray, t),
       color: Color.lerp(a.color, b.color, t),
       gradient: Gradient.lerp(a.gradient, b.gradient, t),
-      spots: lerpFlSpotList(a.spots, b.spots, t),
+      spots: lerpFlSpotList(a.spots, b.spots, t)!,
       showingIndicators: b.showingIndicators,
-      shadow: Shadow.lerp(a.shadow, b.shadow, t),
+      shadow: Shadow.lerp(a.shadow, b.shadow, t)!,
       isStepLineChart: b.isStepLineChart,
       lineChartStepData:
           LineChartStepData.lerp(a.lineChartStepData, b.lineChartStepData, t),
@@ -506,7 +478,7 @@ class LineChartBarData with EquatableMixin {
 /// Holds data for representing a Step Line Chart, and works only if [LineChartBarData.isStepChart] is true.
 class LineChartStepData with EquatableMixin {
   /// Determines the [stepDirection] of each step;
-  LineChartStepData({this.stepDirection = stepDirectionMiddle});
+  const LineChartStepData({this.stepDirection = stepDirectionMiddle});
 
   /// Go to the next spot directly, with the current point's y value.
   static const stepDirectionForward = 0.0;
@@ -553,21 +525,17 @@ class BarAreaData with EquatableMixin {
   ///
   /// If [applyCutOffY] is true, it cuts the drawing by the [cutOffY] line.
   BarAreaData({
-    bool? show,
+    this.show = false,
     Color? color,
     this.gradient,
-    BarAreaSpotsLine? spotsLine,
-    double? cutOffY,
-    bool? applyCutOffY,
-  })  : show = show ?? false,
-        color = color ??
+    this.spotsLine = const BarAreaSpotsLine(),
+    this.cutOffY = 0,
+    this.applyCutOffY = false,
+  }) : color = color ??
             ((color == null && gradient == null)
                 ? Colors.blueGrey.withOpacity(0.5)
-                : null),
-        spotsLine = spotsLine ?? BarAreaSpotsLine(),
-        cutOffY = cutOffY ?? 0,
-        applyCutOffY = applyCutOffY ?? false,
-        assert(applyCutOffY == true ? cutOffY != null : true);
+                : null);
+
   final bool show;
 
   /// If provided, this [BarAreaData] draws with this [color]
@@ -597,7 +565,7 @@ class BarAreaData with EquatableMixin {
       color: Color.lerp(a.color, b.color, t),
       // ignore: invalid_use_of_protected_member
       gradient: Gradient.lerp(a.gradient, b.gradient, t),
-      cutOffY: lerpDouble(a.cutOffY, b.cutOffY, t),
+      cutOffY: lerpDouble(a.cutOffY, b.cutOffY, t)!,
       applyCutOffY: b.applyCutOffY,
     );
   }
@@ -667,15 +635,12 @@ class BarAreaSpotsLine with EquatableMixin {
   /// If [show] is true, [LineChart] draws some lines on above or below the spots,
   /// you can customize the appearance of the lines using [flLineStyle]
   /// and you can decide to show or hide the lines on each spot using [checkToShowSpotLine].
-  BarAreaSpotsLine({
-    bool? show,
-    FlLine? flLineStyle,
-    CheckToShowSpotLine? checkToShowSpotLine,
-    bool? applyCutOffY,
-  })  : show = show ?? false,
-        flLineStyle = flLineStyle ?? FlLine(),
-        checkToShowSpotLine = checkToShowSpotLine ?? showAllSpotsBelowLine,
-        applyCutOffY = applyCutOffY ?? true;
+  const BarAreaSpotsLine({
+    this.show = false,
+    this.flLineStyle = const FlLine(),
+    this.checkToShowSpotLine = showAllSpotsBelowLine,
+    this.applyCutOffY = true,
+  });
 
   /// Determines to show or hide all the lines.
   final bool show;
@@ -797,13 +762,11 @@ class FlDotData with EquatableMixin {
   /// set [show] false to prevent dots from drawing,
   /// if you want to show or hide dots in some spots,
   /// override [checkToShowDot] to handle it in your way.
-  FlDotData({
-    bool? show,
-    CheckToShowDot? checkToShowDot,
-    GetDotPainterCallback? getDotPainter,
-  })  : show = show ?? true,
-        checkToShowDot = checkToShowDot ?? showAllDots,
-        getDotPainter = getDotPainter ?? _defaultGetDotPainter;
+  const FlDotData({
+    this.show = true,
+    this.checkToShowDot = showAllDots,
+    this.getDotPainter = _defaultGetDotPainter,
+  });
 
   /// Determines show or hide all dots.
   final bool show;
@@ -835,6 +798,8 @@ class FlDotData with EquatableMixin {
 
 /// This class contains the interface that all DotPainters should conform to.
 abstract class FlDotPainter with EquatableMixin {
+  const FlDotPainter();
+
   /// This method should be overridden to draw the dot shape.
   void draw(Canvas canvas, FlSpot spot, Offset offsetInCanvas);
 
@@ -851,14 +816,11 @@ class FlDotCirclePainter extends FlDotPainter {
   /// by setting the thickness with [strokeWidth],
   /// and you can change the color of of the stroke with [strokeColor].
   FlDotCirclePainter({
-    Color? color,
+    this.color = Colors.green,
     double? radius,
-    Color? strokeColor,
-    double? strokeWidth,
-  })  : color = color ?? Colors.green,
-        radius = radius ?? 4.0,
-        strokeColor = strokeColor ?? Colors.green.darken(),
-        strokeWidth = strokeWidth ?? 1.0;
+    this.strokeColor = const Color.fromRGBO(76, 175, 80, 1),
+    this.strokeWidth = 1.0,
+  }) : radius = radius ?? 4.0;
 
   /// The fill color to use for the circle
   Color color;
@@ -919,14 +881,11 @@ class FlDotSquarePainter extends FlDotPainter {
   /// by setting the thickness with [strokeWidth],
   /// and you can change the color of of the stroke with [strokeColor].
   FlDotSquarePainter({
-    Color? color,
-    double? size,
-    Color? strokeColor,
-    double? strokeWidth,
-  })  : color = color ?? Colors.green,
-        size = size ?? 4.0,
-        strokeColor = strokeColor ?? Colors.green.darken(),
-        strokeWidth = strokeWidth ?? 1.0;
+    this.color = Colors.green,
+    this.size = 4.0,
+    this.strokeColor = const Color.fromRGBO(76, 175, 80, 1),
+    this.strokeWidth = 1.0,
+  });
 
   /// The fill color to use for the square
   Color color;
@@ -988,12 +947,10 @@ class FlDotCrossPainter extends FlDotPainter {
   /// The [color] and [width] properties determines the color and thickness of the cross shape,
   /// [size] determines the width and height of the shape.
   FlDotCrossPainter({
-    Color? color,
-    double? size,
-    double? width,
-  })  : color = color ?? Colors.green,
-        size = size ?? 8.0,
-        width = width ?? 2.0;
+    this.color = Colors.green,
+    this.size = 8.0,
+    this.width = 2.0,
+  });
 
   /// The fill color to use for the X mark
   Color color;
@@ -1055,7 +1012,7 @@ abstract class FlLineLabel with EquatableMixin {
   /// applies [padding] for spaces, and applies [style] for changing color,
   /// size, ... of the text.
   /// [show] determines showing label or not.
-  FlLineLabel({
+  const FlLineLabel({
     required this.show,
     required this.padding,
     required this.style,
@@ -1107,28 +1064,20 @@ class LineTouchData extends FlTouchData<LineTouchResponse> with EquatableMixin {
   /// You can customize this tooltip using [touchTooltipData], indicator lines starts from position
   /// controlled by [getTouchLineStart] and ends at position controlled by [getTouchLineEnd].
   /// If you need to have a distance threshold for handling touches, use [touchSpotThreshold].
-  LineTouchData({
-    bool? enabled,
+  const LineTouchData({
+    bool enabled = true,
     BaseTouchCallback<LineTouchResponse>? touchCallback,
     MouseCursorResolver<LineTouchResponse>? mouseCursorResolver,
     Duration? longPressDuration,
-    LineTouchTooltipData? touchTooltipData,
-    GetTouchedSpotIndicator? getTouchedSpotIndicator,
-    double? touchSpotThreshold,
-    CalculateTouchDistance? distanceCalculator,
-    bool? handleBuiltInTouches,
-    GetTouchLineY? getTouchLineStart,
-    GetTouchLineY? getTouchLineEnd,
-  })  : touchTooltipData = touchTooltipData ?? LineTouchTooltipData(),
-        getTouchedSpotIndicator =
-            getTouchedSpotIndicator ?? defaultTouchedIndicators,
-        touchSpotThreshold = touchSpotThreshold ?? 10,
-        distanceCalculator = distanceCalculator ?? _xDistance,
-        handleBuiltInTouches = handleBuiltInTouches ?? true,
-        getTouchLineStart = getTouchLineStart ?? defaultGetTouchLineStart,
-        getTouchLineEnd = getTouchLineEnd ?? defaultGetTouchLineEnd,
-        super(
-          enabled ?? true,
+    this.touchTooltipData = const LineTouchTooltipData(),
+    this.getTouchedSpotIndicator = defaultTouchedIndicators,
+    this.touchSpotThreshold = 10,
+    this.distanceCalculator = _xDistance,
+    this.handleBuiltInTouches = true,
+    this.getTouchLineStart = defaultGetTouchLineStart,
+    this.getTouchLineEnd = defaultGetTouchLineEnd,
+  }) : super(
+          enabled,
           touchCallback,
           mouseCursorResolver,
           longPressDuration,
@@ -1246,7 +1195,7 @@ List<TouchedSpotIndicatorData> defaultTouchedIndicators(
       lineColor = _defaultGetDotColor(barData.spots[index], 0, barData);
     }
     const lineStrokeWidth = 4.0;
-    final flLine = FlLine(color: lineColor, strokeWidth: lineStrokeWidth);
+    final flLine = FlLine(color: lineColor!, strokeWidth: lineStrokeWidth);
 
     var dotSize = 10.0;
     if (barData.dotData.show) {
@@ -1287,36 +1236,22 @@ class LineTouchTooltipData with EquatableMixin {
   /// Sometimes, [LineChart] shows the tooltip outside of the chart,
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
-  LineTouchTooltipData({
-    Color? tooltipBgColor,
-    double? tooltipRoundedRadius,
-    EdgeInsets? tooltipPadding,
-    double? tooltipMargin,
-    FLHorizontalAlignment? tooltipHorizontalAlignment,
-    double? tooltipHorizontalOffset,
-    double? maxContentWidth,
-    GetLineTooltipItems? getTooltipItems,
-    bool? fitInsideHorizontally,
-    bool? fitInsideVertically,
-    bool? showOnTopOfTheChartBoxArea,
-    double? rotateAngle,
-    BorderSide? tooltipBorder,
-  })  : tooltipBgColor = tooltipBgColor ?? Colors.blueGrey.darken(15),
-        tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
-        tooltipPadding = tooltipPadding ??
-            const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-        tooltipMargin = tooltipMargin ?? 16,
-        tooltipHorizontalAlignment =
-            tooltipHorizontalAlignment ?? FLHorizontalAlignment.center,
-        tooltipHorizontalOffset = tooltipHorizontalOffset ?? 0,
-        maxContentWidth = maxContentWidth ?? 120,
-        getTooltipItems = getTooltipItems ?? defaultLineTooltipItem,
-        fitInsideHorizontally = fitInsideHorizontally ?? false,
-        fitInsideVertically = fitInsideVertically ?? false,
-        showOnTopOfTheChartBoxArea = showOnTopOfTheChartBoxArea ?? false,
-        rotateAngle = rotateAngle ?? 0.0,
-        tooltipBorder = tooltipBorder ?? BorderSide.none,
-        super();
+  const LineTouchTooltipData({
+    this.tooltipBgColor = const Color.fromRGBO(96, 125, 139, 1),
+    this.tooltipRoundedRadius = 4,
+    this.tooltipPadding =
+        const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+    this.tooltipMargin = 16,
+    this.tooltipHorizontalAlignment = FLHorizontalAlignment.center,
+    this.tooltipHorizontalOffset = 0,
+    this.maxContentWidth = 120,
+    this.getTooltipItems = defaultLineTooltipItem,
+    this.fitInsideHorizontally = false,
+    this.fitInsideVertically = false,
+    this.showOnTopOfTheChartBoxArea = false,
+    this.rotateAngle = 0.0,
+    this.tooltipBorder = BorderSide.none,
+  });
 
   /// The tooltip background color.
   final Color tooltipBgColor;
@@ -1451,7 +1386,7 @@ class TouchLineBarSpot extends LineBarSpot {
 class LineTooltipItem with EquatableMixin {
   /// Shows a [text] with [textStyle], [textDirection],
   /// and optional [children] as a row in the tooltip popup.
-  LineTooltipItem(
+  const LineTooltipItem(
     this.text,
     this.textStyle, {
     this.textAlign = TextAlign.center,
@@ -1494,7 +1429,10 @@ class TouchedSpotIndicatorData with EquatableMixin {
   /// otherwise you can show it manually using [LineChartBarData.showingIndicators].
   /// [indicatorBelowLine] determines line's style, and
   /// [touchedSpotDotData] determines dot's style.
-  TouchedSpotIndicatorData(this.indicatorBelowLine, this.touchedSpotDotData);
+  const TouchedSpotIndicatorData(
+    this.indicatorBelowLine,
+    this.touchedSpotDotData,
+  );
 
   /// Determines line's style.
   final FlLine indicatorBelowLine;
@@ -1514,7 +1452,7 @@ class TouchedSpotIndicatorData with EquatableMixin {
 class ShowingTooltipIndicators with EquatableMixin {
   /// [LineChart] shows some tooltips over each [LineChartBarData],
   /// and [showingSpots] determines in which spots this tooltip should be shown.
-  ShowingTooltipIndicators(this.showingSpots);
+  const ShowingTooltipIndicators(this.showingSpots);
 
   /// Determines the spots that each tooltip should be shown.
   final List<LineBarSpot> showingSpots;
@@ -1532,7 +1470,7 @@ class LineTouchResponse extends BaseTouchResponse {
   /// If touch happens, [LineChart] processes it internally and
   /// passes out a list of [lineBarSpots] it gives you information about the touched spot.
   /// They are sorted based on their distance to the touch event
-  LineTouchResponse(this.lineBarSpots) : super();
+  const LineTouchResponse(this.lineBarSpots);
 
   /// touch happened on these spots
   /// (if a single line provided on the chart, [lineBarSpots]'s length will be 1 always)
@@ -1551,8 +1489,7 @@ class LineTouchResponse extends BaseTouchResponse {
 
 /// It lerps a [LineChartData] to another [LineChartData] (handles animation for updating values)
 class LineChartDataTween extends Tween<LineChartData> {
-  LineChartDataTween({required LineChartData begin, required LineChartData end})
-      : super(begin: begin, end: end);
+  LineChartDataTween({required super.begin, required super.end});
 
   /// Lerps a [LineChartData] based on [t] value, check [Tween.lerp].
   @override

--- a/lib/src/chart/line_chart/line_chart_helper.dart
+++ b/lib/src/chart/line_chart/line_chart_helper.dart
@@ -14,7 +14,7 @@ class LineChartHelper {
     List<LineChartBarData> lineBarsData,
   ) {
     if (lineBarsData.isEmpty) {
-      return LineChartMinMaxAxisValues(0, 0, 0, 0);
+      return const LineChartMinMaxAxisValues(0, 0, 0, 0);
     }
 
     final listWrapper = lineBarsData.toWrapperClass();
@@ -29,7 +29,7 @@ class LineChartHelper {
           lineBarsData.firstWhere((element) => element.spots.isNotEmpty);
     } catch (e) {
       // There is no lineBarData with at least one spot
-      return LineChartMinMaxAxisValues(0, 0, 0, 0);
+      return const LineChartMinMaxAxisValues(0, 0, 0, 0);
     }
 
     final FlSpot firstValidSpot;
@@ -38,7 +38,7 @@ class LineChartHelper {
           lineBarData.spots.firstWhere((element) => element != FlSpot.nullSpot);
     } catch (e) {
       // There is no valid spot
-      return LineChartMinMaxAxisValues(0, 0, 0, 0);
+      return const LineChartMinMaxAxisValues(0, 0, 0, 0);
     }
 
     var minX = firstValidSpot.x;
@@ -76,7 +76,7 @@ class LineChartHelper {
 
 /// Holds minX, maxX, minY, and maxY for use in [LineChartData]
 class LineChartMinMaxAxisValues with EquatableMixin {
-  LineChartMinMaxAxisValues(
+  const LineChartMinMaxAxisValues(
     this.minX,
     this.maxX,
     this.minY,

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -54,10 +54,10 @@ class ScatterChartData extends AxisChartData with EquatableMixin {
         showingTooltipIndicators = showingTooltipIndicators ?? const [],
         scatterLabelSettings = scatterLabelSettings ?? ScatterLabelSettings(),
         super(
-          gridData: gridData ?? FlGridData(),
+          gridData: gridData ?? const FlGridData(),
           touchData: scatterTouchData ?? ScatterTouchData(),
-          titlesData: titlesData ?? FlTitlesData(),
-          clipData: clipData ?? FlClipData.none(),
+          titlesData: titlesData ?? const FlTitlesData(),
+          clipData: clipData ?? const FlClipData.none(),
           minX: minX ??
               ScatterChartHelper.calculateMaxAxisValues(
                 scatterSpots ?? const [],

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -112,7 +112,7 @@ void main() {
       ];
 
       final data = BarChartData(
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         groupsSpace: 10,
         barGroups: barGroups,
       );
@@ -170,7 +170,7 @@ void main() {
       ];
 
       final data = BarChartData(
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         groupsSpace: 10,
         alignment: BarChartAlignment.center,
         barGroups: barGroups,
@@ -227,7 +227,7 @@ void main() {
       ];
 
       final data = BarChartData(
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         groupsSpace: 10,
         barGroups: barGroups,
       );
@@ -339,7 +339,7 @@ void main() {
       ];
 
       final data = BarChartData(
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         groupsSpace: 10,
         barGroups: barGroups,
         alignment: BarChartAlignment.center,
@@ -599,7 +599,7 @@ void main() {
       ];
 
       final data = BarChartData(
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         groupsSpace: 10,
         barGroups: barGroups,
         alignment: BarChartAlignment.center,
@@ -1487,7 +1487,7 @@ void main() {
 
       final data = BarChartData(
         barGroups: barGroups,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         alignment: BarChartAlignment.center,
         groupsSpace: 10,
         barTouchData: BarTouchData(
@@ -1585,7 +1585,7 @@ void main() {
 
       final data = BarChartData(
         barGroups: barGroups,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         alignment: BarChartAlignment.center,
         groupsSpace: 10,
         barTouchData: BarTouchData(
@@ -1669,7 +1669,7 @@ void main() {
             ],
           ),
         ],
-        extraLinesData: ExtraLinesData(),
+        extraLinesData: const ExtraLinesData(),
       );
 
       final barChartPainter = BarChartPainter();
@@ -2049,7 +2049,7 @@ void main() {
             ],
           )
         ],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         extraLinesData: ExtraLinesData(
           horizontalLines: [
             HorizontalLine(

--- a/test/chart/bar_chart/bar_chart_renderer_test.dart
+++ b/test/chart/bar_chart/bar_chart_renderer_test.dart
@@ -15,28 +15,28 @@ import 'bar_chart_renderer_test.mocks.dart';
 void main() {
   group('BarChartRenderer', () {
     final data = BarChartData(
-      titlesData: FlTitlesData(
+      titlesData: const FlTitlesData(
         leftTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 20, showTitles: true),
         ),
         rightTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 64, showTitles: true),
         ),
-        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        bottomTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: AxisTitles(),
+        bottomTitles: AxisTitles(),
       ),
     );
 
     final targetData = BarChartData(
-      titlesData: FlTitlesData(
+      titlesData: const FlTitlesData(
         leftTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 8, showTitles: true),
         ),
         rightTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 20, showTitles: true),
         ),
-        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        bottomTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: AxisTitles(),
+        bottomTitles: AxisTitles(),
       ),
     );
 

--- a/test/chart/base/axis_chart/axis_chart_data_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_data_test.dart
@@ -80,7 +80,7 @@ void main() {
 
       expect(
         flLine1 ==
-            FlLine(
+            const FlLine(
               color: Colors.green,
               strokeWidth: 1.001,
               dashArray: [1, 2, 3],
@@ -90,7 +90,7 @@ void main() {
 
       expect(
         flLine1 ==
-            FlLine(
+            const FlLine(
               color: Colors.green,
               strokeWidth: 1,
               dashArray: [
@@ -101,24 +101,29 @@ void main() {
       );
 
       expect(
-        flLine1 == FlLine(color: Colors.green, strokeWidth: 1, dashArray: []),
+        flLine1 ==
+            const FlLine(color: Colors.green, strokeWidth: 1, dashArray: []),
         false,
       );
 
       expect(
-        flLine1 == FlLine(color: Colors.green, strokeWidth: 1),
+        flLine1 == const FlLine(color: Colors.green, strokeWidth: 1),
         false,
       );
 
       expect(
         flLine1 ==
-            FlLine(color: Colors.white, strokeWidth: 1, dashArray: [1, 2, 3]),
+            const FlLine(
+              color: Colors.white,
+              strokeWidth: 1,
+              dashArray: [1, 2, 3],
+            ),
         false,
       );
 
       expect(
         flLine1 ==
-            FlLine(
+            const FlLine(
               color: Colors.green,
               strokeWidth: 100,
               dashArray: [1, 2, 3],

--- a/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
@@ -14,7 +14,7 @@ void main() {
   );
 
   final lineChartDataWithNoTitles = lineChartDataBase.copyWith(
-    titlesData: FlTitlesData(
+    titlesData: const FlTitlesData(
       show: false,
       leftTitles: AxisTitles(),
       topTitles: AxisTitles(),
@@ -33,7 +33,6 @@ void main() {
       ),
     ),
     titlesData: FlTitlesData(
-      show: true,
       leftTitles: AxisTitles(
         axisNameWidget: const Icon(Icons.arrow_left),
         axisNameSize: 10,
@@ -96,7 +95,6 @@ void main() {
       ),
     ),
     titlesData: FlTitlesData(
-      show: true,
       leftTitles: AxisTitles(
         axisNameWidget: const Icon(Icons.arrow_left),
         axisNameSize: 10,
@@ -109,9 +107,9 @@ void main() {
           interval: 1,
         ),
       ),
-      topTitles: AxisTitles(),
-      rightTitles: AxisTitles(),
-      bottomTitles: AxisTitles(),
+      topTitles: const AxisTitles(),
+      rightTitles: const AxisTitles(),
+      bottomTitles: const AxisTitles(),
     ),
   );
 
@@ -119,7 +117,6 @@ void main() {
       lineChartDataBase.copyWith(
     borderData: FlBorderData(show: false),
     titlesData: FlTitlesData(
-      show: true,
       leftTitles: AxisTitles(
         axisNameSize: 10,
         sideTitles: SideTitles(
@@ -131,9 +128,9 @@ void main() {
           interval: 1,
         ),
       ),
-      topTitles: AxisTitles(),
-      rightTitles: AxisTitles(),
-      bottomTitles: AxisTitles(),
+      topTitles: const AxisTitles(),
+      rightTitles: const AxisTitles(),
+      bottomTitles: const AxisTitles(),
     ),
   );
 
@@ -141,12 +138,10 @@ void main() {
       lineChartDataBase.copyWith(
     borderData: FlBorderData(show: false),
     titlesData: FlTitlesData(
-      show: true,
       leftTitles: AxisTitles(
         axisNameSize: 10,
         axisNameWidget: const Icon(Icons.arrow_left),
         sideTitles: SideTitles(
-          showTitles: false,
           reservedSize: 10,
           getTitlesWidget: (double value, TitleMeta meta) {
             return Text('L-${value.toInt()}');
@@ -154,9 +149,9 @@ void main() {
           interval: 1,
         ),
       ),
-      topTitles: AxisTitles(),
-      rightTitles: AxisTitles(),
-      bottomTitles: AxisTitles(),
+      topTitles: const AxisTitles(),
+      rightTitles: const AxisTitles(),
+      bottomTitles: const AxisTitles(),
     ),
   );
 

--- a/test/chart/base/axis_chart/side_titles/side_titles_widget_test.dart
+++ b/test/chart/base/axis_chart/side_titles/side_titles_widget_test.dart
@@ -14,7 +14,7 @@ void main() {
   );
 
   final lineChartDataWithNoTitles = lineChartDataBase.copyWith(
-    titlesData: FlTitlesData(
+    titlesData: const FlTitlesData(
       show: false,
       leftTitles: AxisTitles(),
       topTitles: AxisTitles(),
@@ -25,7 +25,6 @@ void main() {
 
   final lineChartDataWithAllTitles = lineChartDataBase.copyWith(
     titlesData: FlTitlesData(
-      show: true,
       leftTitles: AxisTitles(
         axisNameWidget: const Text('Left Titles'),
         sideTitles: SideTitles(
@@ -71,7 +70,6 @@ void main() {
 
   final lineChartDataWithOnlyLeftTitles = lineChartDataBase.copyWith(
     titlesData: FlTitlesData(
-      show: true,
       leftTitles: AxisTitles(
         axisNameWidget: const Text('Left Titles'),
         sideTitles: SideTitles(
@@ -82,16 +80,15 @@ void main() {
           interval: 1,
         ),
       ),
-      topTitles: AxisTitles(),
-      rightTitles: AxisTitles(),
-      bottomTitles: AxisTitles(),
+      topTitles: const AxisTitles(),
+      rightTitles: const AxisTitles(),
+      bottomTitles: const AxisTitles(),
     ),
   );
 
   final lineChartDataWithOnlyLeftTitlesWithoutAxisName =
       lineChartDataBase.copyWith(
     titlesData: FlTitlesData(
-      show: true,
       leftTitles: AxisTitles(
         sideTitles: SideTitles(
           showTitles: true,
@@ -101,9 +98,9 @@ void main() {
           interval: 1,
         ),
       ),
-      topTitles: AxisTitles(),
-      rightTitles: AxisTitles(),
-      bottomTitles: AxisTitles(),
+      topTitles: const AxisTitles(),
+      rightTitles: const AxisTitles(),
+      bottomTitles: const AxisTitles(),
     ),
   );
 
@@ -129,10 +126,9 @@ void main() {
       ),
     ],
     titlesData: FlTitlesData(
-      show: true,
-      leftTitles: AxisTitles(),
-      topTitles: AxisTitles(),
-      rightTitles: AxisTitles(),
+      leftTitles: const AxisTitles(),
+      topTitles: const AxisTitles(),
+      rightTitles: const AxisTitles(),
       bottomTitles: AxisTitles(
         axisNameWidget: const Icon(Icons.check),
         sideTitles: SideTitles(
@@ -172,9 +168,8 @@ void main() {
       ),
     ],
     titlesData: FlTitlesData(
-      show: true,
-      leftTitles: AxisTitles(),
-      topTitles: AxisTitles(),
+      leftTitles: const AxisTitles(),
+      topTitles: const AxisTitles(),
       rightTitles: AxisTitles(
         axisNameWidget: const Icon(Icons.arrow_right),
         sideTitles: SideTitles(
@@ -190,16 +185,15 @@ void main() {
           },
         ),
       ),
-      bottomTitles: AxisTitles(),
+      bottomTitles: const AxisTitles(),
     ),
   );
 
   final barChartDataWithEmptyGroups = BarChartData(
     barGroups: [],
     titlesData: FlTitlesData(
-      show: true,
-      leftTitles: AxisTitles(),
-      topTitles: AxisTitles(),
+      leftTitles: const AxisTitles(),
+      topTitles: const AxisTitles(),
       rightTitles: AxisTitles(
         axisNameWidget: const Icon(Icons.arrow_right),
         sideTitles: SideTitles(
@@ -215,7 +209,7 @@ void main() {
           },
         ),
       ),
-      bottomTitles: AxisTitles(),
+      bottomTitles: const AxisTitles(),
     ),
   );
 

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -128,7 +128,6 @@ class MockData {
   }
 
   static final LineChartBarData lineChartBarData1 = LineChartBarData(
-    show: true,
     dashArray: [0, 1],
     gradient: const LinearGradient(
       colors: [Colors.red, Colors.green],
@@ -141,21 +140,17 @@ class MockData {
       flSpot2,
     ],
     shadow: shadow1,
-    isStepLineChart: false,
     aboveBarData: barAreaData1,
     belowBarData: barAreaData2,
     barWidth: 12,
     curveSmoothness: 12,
     dotData: flDotData1,
-    isCurved: false,
     isStrokeCapRound: true,
-    preventCurveOverShooting: false,
     preventCurveOvershootingThreshold: 1.2,
     showingIndicators: [0, 1],
   );
 
   static final LineChartBarData lineChartBarData2 = LineChartBarData(
-    show: true,
     dashArray: [0, 1],
     gradient: const LinearGradient(
       colors: [Colors.red, Colors.green],
@@ -169,15 +164,12 @@ class MockData {
     ],
     shadow: shadow2,
     isStepLineChart: true,
-    lineChartStepData: lineChartStepData1,
     aboveBarData: barAreaData1,
     belowBarData: barAreaData2,
     barWidth: 12,
     curveSmoothness: 12,
     dotData: flDotData1,
-    isCurved: false,
     isStrokeCapRound: true,
-    preventCurveOverShooting: false,
     preventCurveOvershootingThreshold: 1.2,
     showingIndicators: [0, 4],
   );
@@ -354,42 +346,36 @@ class MockData {
     barGroups: [barGroupData0, barGroupData1, barGroupData2],
   );
 
-  static final sideTitles1 = SideTitles(
+  static const sideTitles1 = SideTitles(
     reservedSize: 10,
-    showTitles: false,
     interval: 23,
   );
-  static final sideTitles1Clone = SideTitles(
+  static const sideTitles1Clone = SideTitles(
     reservedSize: 10,
-    showTitles: false,
     interval: 23,
   );
-  static final sideTitles2 = SideTitles(
+  static const sideTitles2 = SideTitles(
     reservedSize: 10,
-    showTitles: false,
     interval: 12,
   );
-  static final sideTitles3 = SideTitles(
+  static const sideTitles3 = SideTitles(
     reservedSize: 10,
-    showTitles: false,
     getTitlesWidget: getTitles,
     interval: 12,
   );
-  static final sideTitles4 = SideTitles(
+  static const sideTitles4 = SideTitles(
     reservedSize: 11,
     showTitles: true,
     getTitlesWidget: getTitles,
     interval: 12,
   );
-  static final sideTitles5 = SideTitles(
+  static const sideTitles5 = SideTitles(
     reservedSize: 10,
-    showTitles: false,
     getTitlesWidget: getTitles,
     interval: 43,
   );
-  static final sideTitles6 = SideTitles(
+  static const sideTitles6 = SideTitles(
     reservedSize: 10,
-    showTitles: false,
     getTitlesWidget: getTitles,
     interval: 22,
   );
@@ -443,71 +429,65 @@ class MockData {
   static const widget4 = Text('axis4');
   static const widget5 = Text('axis5');
 
-  static final axisTitles1 = AxisTitles(
+  static const axisTitles1 = AxisTitles(
     axisNameWidget: widget1,
     sideTitles: sideTitles1,
   );
-  static final axisTitles1Clone = AxisTitles(
+  static const axisTitles1Clone = AxisTitles(
     axisNameWidget: widget1,
     sideTitles: sideTitles1Clone,
   );
-  static final axisTitles2 = AxisTitles(
+  static const axisTitles2 = AxisTitles(
     axisNameWidget: widget2,
     sideTitles: sideTitles2,
   );
-  static final axisTitles3 = AxisTitles(
+  static const axisTitles3 = AxisTitles(
     axisNameWidget: widget3,
     sideTitles: sideTitles3,
   );
-  static final axisTitles4 = AxisTitles(
+  static const axisTitles4 = AxisTitles(
     axisNameWidget: widget4,
     sideTitles: sideTitles4,
   );
-  static final axisTitles5 = AxisTitles(
+  static const axisTitles5 = AxisTitles(
     axisNameWidget: widget5,
     axisNameSize: 889,
     sideTitles: sideTitles4,
   );
 
-  static final flTitlesData1 = FlTitlesData(
-    show: true,
+  static const flTitlesData1 = FlTitlesData(
     bottomTitles: axisTitles1,
     topTitles: axisTitles2,
     rightTitles: axisTitles3,
     leftTitles: axisTitles4,
   );
-  static final flTitlesData1Clone = FlTitlesData(
-    show: true,
+  static const flTitlesData1Clone = FlTitlesData(
     bottomTitles: axisTitles1Clone,
     topTitles: axisTitles2,
     rightTitles: axisTitles3,
     leftTitles: axisTitles4,
   );
-  static final flTitlesData2 = FlTitlesData(
-    show: true,
+  static const flTitlesData2 = FlTitlesData(
     topTitles: axisTitles2,
     rightTitles: axisTitles3,
     leftTitles: axisTitles4,
   );
-  static final flTitlesData3 = FlTitlesData(
-    show: true,
+  static const flTitlesData3 = FlTitlesData(
     bottomTitles: axisTitles1,
     rightTitles: axisTitles3,
     leftTitles: axisTitles4,
   );
-  static final flTitlesData4 = FlTitlesData(
-    show: true,
+  static const flTitlesData4 = FlTitlesData(
     bottomTitles: axisTitles1,
     topTitles: axisTitles2,
     leftTitles: axisTitles4,
   );
-  static final flTitlesData5 = FlTitlesData(
-    show: true,
+  static const flTitlesData5 = FlTitlesData(
     bottomTitles: axisTitles1,
     topTitles: axisTitles2,
     rightTitles: axisTitles3,
   );
-  static final flTitlesData6 = FlTitlesData(
+  static const flTitlesData6 = FlTitlesData(
     show: false,
     bottomTitles: axisTitles1,
     topTitles: axisTitles2,
@@ -556,14 +536,14 @@ final RangeAnnotations rangeAnnotations2 = RangeAnnotations(
   ],
 );
 
-final FlLine flLine1 =
+const FlLine flLine1 =
     FlLine(color: Colors.green, strokeWidth: 1, dashArray: [1, 2, 3]);
-final FlLine flLine1Clone =
+const FlLine flLine1Clone =
     FlLine(color: Colors.green, strokeWidth: 1, dashArray: [1, 2, 3]);
 
 bool checkToShowLine(double value) => true;
 
-FlLine getDrawingLine(double value) => FlLine();
+FlLine getDrawingLine(double value) => const FlLine();
 
 const FlSpot flSpot1 = FlSpot(1, 1);
 final FlSpot flSpot1Clone = flSpot1.copyWith();
@@ -576,57 +556,44 @@ Widget getTitles(double value, TitleMeta meta) => const Text('sallam');
 TextStyle getTextStyles(BuildContext context, double value) =>
     const TextStyle(color: Colors.green);
 
-final FlGridData flGridData1 = FlGridData(
-  show: true,
+const FlGridData flGridData1 = FlGridData(
   verticalInterval: 12,
   horizontalInterval: 22,
   drawVerticalLine: false,
-  drawHorizontalLine: true,
   checkToShowVerticalLine: checkToShowLine,
   getDrawingHorizontalLine: getDrawingLine,
 );
-final FlGridData flGridData1Clone = FlGridData(
-  show: true,
+const FlGridData flGridData1Clone = FlGridData(
   verticalInterval: 12,
   horizontalInterval: 22,
   drawVerticalLine: false,
-  drawHorizontalLine: true,
   checkToShowVerticalLine: checkToShowLine,
   getDrawingHorizontalLine: getDrawingLine,
 );
 final FlGridData flGridData2 = FlGridData(
-  show: true,
   verticalInterval: 12,
   horizontalInterval: 22,
   drawVerticalLine: false,
-  drawHorizontalLine: true,
   checkToShowVerticalLine: checkToShowLine,
   getDrawingHorizontalLine: getDrawingLine,
   getDrawingVerticalLine: (value) => flLine1,
 );
-final FlGridData flGridData3 = FlGridData(
-  show: true,
+const FlGridData flGridData3 = FlGridData(
   verticalInterval: 12,
   horizontalInterval: 43,
   drawVerticalLine: false,
-  drawHorizontalLine: true,
   checkToShowVerticalLine: checkToShowLine,
   getDrawingHorizontalLine: getDrawingLine,
 );
-final FlGridData flGridData4 = FlGridData(
-  show: true,
+const FlGridData flGridData4 = FlGridData(
   verticalInterval: 12,
   horizontalInterval: 22,
   drawVerticalLine: false,
-  drawHorizontalLine: true,
   getDrawingHorizontalLine: getDrawingLine,
 );
-final FlGridData flGridData5 = FlGridData(
-  show: true,
+const FlGridData flGridData5 = FlGridData(
   verticalInterval: 12,
   horizontalInterval: 22,
-  drawVerticalLine: true,
-  drawHorizontalLine: true,
   checkToShowVerticalLine: checkToShowLine,
   getDrawingHorizontalLine: getDrawingLine,
 );
@@ -646,18 +613,17 @@ final FlBorderData borderData2 = FlBorderData(
 
 bool checkToShowSpotLine(FlSpot spot) => true;
 
-final BarAreaSpotsLine barAreaSpotsLine1 =
+const BarAreaSpotsLine barAreaSpotsLine1 =
     BarAreaSpotsLine(show: true, checkToShowSpotLine: checkToShowSpotLine);
-final BarAreaSpotsLine barAreaSpotsLine1Clone =
+const BarAreaSpotsLine barAreaSpotsLine1Clone =
     BarAreaSpotsLine(show: true, checkToShowSpotLine: checkToShowSpotLine);
 
-final BarAreaSpotsLine barAreaSpotsLine2 = BarAreaSpotsLine(
+const BarAreaSpotsLine barAreaSpotsLine2 = BarAreaSpotsLine(
   show: true,
 );
 
 final BarAreaData barAreaData1 = BarAreaData(
   show: true,
-  applyCutOffY: false,
   cutOffY: 12,
   gradient: const LinearGradient(
     colors: [Colors.green, Colors.blue],
@@ -669,7 +635,6 @@ final BarAreaData barAreaData1 = BarAreaData(
 );
 final BarAreaData barAreaData1Clone = BarAreaData(
   show: true,
-  applyCutOffY: false,
   cutOffY: 12,
   gradient: const LinearGradient(
     colors: [Colors.green, Colors.blue],
@@ -682,7 +647,6 @@ final BarAreaData barAreaData1Clone = BarAreaData(
 
 final BarAreaData barAreaData2 = BarAreaData(
   show: true,
-  applyCutOffY: false,
   cutOffY: 12,
   gradient: const LinearGradient(
     colors: [Colors.green, Colors.blue],
@@ -694,7 +658,6 @@ final BarAreaData barAreaData2 = BarAreaData(
 );
 final BarAreaData barAreaData3 = BarAreaData(
   show: true,
-  applyCutOffY: false,
   cutOffY: 12,
   gradient: const LinearGradient(
     colors: [Colors.green, Colors.blue],
@@ -706,7 +669,6 @@ final BarAreaData barAreaData3 = BarAreaData(
 );
 final BarAreaData barAreaData4 = BarAreaData(
   show: true,
-  applyCutOffY: false,
   cutOffY: 12,
   gradient: const LinearGradient(
     colors: [Colors.green, Colors.blue],
@@ -725,7 +687,7 @@ FlDotCirclePainter getDotDrawer(
   LineChartBarData barData,
   int index,
 ) =>
-    FlDotCirclePainter(radius: 44, color: Colors.green, strokeWidth: 12);
+    FlDotCirclePainter(radius: 44, strokeWidth: 12);
 
 FlDotCirclePainter getDotDrawer5(
   FlSpot spot,
@@ -733,7 +695,7 @@ FlDotCirclePainter getDotDrawer5(
   LineChartBarData barData,
   int index,
 ) =>
-    FlDotCirclePainter(radius: 44, color: Colors.green, strokeWidth: 14);
+    FlDotCirclePainter(radius: 44, strokeWidth: 14);
 
 FlDotCirclePainter getDotDrawer6(
   FlSpot spot,
@@ -741,7 +703,7 @@ FlDotCirclePainter getDotDrawer6(
   LineChartBarData barData,
   int index,
 ) =>
-    FlDotCirclePainter(radius: 44.01, color: Colors.green, strokeWidth: 14);
+    FlDotCirclePainter(radius: 44.01, strokeWidth: 14);
 
 FlDotCirclePainter getDotDrawerTouched(
   FlSpot spot,
@@ -757,7 +719,7 @@ FlDotCirclePainter getDotDrawerTouched4(
   LineChartBarData barData,
   int index,
 ) =>
-    FlDotCirclePainter(radius: 12, color: Colors.green);
+    FlDotCirclePainter(radius: 12);
 
 FlDotCirclePainter getDotDrawerTouched6(
   FlSpot spot,
@@ -767,29 +729,24 @@ FlDotCirclePainter getDotDrawerTouched6(
 ) =>
     FlDotCirclePainter(radius: 12.01, color: Colors.red);
 
-final FlDotData flDotData1 = FlDotData(
-  show: true,
+const FlDotData flDotData1 = FlDotData(
   getDotPainter: getDotDrawer,
   checkToShowDot: checkToShowDot,
 );
-final FlDotData flDotData1Clone = FlDotData(
-  show: true,
+const FlDotData flDotData1Clone = FlDotData(
   getDotPainter: getDotDrawer,
   checkToShowDot: checkToShowDot,
 );
 
-final FlDotData flDotData4 = FlDotData(
-  show: true,
+const FlDotData flDotData4 = FlDotData(
   getDotPainter: getDotDrawer,
 );
 
-final FlDotData flDotData5 = FlDotData(
-  show: true,
+const FlDotData flDotData5 = FlDotData(
   getDotPainter: getDotDrawer5,
 );
 
-final FlDotData flDotData6 = FlDotData(
-  show: true,
+const FlDotData flDotData6 = FlDotData(
   getDotPainter: getDotDrawer6,
 );
 
@@ -814,16 +771,15 @@ final Shadow shadow4 = Shadow(
   blurRadius: 12,
 );
 
-final LineChartStepData lineChartStepData1 = LineChartStepData();
+const LineChartStepData lineChartStepData1 = LineChartStepData();
 
-final LineChartStepData lineChartStepData1Clone = LineChartStepData();
+const LineChartStepData lineChartStepData1Clone = LineChartStepData();
 
-final LineChartStepData lineChartStepData2 = LineChartStepData(
+const LineChartStepData lineChartStepData2 = LineChartStepData(
   stepDirection: LineChartStepData.stepDirectionForward,
 );
 
 final LineChartBarData lineChartBarData1 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -836,20 +792,16 @@ final LineChartBarData lineChartBarData1 = LineChartBarData(
     flSpot2,
   ],
   shadow: shadow1,
-  isStepLineChart: false,
   aboveBarData: barAreaData1,
   belowBarData: barAreaData2,
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 final LineChartBarData lineChartBarData1Clone = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -862,21 +814,17 @@ final LineChartBarData lineChartBarData1Clone = LineChartBarData(
     flSpot2,
   ],
   shadow: shadow1Clone,
-  isStepLineChart: false,
   aboveBarData: barAreaData1Clone,
   belowBarData: barAreaData2,
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1Clone,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 
 final LineChartBarData lineChartBarData2 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -890,21 +838,17 @@ final LineChartBarData lineChartBarData2 = LineChartBarData(
   ],
   shadow: shadow2,
   isStepLineChart: true,
-  lineChartStepData: lineChartStepData1,
   aboveBarData: barAreaData1,
   belowBarData: barAreaData2,
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 4],
 );
 
 final LineChartBarData lineChartBarData3 = LineChartBarData(
-  show: true,
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
     stops: [0, 1],
@@ -923,15 +867,12 @@ final LineChartBarData lineChartBarData3 = LineChartBarData(
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 
 final LineChartBarData lineChartBarData4 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -944,22 +885,18 @@ final LineChartBarData lineChartBarData4 = LineChartBarData(
     flSpot1,
   ],
   shadow: shadow4,
-  isStepLineChart: false,
   lineChartStepData: lineChartStepData2,
   aboveBarData: barAreaData1,
   belowBarData: barAreaData2,
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 
 final LineChartBarData lineChartBarData5 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -976,15 +913,12 @@ final LineChartBarData lineChartBarData5 = LineChartBarData(
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 
 final LineChartBarData lineChartBarData6 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -1001,15 +935,12 @@ final LineChartBarData lineChartBarData6 = LineChartBarData(
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 
 final LineChartBarData lineChartBarData7 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: LinearGradient(
     colors: [Colors.red, Colors.green.withOpacity(0.4)],
@@ -1026,15 +957,12 @@ final LineChartBarData lineChartBarData7 = LineChartBarData(
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 
 final LineChartBarData lineChartBarData8 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -1051,15 +979,12 @@ final LineChartBarData lineChartBarData8 = LineChartBarData(
   barWidth: 12,
   curveSmoothness: 12.01,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
-  preventCurveOverShooting: false,
   preventCurveOvershootingThreshold: 1.2,
   showingIndicators: [0, 1],
 );
 
 final LineChartBarData lineChartBarData9 = LineChartBarData(
-  show: true,
   dashArray: [0, 1],
   gradient: const LinearGradient(
     colors: [Colors.red, Colors.green],
@@ -1076,7 +1001,6 @@ final LineChartBarData lineChartBarData9 = LineChartBarData(
   barWidth: 12,
   curveSmoothness: 12,
   dotData: flDotData1,
-  isCurved: false,
   isStrokeCapRound: true,
   preventCurveOverShooting: true,
   preventCurveOvershootingThreshold: 1.2,
@@ -1126,7 +1050,7 @@ final LineTouchResponse lineTouchResponse2 = LineTouchResponse(
   ],
 );
 
-final LineTouchResponse lineTouchResponse3 = LineTouchResponse(
+const LineTouchResponse lineTouchResponse3 = LineTouchResponse(
   [],
 );
 
@@ -1144,7 +1068,7 @@ final LineTouchResponse lineTouchResponse5 = LineTouchResponse(
   ],
 );
 
-final TouchedSpotIndicatorData touchedSpotIndicatorData1 =
+const TouchedSpotIndicatorData touchedSpotIndicatorData1 =
     TouchedSpotIndicatorData(
   FlLine(
     color: Colors.red,
@@ -1153,10 +1077,9 @@ final TouchedSpotIndicatorData touchedSpotIndicatorData1 =
   FlDotData(
     getDotPainter: getDotDrawerTouched,
     checkToShowDot: checkToShowDot,
-    show: true,
   ),
 );
-final TouchedSpotIndicatorData touchedSpotIndicatorData1Clone =
+const TouchedSpotIndicatorData touchedSpotIndicatorData1Clone =
     TouchedSpotIndicatorData(
   FlLine(
     color: Colors.red,
@@ -1165,11 +1088,10 @@ final TouchedSpotIndicatorData touchedSpotIndicatorData1Clone =
   FlDotData(
     getDotPainter: getDotDrawerTouched,
     checkToShowDot: checkToShowDot,
-    show: true,
   ),
 );
 
-final TouchedSpotIndicatorData touchedSpotIndicatorData2 =
+const TouchedSpotIndicatorData touchedSpotIndicatorData2 =
     TouchedSpotIndicatorData(
   FlLine(
     color: Colors.red,
@@ -1177,10 +1099,9 @@ final TouchedSpotIndicatorData touchedSpotIndicatorData2 =
   ),
   FlDotData(
     getDotPainter: getDotDrawerTouched,
-    show: true,
   ),
 );
-final TouchedSpotIndicatorData touchedSpotIndicatorData3 =
+const TouchedSpotIndicatorData touchedSpotIndicatorData3 =
     TouchedSpotIndicatorData(
   FlLine(
     color: Colors.red,
@@ -1188,10 +1109,9 @@ final TouchedSpotIndicatorData touchedSpotIndicatorData3 =
   FlDotData(
     getDotPainter: getDotDrawerTouched,
     checkToShowDot: checkToShowDot,
-    show: true,
   ),
 );
-final TouchedSpotIndicatorData touchedSpotIndicatorData4 =
+const TouchedSpotIndicatorData touchedSpotIndicatorData4 =
     TouchedSpotIndicatorData(
   FlLine(
     color: Colors.green,
@@ -1200,10 +1120,9 @@ final TouchedSpotIndicatorData touchedSpotIndicatorData4 =
   FlDotData(
     getDotPainter: getDotDrawerTouched4,
     checkToShowDot: checkToShowDot,
-    show: true,
   ),
 );
-final TouchedSpotIndicatorData touchedSpotIndicatorData5 =
+const TouchedSpotIndicatorData touchedSpotIndicatorData5 =
     TouchedSpotIndicatorData(
   FlLine(
     color: Colors.red,
@@ -1215,7 +1134,7 @@ final TouchedSpotIndicatorData touchedSpotIndicatorData5 =
     show: false,
   ),
 );
-final TouchedSpotIndicatorData touchedSpotIndicatorData6 =
+const TouchedSpotIndicatorData touchedSpotIndicatorData6 =
     TouchedSpotIndicatorData(
   FlLine(
     color: Colors.red,
@@ -1224,121 +1143,110 @@ final TouchedSpotIndicatorData touchedSpotIndicatorData6 =
   FlDotData(
     getDotPainter: getDotDrawerTouched6,
     checkToShowDot: checkToShowDot,
-    show: true,
   ),
 );
 
-final LineTooltipItem lineTooltipItem1 =
-    LineTooltipItem('', const TextStyle(color: Colors.green));
-final LineTooltipItem lineTooltipItem1Clone =
-    LineTooltipItem('', const TextStyle(color: Colors.green));
+const LineTooltipItem lineTooltipItem1 =
+    LineTooltipItem('', TextStyle(color: Colors.green));
+const LineTooltipItem lineTooltipItem1Clone =
+    LineTooltipItem('', TextStyle(color: Colors.green));
 
-final LineTooltipItem lineTooltipItem2 =
-    LineTooltipItem('ss', const TextStyle(color: Colors.green));
-final LineTooltipItem lineTooltipItem3 =
-    LineTooltipItem('', const TextStyle(color: Colors.blue));
-final LineTooltipItem lineTooltipItem4 =
-    LineTooltipItem('', const TextStyle(fontSize: 33));
+const LineTooltipItem lineTooltipItem2 =
+    LineTooltipItem('ss', TextStyle(color: Colors.green));
+const LineTooltipItem lineTooltipItem3 =
+    LineTooltipItem('', TextStyle(color: Colors.blue));
+const LineTooltipItem lineTooltipItem4 =
+    LineTooltipItem('', TextStyle(fontSize: 33));
 
 List<LineTooltipItem?> lineChartGetTooltipItems(List<LineBarSpot> list) {
   return list.map((s) => lineTooltipItem1).toList();
 }
 
-final LineTouchTooltipData lineTouchTooltipData1 = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.1),
+const LineTouchTooltipData lineTouchTooltipData1 = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.1),
   tooltipBgColor: Colors.green,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 33,
-  tooltipBorder: const BorderSide(color: Colors.red),
+  tooltipBorder: BorderSide(color: Colors.red),
 );
-final LineTouchTooltipData lineTouchTooltipData1Clone = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.1),
+const LineTouchTooltipData lineTouchTooltipData1Clone = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.1),
   tooltipBgColor: Colors.green,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 33,
-  tooltipBorder: const BorderSide(color: Colors.red),
+  tooltipBorder: BorderSide(color: Colors.red),
 );
 
-final LineTouchTooltipData lineTouchTooltipData2 = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.1),
+const LineTouchTooltipData lineTouchTooltipData2 = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.1),
   tooltipBgColor: Colors.red,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 33,
-  tooltipBorder: const BorderSide(color: Colors.red),
-  tooltipHorizontalAlignment: FLHorizontalAlignment.center,
+  tooltipBorder: BorderSide(color: Colors.red),
 );
-final LineTouchTooltipData lineTouchTooltipData3 = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.2),
+const LineTouchTooltipData lineTouchTooltipData3 = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.2),
   tooltipBgColor: Colors.green,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 33,
-  tooltipBorder: const BorderSide(color: Colors.red),
+  tooltipBorder: BorderSide(color: Colors.red),
   tooltipHorizontalAlignment: FLHorizontalAlignment.left,
 );
-final LineTouchTooltipData lineTouchTooltipData4 = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.1),
+const LineTouchTooltipData lineTouchTooltipData4 = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.1),
   tooltipBgColor: Colors.green,
   maxContentWidth: 13,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 33,
-  tooltipBorder: const BorderSide(color: Colors.red),
+  tooltipBorder: BorderSide(color: Colors.red),
   tooltipHorizontalAlignment: FLHorizontalAlignment.right,
 );
-final LineTouchTooltipData lineTouchTooltipData5 = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.1),
+const LineTouchTooltipData lineTouchTooltipData5 = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.1),
   tooltipBgColor: Colors.green,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 34,
-  tooltipBorder: const BorderSide(color: Colors.red),
-  tooltipHorizontalAlignment: FLHorizontalAlignment.center,
+  tooltipBorder: BorderSide(color: Colors.red),
   tooltipHorizontalOffset: 10,
 );
-final LineTouchTooltipData lineTouchTooltipData6 = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.1),
+const LineTouchTooltipData lineTouchTooltipData6 = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.1),
   tooltipBgColor: Colors.green,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 33,
-  tooltipBorder: const BorderSide(color: Colors.pink),
+  tooltipBorder: BorderSide(color: Colors.pink),
   tooltipHorizontalAlignment: FLHorizontalAlignment.left,
   tooltipHorizontalOffset: -10,
 );
-final LineTouchTooltipData lineTouchTooltipData7 = LineTouchTooltipData(
-  tooltipPadding: const EdgeInsets.all(0.1),
+const LineTouchTooltipData lineTouchTooltipData7 = LineTouchTooltipData(
+  tooltipPadding: EdgeInsets.all(0.1),
   tooltipBgColor: Colors.green,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
-  fitInsideVertically: false,
   tooltipRoundedRadius: 12,
   tooltipMargin: 33,
-  tooltipBorder: const BorderSide(color: Colors.red, width: 2),
+  tooltipBorder: BorderSide(color: Colors.red, width: 2),
   tooltipHorizontalAlignment: FLHorizontalAlignment.right,
   tooltipHorizontalOffset: 10,
 );
@@ -1351,16 +1259,14 @@ List<TouchedSpotIndicatorData?> getTouchedSpotIndicator(
 ) =>
     indexes.map((i) => touchedSpotIndicatorData1).toList();
 
-final LineTouchData lineTouchData1 = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData1 = LineTouchData(
   touchCallback: lineTouchCallback,
   getTouchedSpotIndicator: getTouchedSpotIndicator,
   handleBuiltInTouches: false,
   touchSpotThreshold: 12,
   touchTooltipData: lineTouchTooltipData1,
 );
-final LineTouchData lineTouchData1Clone = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData1Clone = LineTouchData(
   touchCallback: lineTouchCallback,
   getTouchedSpotIndicator: getTouchedSpotIndicator,
   handleBuiltInTouches: false,
@@ -1368,45 +1274,38 @@ final LineTouchData lineTouchData1Clone = LineTouchData(
   touchTooltipData: lineTouchTooltipData1,
 );
 
-final LineTouchData lineTouchData2 = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData2 = LineTouchData(
   getTouchedSpotIndicator: getTouchedSpotIndicator,
   handleBuiltInTouches: false,
   touchSpotThreshold: 12,
   touchTooltipData: lineTouchTooltipData1,
 );
-final LineTouchData lineTouchData3 = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData3 = LineTouchData(
   touchCallback: lineTouchCallback,
   handleBuiltInTouches: false,
   touchSpotThreshold: 12,
   touchTooltipData: lineTouchTooltipData1,
 );
-final LineTouchData lineTouchData4 = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData4 = LineTouchData(
   touchCallback: lineTouchCallback,
   getTouchedSpotIndicator: getTouchedSpotIndicator,
   handleBuiltInTouches: false,
   touchSpotThreshold: 12,
 );
-final LineTouchData lineTouchData5 = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData5 = LineTouchData(
   touchCallback: lineTouchCallback,
   getTouchedSpotIndicator: getTouchedSpotIndicator,
   handleBuiltInTouches: false,
   touchSpotThreshold: 12.001,
   touchTooltipData: lineTouchTooltipData1,
 );
-final LineTouchData lineTouchData6 = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData6 = LineTouchData(
   touchCallback: lineTouchCallback,
   getTouchedSpotIndicator: getTouchedSpotIndicator,
-  handleBuiltInTouches: true,
   touchSpotThreshold: 12,
   touchTooltipData: lineTouchTooltipData1,
 );
 final LineTouchData lineTouchData7 = LineTouchData(
-  enabled: true,
   touchCallback: lineTouchCallback,
   getTouchedSpotIndicator: getTouchedSpotIndicator,
   handleBuiltInTouches: false,
@@ -1414,8 +1313,7 @@ final LineTouchData lineTouchData7 = LineTouchData(
   touchTooltipData: lineTouchTooltipData1,
   getTouchLineEnd: (barData, index) => double.infinity,
 );
-final LineTouchData lineTouchData8 = LineTouchData(
-  enabled: true,
+const LineTouchData lineTouchData8 = LineTouchData(
   touchCallback: lineTouchCallback,
   getTouchedSpotIndicator: getTouchedSpotIndicator,
   handleBuiltInTouches: false,
@@ -1754,7 +1652,6 @@ final ExtraLinesData extraLinesData6 = ExtraLinesData(
     verticalLine2,
     verticalLine3,
   ],
-  extraLinesOnTop: true,
 );
 
 final SizedPicture sizedPicture1 = SizedPicture(
@@ -1882,7 +1779,7 @@ final ShowingTooltipIndicators showingTooltipIndicator1Clone =
     ShowingTooltipIndicators(
   [lineBarSpot1, lineBarSpot2],
 );
-final ShowingTooltipIndicators showingTooltipIndicator2 =
+const ShowingTooltipIndicators showingTooltipIndicator2 =
     ShowingTooltipIndicators(
   [],
 );
@@ -1906,7 +1803,6 @@ final LineChartData lineChartData1 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -1926,7 +1822,6 @@ final LineChartData lineChartData1Clone = LineChartData(
     showingTooltipIndicator1Clone,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -1945,7 +1840,6 @@ final LineChartData lineChartData2 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -1965,7 +1859,6 @@ final LineChartData lineChartData3 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -1982,7 +1875,6 @@ final LineChartData lineChartData4 = LineChartData(
   borderData: borderData1,
   lineTouchData: lineTouchData1,
   showingTooltipIndicators: [],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2002,7 +1894,6 @@ final LineChartData lineChartData5 = LineChartData(
     showingTooltipIndicator2,
     showingTooltipIndicator1,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2018,7 +1909,6 @@ final LineChartData lineChartData5 = LineChartData(
 final LineChartData lineChartData6 = LineChartData(
   borderData: borderData1,
   lineTouchData: lineTouchData1,
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2038,7 +1928,6 @@ final LineChartData lineChartData7 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2058,7 +1947,7 @@ final LineChartData lineChartData8 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.all(),
+  clipData: const FlClipData.all(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2078,7 +1967,6 @@ final LineChartData lineChartData9 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red.withOpacity(0.2),
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2098,7 +1986,6 @@ final LineChartData lineChartData10 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 24,
   rangeAnnotations: rangeAnnotations1,
@@ -2118,7 +2005,6 @@ final LineChartData lineChartData11 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   gridData: flGridData1,
@@ -2137,7 +2023,6 @@ final LineChartData lineChartData12 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2157,7 +2042,6 @@ final LineChartData lineChartData13 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2177,7 +2061,6 @@ final LineChartData lineChartData14 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2197,7 +2080,6 @@ final LineChartData lineChartData15 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2216,7 +2098,6 @@ final LineChartData lineChartData16 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2236,7 +2117,6 @@ final LineChartData lineChartData17 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2256,7 +2136,6 @@ final LineChartData lineChartData18 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2276,7 +2155,6 @@ final LineChartData lineChartData19 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2296,7 +2174,6 @@ final LineChartData lineChartData20 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  clipData: FlClipData.none(),
   backgroundColor: Colors.red,
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
@@ -2328,7 +2205,7 @@ final PieChartData pieChartData1Clone = pieChartData1.copyWith();
 
 bool gridCheckToShowLine(double value) => true;
 
-FlLine gridGetDrawingLine(double value) => FlLine();
+FlLine gridGetDrawingLine(double value) => const FlLine();
 
 ScatterTooltipItem? scatterChartGetTooltipItems(ScatterSpot spots) {
   return ScatterTooltipItem(
@@ -2355,19 +2232,18 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
   maxY: 12,
   maxX: 22,
   minX: 11,
-  gridData: FlGridData(
+  gridData: const FlGridData(
     show: false,
     getDrawingHorizontalLine: gridGetDrawingLine,
     getDrawingVerticalLine: gridGetDrawingLine,
     checkToShowHorizontalLine: gridCheckToShowLine,
     checkToShowVerticalLine: gridCheckToShowLine,
-    drawHorizontalLine: true,
     drawVerticalLine: false,
     horizontalInterval: 33,
     verticalInterval: 1,
   ),
   backgroundColor: Colors.black,
-  clipData: FlClipData.none(),
+  clipData: const FlClipData.none(),
   borderData: FlBorderData(
     show: true,
     border: Border.all(
@@ -2395,12 +2271,10 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
     touchSpotThreshold: 12,
   ),
   showingTooltipIndicators: [0, 1, 2],
-  titlesData: FlTitlesData(
-    show: true,
+  titlesData: const FlTitlesData(
     leftTitles: AxisTitles(
       axisNameSize: 33,
       axisNameWidget: MockData.widget1,
-      sideTitles: SideTitles(showTitles: false),
     ),
     rightTitles: AxisTitles(
       axisNameSize: 1326,
@@ -2410,12 +2284,10 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
     topTitles: AxisTitles(
       axisNameSize: 34,
       axisNameWidget: MockData.widget4,
-      sideTitles: SideTitles(showTitles: false),
     ),
     bottomTitles: AxisTitles(
       axisNameSize: 22,
       axisNameWidget: MockData.widget2,
-      sideTitles: SideTitles(showTitles: false),
     ),
   ),
   scatterLabelSettings: ScatterLabelSettings(
@@ -3284,11 +3156,11 @@ final RadarChartData radarChartData2 = RadarChartData(
   ticksTextStyle: const TextStyle(color: Colors.purple, fontSize: 10),
 );
 
-final Line line1 = Line(Offset.zero, const Offset(10, 10));
-final Line line2 = Line(const Offset(-4, -12), const Offset(6, 8));
-final Line line3 = Line(const Offset(18, -1), Offset.zero);
-final Line line4 = Line(const Offset(8, 8), const Offset(-4, -22));
-final Line line5 = Line(const Offset(2, 3), const Offset(5, 8));
+const Line line1 = Line(Offset.zero, Offset(10, 10));
+const Line line2 = Line(Offset(-4, -12), Offset(6, 8));
+const Line line3 = Line(Offset(18, -1), Offset.zero);
+const Line line4 = Line(Offset(8, 8), Offset(-4, -22));
+const Line line5 = Line(Offset(2, 3), Offset(5, 8));
 
 const TextStyle textStyle1 =
     TextStyle(color: Colors.red, fontWeight: FontWeight.bold);

--- a/test/chart/line_chart/line_chart_helper_test.dart
+++ b/test/chart/line_chart/line_chart_helper_test.dart
@@ -72,7 +72,7 @@ void main() {
         )
       ];
       final result1 = LineChartHelper.calculateMaxAxisValues(lineBars);
-      expect(result1, LineChartMinMaxAxisValues(0, 0, 0, 0));
+      expect(result1, const LineChartMinMaxAxisValues(0, 0, 0, 0));
     });
 
     test('Test null spot 2', () {
@@ -87,7 +87,7 @@ void main() {
         )
       ];
       final result1 = LineChartHelper.calculateMaxAxisValues(lineBars);
-      expect(result1, LineChartMinMaxAxisValues(-1, 4, -3, 5));
+      expect(result1, const LineChartMinMaxAxisValues(-1, 4, -3, 5));
     });
   });
 }

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -50,7 +50,7 @@ void main() {
           bar1,
           bar2,
         ],
-        clipData: FlClipData.all(),
+        clipData: const FlClipData.all(),
         extraLinesData: ExtraLinesData(
           horizontalLines: [
             HorizontalLine(y: 1),
@@ -69,7 +69,6 @@ void main() {
           ])
         ],
         lineTouchData: LineTouchData(
-          enabled: true,
           getTouchedSpotIndicator:
               (LineChartBarData barData, List<int> spotIndexes) {
             return spotIndexes.asMap().entries.map((entry) {
@@ -77,9 +76,9 @@ void main() {
               if (i == 0) {
                 return null;
               }
-              return TouchedSpotIndicatorData(
+              return const TouchedSpotIndicatorData(
                 FlLine(color: MockData.color0),
-                FlDotData(show: true),
+                FlDotData(),
               );
             }).toList();
           },
@@ -142,17 +141,16 @@ void main() {
           bar1,
           bar2,
         ],
-        clipData: FlClipData.all(),
+        clipData: const FlClipData.all(),
         lineTouchData: LineTouchData(
-          enabled: true,
           getTouchedSpotIndicator:
               (LineChartBarData barData, List<int> spotIndexes) {
             return List.generate(
               spotIndexes.length + 1,
               (index) {
-                return TouchedSpotIndicatorData(
+                return const TouchedSpotIndicatorData(
                   FlLine(color: MockData.color0),
-                  FlDotData(show: true),
+                  FlDotData(),
                 );
               },
             ).toList();
@@ -217,14 +215,7 @@ void main() {
     test('test 1', () {
       const viewSize = Size(400, 400);
 
-      final data = LineChartData(
-        clipData: FlClipData(
-          top: false,
-          bottom: false,
-          left: false,
-          right: false,
-        ),
-      );
+      final data = LineChartData();
 
       final lineChartPainter = LineChartPainter();
       final holder = PaintHolder<LineChartData>(data, data, 1);
@@ -249,8 +240,7 @@ void main() {
       const viewSize = Size(400, 400);
 
       final data = LineChartData(
-        titlesData: FlTitlesData(
-          show: true,
+        titlesData: const FlTitlesData(
           leftTitles: AxisTitles(
             sideTitles: SideTitles(showTitles: true, reservedSize: 10),
           ),
@@ -265,7 +255,7 @@ void main() {
           ),
         ),
         borderData: FlBorderData(show: true, border: Border.all(width: 8)),
-        clipData: FlClipData(
+        clipData: const FlClipData(
           top: false,
           bottom: false,
           left: true,
@@ -296,8 +286,7 @@ void main() {
       const viewSize = Size(400, 400);
 
       final data = LineChartData(
-        titlesData: FlTitlesData(
-          show: true,
+        titlesData: const FlTitlesData(
           leftTitles: AxisTitles(
             sideTitles: SideTitles(showTitles: true, reservedSize: 10),
           ),
@@ -315,7 +304,7 @@ void main() {
           ),
         ),
         borderData: FlBorderData(show: true, border: Border.all(width: 8)),
-        clipData: FlClipData(
+        clipData: const FlClipData(
           top: true,
           bottom: true,
           left: true,
@@ -348,7 +337,6 @@ void main() {
       const viewSize = Size(400, 400);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           flSpot1,
           flSpot2,
@@ -378,7 +366,6 @@ void main() {
       const viewSize = Size(400, 400);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           flSpot1,
           flSpot2,
@@ -409,7 +396,6 @@ void main() {
       const viewSize = Size(400, 400);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           flSpot1,
           flSpot2,
@@ -450,7 +436,6 @@ void main() {
       const viewSize = Size(400, 400);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           flSpot1,
           flSpot2,
@@ -460,7 +445,6 @@ void main() {
       );
 
       final barData2 = LineChartBarData(
-        show: true,
         spots: const [
           flSpot2,
           flSpot1,
@@ -514,11 +498,7 @@ void main() {
     test('test 1', () {
       const viewSize = Size(400, 400);
 
-      final barData = LineChartBarData(
-        show: true,
-        spots: const [],
-        dotData: FlDotData(show: true),
-      );
+      final barData = LineChartBarData();
 
       final data = LineChartData(
         lineBarsData: [
@@ -545,9 +525,8 @@ void main() {
       const viewSize = Size(400, 400);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [FlSpot(1, 1)],
-        dotData: FlDotData(show: false),
+        dotData: const FlDotData(show: false),
       );
 
       final data = LineChartData(
@@ -575,7 +554,6 @@ void main() {
       const viewSize = Size(400, 400);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(2, 2),
@@ -584,7 +562,6 @@ void main() {
           FlSpot.nullSpot,
           FlSpot(5, 5),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final data = LineChartData(
@@ -612,7 +589,6 @@ void main() {
       const viewSize = Size(100, 100);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(2, 2),
@@ -621,7 +597,6 @@ void main() {
           FlSpot.nullSpot,
           FlSpot(5, 5),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final data = LineChartData(
@@ -632,7 +607,7 @@ void main() {
         lineBarsData: [
           barData,
         ],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -717,11 +692,7 @@ void main() {
     test('test 1', () {
       const viewSize = Size(400, 400);
 
-      final lineChartBarData = LineChartBarData(
-        show: true,
-        spots: const [],
-        dotData: FlDotData(show: true),
-      );
+      final lineChartBarData = LineChartBarData();
 
       final data = LineChartData(
         lineBarsData: [lineChartBarData],
@@ -750,16 +721,13 @@ void main() {
       const spot2 = FlSpot(2, 2);
       const spot3 = FlSpot(3, 3);
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: const [spot1, spot2, spot3],
-        dotData: FlDotData(show: true),
         showingIndicators: [0, 1],
       );
 
       final data = LineChartData(
         lineBarsData: [lineChartBarData],
         lineTouchData: LineTouchData(
-          enabled: true,
           getTouchedSpotIndicator: (barData, spotIndexes) {
             return spotIndexes.asMap().entries.map((e) {
               final index = e.key;
@@ -769,7 +737,7 @@ void main() {
               final strokeWidth = index == 0 ? 8.0 : 12.0;
               return TouchedSpotIndicatorData(
                 FlLine(color: color, strokeWidth: strokeWidth),
-                FlDotData(show: false),
+                const FlDotData(show: false),
               );
             }).toList();
           },
@@ -822,7 +790,6 @@ void main() {
       const spot2 = FlSpot(2, 2);
       const spot3 = FlSpot(3, 3);
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: const [spot1, spot2, spot3],
         showingIndicators: [0, 1],
       );
@@ -830,7 +797,6 @@ void main() {
       final data = LineChartData(
         lineBarsData: [lineChartBarData],
         lineTouchData: LineTouchData(
-          enabled: true,
           getTouchedSpotIndicator: (barData, spotIndexes) {
             return spotIndexes.asMap().entries.map((e) {
               final index = e.key;
@@ -840,7 +806,7 @@ void main() {
               final strokeWidth = index == 0 ? 8.0 : 12.0;
               return TouchedSpotIndicatorData(
                 FlLine(color: color, strokeWidth: strokeWidth),
-                FlDotData(show: true),
+                const FlDotData(),
               );
             }).toList();
           },
@@ -894,13 +860,11 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot.zero,
           FlSpot(5, 5),
           FlSpot(10, 0),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final data = LineChartData(
@@ -910,7 +874,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -950,13 +914,11 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot.zero,
           FlSpot(5, 5),
           FlSpot(10, 0),
         ],
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
       );
 
@@ -967,7 +929,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1009,13 +971,11 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot.zero,
           FlSpot(5, 5),
           FlSpot(10, 0),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final data = LineChartData(
@@ -1025,7 +985,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1067,13 +1027,11 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot.zero,
           FlSpot(5, 5),
           FlSpot(10, 0),
         ],
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
       );
 
@@ -1084,7 +1042,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1132,9 +1090,7 @@ void main() {
       ];
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: barSpots,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
       );
 
@@ -1145,7 +1101,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1183,9 +1139,7 @@ void main() {
       ];
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: barSpots,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
         belowBarData: BarAreaData(
           cutOffY: 4,
@@ -1200,7 +1154,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1240,9 +1194,7 @@ void main() {
       ];
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: barSpots,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
       );
 
@@ -1253,7 +1205,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1292,9 +1244,7 @@ void main() {
       ];
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: barSpots,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
         belowBarData: BarAreaData(
           show: true,
@@ -1311,7 +1261,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1358,9 +1308,7 @@ void main() {
       ];
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: barSpots,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
         belowBarData: BarAreaData(
           show: true,
@@ -1369,11 +1317,11 @@ void main() {
           ),
           applyCutOffY: true,
           cutOffY: 8,
-          spotsLine: BarAreaSpotsLine(
+          spotsLine: const BarAreaSpotsLine(
             show: true,
             applyCutOffY: false,
             flLineStyle: FlLine(
-              color: const Color(0x00F0F0F0),
+              color: Color(0x00F0F0F0),
               strokeWidth: 18,
             ),
           ),
@@ -1387,7 +1335,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1476,9 +1424,7 @@ void main() {
       ];
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: barSpots,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
         aboveBarData: BarAreaData(
           show: true,
@@ -1495,7 +1441,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1542,9 +1488,7 @@ void main() {
       ];
 
       final lineChartBarData = LineChartBarData(
-        show: true,
         spots: barSpots,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
         aboveBarData: BarAreaData(
           show: true,
@@ -1553,11 +1497,11 @@ void main() {
           ),
           applyCutOffY: true,
           cutOffY: 8,
-          spotsLine: BarAreaSpotsLine(
+          spotsLine: const BarAreaSpotsLine(
             show: true,
             applyCutOffY: false,
             flLineStyle: FlLine(
-              color: const Color(0x00F0F0F0),
+              color: Color(0x00F0F0F0),
               strokeWidth: 18,
             ),
           ),
@@ -1571,7 +1515,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1665,9 +1609,7 @@ void main() {
       ];
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: barSpots1,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
         aboveBarData: BarAreaData(
           show: true,
@@ -1678,9 +1620,7 @@ void main() {
       );
 
       final lineChartBarData2 = LineChartBarData(
-        show: true,
         spots: barSpots2,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
       );
 
@@ -1697,7 +1637,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1, lineChartBarData2],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         betweenBarsData: [betweenBarData1],
       );
 
@@ -1742,9 +1682,7 @@ void main() {
       ];
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: barSpots1,
-        dotData: FlDotData(show: true),
         isStepLineChart: true,
         shadow: const Shadow(color: Color(0x0000FF00)),
       );
@@ -1773,9 +1711,7 @@ void main() {
       ];
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: barSpots1,
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -1830,7 +1766,6 @@ void main() {
       final lineChartBarData1 = LineChartBarData(
         show: false,
         spots: barSpots1,
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -1848,7 +1783,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1879,9 +1814,7 @@ void main() {
       ];
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: barSpots1,
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -1900,7 +1833,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -1940,9 +1873,7 @@ void main() {
       ];
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: barSpots1,
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -1959,7 +1890,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -2002,8 +1933,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
-        extraLinesData: ExtraLinesData(horizontalLines: [], verticalLines: []),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -2031,7 +1961,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -2059,7 +1989,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         extraLinesData: ExtraLinesData(
           horizontalLines: [
             HorizontalLine(
@@ -2142,7 +2072,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         extraLinesData: ExtraLinesData(
           horizontalLines: [
             HorizontalLine(
@@ -2197,7 +2127,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         extraLinesData: ExtraLinesData(
           verticalLines: [
             VerticalLine(
@@ -2251,7 +2181,7 @@ void main() {
         maxY: 10,
         minX: -1,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         extraLinesData: ExtraLinesData(
           verticalLines: [
             VerticalLine(
@@ -2316,7 +2246,6 @@ void main() {
       const viewSize = Size(100, 100);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(2, 2),
@@ -2325,7 +2254,6 @@ void main() {
           FlSpot.nullSpot,
           FlSpot(5, 5),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final tooltipData = LineTouchTooltipData(
@@ -2337,7 +2265,6 @@ void main() {
         tooltipPadding: const EdgeInsets.all(12),
         fitInsideHorizontally: true,
         fitInsideVertically: true,
-        showOnTopOfTheChartBoxArea: false,
         getTooltipItems: (List<LineBarSpot> touchedSpots) {
           return touchedSpots
               .map((e) => LineTooltipItem(e.barIndex.toString(), textStyle1))
@@ -2350,11 +2277,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
-        extraLinesData: ExtraLinesData(
-          horizontalLines: [],
-          verticalLines: [],
-        ),
+        titlesData: const FlTitlesData(show: false),
         lineTouchData: LineTouchData(
           touchTooltipData: tooltipData,
         ),
@@ -2433,7 +2356,6 @@ void main() {
       const viewSize = Size(100, 100);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(2, 2),
@@ -2442,7 +2364,6 @@ void main() {
           FlSpot.nullSpot,
           FlSpot(5, 5),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final tooltipData = LineTouchTooltipData(
@@ -2453,9 +2374,7 @@ void main() {
         tooltipMargin: 12,
         tooltipHorizontalAlignment: FLHorizontalAlignment.left,
         tooltipPadding: const EdgeInsets.all(12),
-        fitInsideHorizontally: false,
         fitInsideVertically: true,
-        showOnTopOfTheChartBoxArea: false,
         getTooltipItems: (List<LineBarSpot> touchedSpots) {
           return touchedSpots
               .map((e) => LineTooltipItem(e.barIndex.toString(), textStyle1))
@@ -2468,11 +2387,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
-        extraLinesData: ExtraLinesData(
-          horizontalLines: [],
-          verticalLines: [],
-        ),
+        titlesData: const FlTitlesData(show: false),
         lineTouchData: LineTouchData(
           touchTooltipData: tooltipData,
         ),
@@ -2551,7 +2466,6 @@ void main() {
       const viewSize = Size(100, 100);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(2, 2),
@@ -2560,7 +2474,6 @@ void main() {
           FlSpot.nullSpot,
           FlSpot(5, 5),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final tooltipData = LineTouchTooltipData(
@@ -2571,9 +2484,7 @@ void main() {
         tooltipMargin: 12,
         tooltipHorizontalAlignment: FLHorizontalAlignment.right,
         tooltipPadding: const EdgeInsets.all(12),
-        fitInsideHorizontally: false,
         fitInsideVertically: true,
-        showOnTopOfTheChartBoxArea: false,
         getTooltipItems: (List<LineBarSpot> touchedSpots) {
           return touchedSpots
               .map((e) => LineTooltipItem(e.barIndex.toString(), textStyle1))
@@ -2586,11 +2497,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
-        extraLinesData: ExtraLinesData(
-          horizontalLines: [],
-          verticalLines: [],
-        ),
+        titlesData: const FlTitlesData(show: false),
         lineTouchData: LineTouchData(
           touchTooltipData: tooltipData,
         ),
@@ -2671,7 +2578,6 @@ void main() {
       const viewSize = Size(100, 100);
 
       final barData = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(2, 2),
@@ -2680,7 +2586,6 @@ void main() {
           FlSpot.nullSpot,
           FlSpot(5, 5),
         ],
-        dotData: FlDotData(show: true),
       );
 
       final data = LineChartData(
@@ -2713,7 +2618,6 @@ void main() {
           FlSpot(6, 1),
           FlSpot(8, 1),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2732,7 +2636,6 @@ void main() {
           FlSpot(3.5, 2),
           FlSpot(4.3, 2),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2750,8 +2653,8 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1, lineChartBarData2],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
-        lineTouchData: LineTouchData(
+        titlesData: const FlTitlesData(show: false),
+        lineTouchData: const LineTouchData(
           touchSpotThreshold: 0.5,
         ),
       );
@@ -2767,14 +2670,12 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(4, 1),
           FlSpot(6, 1),
           FlSpot(8, 1),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2786,14 +2687,12 @@ void main() {
       );
 
       final lineChartBarData2 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1.1, 2),
           FlSpot(2, 2),
           FlSpot(3.5, 2),
           FlSpot(4.3, 2),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2811,8 +2710,8 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1, lineChartBarData2],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
-        lineTouchData: LineTouchData(
+        titlesData: const FlTitlesData(show: false),
+        lineTouchData: const LineTouchData(
           touchSpotThreshold: 5,
         ),
       );
@@ -2845,14 +2744,12 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(2, 1),
           FlSpot(3, 1),
           FlSpot(8, 1),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2864,14 +2761,12 @@ void main() {
       );
 
       final lineChartBarData2 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1.3, 1),
           FlSpot(2, 1),
           FlSpot(3, 1),
           FlSpot(4, 1),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2889,8 +2784,8 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1, lineChartBarData2],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
-        lineTouchData: LineTouchData(
+        titlesData: const FlTitlesData(show: false),
+        lineTouchData: const LineTouchData(
           touchSpotThreshold: 5,
         ),
       );
@@ -2922,7 +2817,6 @@ void main() {
           FlSpot(6, 1),
           FlSpot(8, 1),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2941,7 +2835,6 @@ void main() {
           FlSpot(3.5, 2),
           FlSpot(4.3, 2),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -2959,8 +2852,8 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1, lineChartBarData2],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
-        lineTouchData: LineTouchData(
+        titlesData: const FlTitlesData(show: false),
+        lineTouchData: const LineTouchData(
           touchSpotThreshold: 0.5,
         ),
       );
@@ -2990,14 +2883,12 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(4, 1),
           FlSpot(6, 1),
           FlSpot(8, 1),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -3009,14 +2900,12 @@ void main() {
       );
 
       final lineChartBarData2 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1.1, 2),
           FlSpot(2, 2),
           FlSpot(3.5, 2),
           FlSpot(4.3, 2),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -3034,8 +2923,8 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1, lineChartBarData2],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
-        lineTouchData: LineTouchData(
+        titlesData: const FlTitlesData(show: false),
+        lineTouchData: const LineTouchData(
           touchSpotThreshold: 5,
         ),
       );
@@ -3108,14 +2997,12 @@ void main() {
       const viewSize = Size(100, 100);
 
       final lineChartBarData1 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1, 1),
           FlSpot(4, 1),
           FlSpot(6, 4),
           FlSpot(8, 1),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -3127,14 +3014,12 @@ void main() {
       );
 
       final lineChartBarData2 = LineChartBarData(
-        show: true,
         spots: const [
           FlSpot(1.1, 4),
           FlSpot(2, 4),
           FlSpot(3.5, 1),
           FlSpot(4.3, 4),
         ],
-        dotData: FlDotData(show: true),
         barWidth: 80,
         isStrokeCapRound: true,
         isStepLineChart: true,
@@ -3152,7 +3037,7 @@ void main() {
         maxX: 10,
         lineBarsData: [lineChartBarData1, lineChartBarData2],
         showingTooltipIndicators: [],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         lineTouchData: LineTouchData(
           distanceCalculator: (Offset a, Offset b) {
             final dx = a.dx - b.dx;
@@ -3227,11 +3112,9 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
-        gridData: FlGridData(
+        titlesData: const FlTitlesData(show: false),
+        gridData: const FlGridData(
           show: false,
-          drawVerticalLine: true,
-          drawHorizontalLine: true,
           horizontalInterval: 2,
         ),
       );
@@ -3259,22 +3142,20 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         gridData: FlGridData(
-          show: true,
           drawVerticalLine: false,
-          drawHorizontalLine: true,
           horizontalInterval: 2,
           checkToShowHorizontalLine: (value) => value != 2 && value != 8,
           getDrawingHorizontalLine: (value) {
             if (value == 4) {
-              return FlLine(
+              return const FlLine(
                 color: MockData.color1,
                 strokeWidth: 11,
                 dashArray: [1, 1],
               );
             } else if (value == 6) {
-              return FlLine(
+              return const FlLine(
                 color: MockData.color2,
                 strokeWidth: 22,
                 dashArray: [2, 2],
@@ -3340,22 +3221,20 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         gridData: FlGridData(
-          show: true,
-          drawVerticalLine: true,
           drawHorizontalLine: false,
           verticalInterval: 2,
           checkToShowVerticalLine: (value) => value != 2 && value != 8,
           getDrawingVerticalLine: (value) {
             if (value == 4) {
-              return FlLine(
+              return const FlLine(
                 color: MockData.color1,
                 strokeWidth: 11,
                 dashArray: [1, 1],
               );
             } else if (value == 6) {
-              return FlLine(
+              return const FlLine(
                 color: MockData.color2,
                 strokeWidth: 22,
                 dashArray: [2, 2],
@@ -3421,11 +3300,6 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        gridData: FlGridData(
-          show: true,
-          drawVerticalLine: true,
-          drawHorizontalLine: true,
-        ),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -3455,7 +3329,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         backgroundColor: MockData.color1.withOpacity(0),
       );
 
@@ -3477,7 +3351,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         backgroundColor: MockData.color1,
       );
 
@@ -3508,8 +3382,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
-        rangeAnnotations: RangeAnnotations(),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -3530,7 +3403,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         rangeAnnotations: RangeAnnotations(
           horizontalRangeAnnotations: [
             HorizontalRangeAnnotation(y1: 4, y2: 10, color: MockData.color1),
@@ -3572,7 +3445,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         rangeAnnotations: RangeAnnotations(
           verticalRangeAnnotations: [
             VerticalRangeAnnotation(x1: 1, x2: 2, color: MockData.color1),
@@ -3614,7 +3487,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         rangeAnnotations: RangeAnnotations(
           horizontalRangeAnnotations: [
             HorizontalRangeAnnotation(y1: 4, y2: 10, color: MockData.color1),

--- a/test/chart/line_chart/line_chart_renderer_test.dart
+++ b/test/chart/line_chart/line_chart_renderer_test.dart
@@ -15,28 +15,28 @@ import 'line_chart_renderer_test.mocks.dart';
 void main() {
   group('LineChartRenderer', () {
     final data = LineChartData(
-      titlesData: FlTitlesData(
+      titlesData: const FlTitlesData(
         leftTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 20, showTitles: true),
         ),
         rightTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 464, showTitles: true),
         ),
-        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        bottomTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: AxisTitles(),
+        bottomTitles: AxisTitles(),
       ),
     );
 
     final targetData = LineChartData(
-      titlesData: FlTitlesData(
+      titlesData: const FlTitlesData(
         leftTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 8, showTitles: true),
         ),
         rightTitles: AxisTitles(
           sideTitles: SideTitles(reservedSize: 20, showTitles: true),
         ),
-        topTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
-        bottomTitles: AxisTitles(sideTitles: SideTitles(showTitles: false)),
+        topTitles: AxisTitles(),
+        bottomTitles: AxisTitles(),
       ),
     );
 

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -506,7 +506,7 @@ void main() {
     test('test 1', () {
       final barChartPainter = PieChartPainter();
       final path0 = barChartPainter.createRectPathAroundLine(
-        Line(Offset.zero, const Offset(10, 0)),
+        const Line(Offset.zero, Offset(10, 0)),
         4,
       );
       final path0Length = path0
@@ -517,7 +517,7 @@ void main() {
       expect(path0Length, 32.0);
 
       final path1 = barChartPainter.createRectPathAroundLine(
-        Line(const Offset(32, 11), const Offset(12, 5)),
+        const Line(Offset(32, 11), Offset(12, 5)),
         66,
       );
       final path1Length = path1

--- a/test/chart/scatter_chart/scatter_chart_data_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_data_test.dart
@@ -85,19 +85,18 @@ void main() {
       );
       expect(
         scatterChartData1 ==
-            scatterChartData1Clone.copyWith(clipData: FlClipData.all()),
+            scatterChartData1Clone.copyWith(clipData: const FlClipData.all()),
         false,
       );
       expect(
         scatterChartData1 ==
             scatterChartData1Clone.copyWith(
-              gridData: FlGridData(
+              gridData: const FlGridData(
                 show: false,
                 getDrawingHorizontalLine: gridGetDrawingLine,
                 getDrawingVerticalLine: gridGetDrawingLine,
                 checkToShowHorizontalLine: gridCheckToShowLine,
                 checkToShowVerticalLine: gridCheckToShowLine,
-                drawHorizontalLine: true,
                 drawVerticalLine: false,
                 horizontalInterval: 33,
                 verticalInterval: 1,
@@ -108,13 +107,11 @@ void main() {
       expect(
         scatterChartData1 ==
             scatterChartData1Clone.copyWith(
-              gridData: FlGridData(
-                show: true,
+              gridData: const FlGridData(
                 getDrawingHorizontalLine: gridGetDrawingLine,
                 getDrawingVerticalLine: gridGetDrawingLine,
                 checkToShowHorizontalLine: gridCheckToShowLine,
                 checkToShowVerticalLine: gridCheckToShowLine,
-                drawHorizontalLine: true,
                 drawVerticalLine: false,
                 horizontalInterval: 33,
                 verticalInterval: 1,
@@ -127,19 +124,18 @@ void main() {
             scatterChartData1Clone.copyWith(
               gridData: FlGridData(
                 show: false,
-                getDrawingHorizontalLine: (value) => FlLine(
+                getDrawingHorizontalLine: (value) => const FlLine(
                   color: Colors.green,
                   strokeWidth: 12,
                   dashArray: [1, 2],
                 ),
-                getDrawingVerticalLine: (value) => FlLine(
+                getDrawingVerticalLine: (value) => const FlLine(
                   color: Colors.yellow,
                   strokeWidth: 33,
                   dashArray: [0, 1],
                 ),
                 checkToShowHorizontalLine: (value) => false,
                 checkToShowVerticalLine: (value) => true,
-                drawHorizontalLine: true,
                 drawVerticalLine: false,
                 horizontalInterval: 32,
                 verticalInterval: 1,
@@ -150,12 +146,10 @@ void main() {
       expect(
         scatterChartData1 ==
             scatterChartData1Clone.copyWith(
-              titlesData: FlTitlesData(
-                show: true,
+              titlesData: const FlTitlesData(
                 leftTitles: AxisTitles(
                   axisNameSize: 33,
                   axisNameWidget: MockData.widget1,
-                  sideTitles: SideTitles(showTitles: false),
                 ),
                 rightTitles: AxisTitles(
                   axisNameSize: 1326,
@@ -165,12 +159,10 @@ void main() {
                 topTitles: AxisTitles(
                   axisNameSize: 34,
                   axisNameWidget: MockData.widget4,
-                  sideTitles: SideTitles(showTitles: false),
                 ),
                 bottomTitles: AxisTitles(
                   axisNameSize: 22,
                   axisNameWidget: MockData.widget2,
-                  sideTitles: SideTitles(showTitles: false),
                 ),
               ),
             ),
@@ -179,27 +171,23 @@ void main() {
       expect(
         scatterChartData1 ==
             scatterChartData1Clone.copyWith(
-              titlesData: FlTitlesData(
-                show: true,
+              titlesData: const FlTitlesData(
                 leftTitles: AxisTitles(
                   axisNameSize: 332,
-                  axisNameWidget: const Text('title 1'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 1'),
                 ),
                 rightTitles: AxisTitles(
                   axisNameSize: 1326,
-                  axisNameWidget: const Text('title 3'),
+                  axisNameWidget: Text('title 3'),
                   sideTitles: SideTitles(reservedSize: 500, showTitles: true),
                 ),
                 topTitles: AxisTitles(
                   axisNameSize: 34,
-                  axisNameWidget: const Text('title 4'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 4'),
                 ),
                 bottomTitles: AxisTitles(
                   axisNameSize: 22,
-                  axisNameWidget: const Text('title 2'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 2'),
                 ),
               ),
             ),
@@ -208,26 +196,23 @@ void main() {
       expect(
         scatterChartData1 ==
             scatterChartData1Clone.copyWith(
-              titlesData: FlTitlesData(
-                show: true,
+              titlesData: const FlTitlesData(
                 leftTitles: AxisTitles(
                   axisNameSize: 33,
-                  axisNameWidget: const Text('title 1'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 1'),
                 ),
                 rightTitles: AxisTitles(
                   axisNameSize: 1326,
-                  axisNameWidget: const Text('title 3'),
+                  axisNameWidget: Text('title 3'),
                   sideTitles: SideTitles(reservedSize: 500, showTitles: true),
                 ),
                 topTitles: AxisTitles(
                   axisNameSize: 34,
-                  axisNameWidget: const Text('title 4'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 4'),
                 ),
                 bottomTitles: AxisTitles(
                   axisNameSize: 22,
-                  axisNameWidget: const Text('title 2'),
+                  axisNameWidget: Text('title 2'),
                   sideTitles: SideTitles(showTitles: true),
                 ),
               ),
@@ -237,27 +222,23 @@ void main() {
       expect(
         scatterChartData1 ==
             scatterChartData1Clone.copyWith(
-              titlesData: FlTitlesData(
-                show: true,
+              titlesData: const FlTitlesData(
                 leftTitles: AxisTitles(
                   axisNameSize: 33,
-                  axisNameWidget: const Text('title 1'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 1'),
                 ),
                 rightTitles: AxisTitles(
                   axisNameSize: 1326,
-                  axisNameWidget: const Text('title 1'),
+                  axisNameWidget: Text('title 1'),
                   sideTitles: SideTitles(reservedSize: 500, showTitles: true),
                 ),
                 topTitles: AxisTitles(
                   axisNameSize: 34,
-                  axisNameWidget: const Text('title 4'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 4'),
                 ),
                 bottomTitles: AxisTitles(
                   axisNameSize: 22,
-                  axisNameWidget: const Text('title 2'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 2'),
                 ),
               ),
             ),
@@ -266,27 +247,23 @@ void main() {
       expect(
         scatterChartData1 ==
             scatterChartData1Clone.copyWith(
-              titlesData: FlTitlesData(
-                show: true,
+              titlesData: const FlTitlesData(
                 leftTitles: AxisTitles(
                   axisNameSize: 33,
-                  axisNameWidget: const Text('title 1'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 1'),
                 ),
                 rightTitles: AxisTitles(
                   axisNameSize: 13262,
-                  axisNameWidget: const Text('title 3'),
+                  axisNameWidget: Text('title 3'),
                   sideTitles: SideTitles(reservedSize: 500, showTitles: true),
                 ),
                 topTitles: AxisTitles(
                   axisNameSize: 34,
-                  axisNameWidget: const Text('title 4'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 4'),
                 ),
                 bottomTitles: AxisTitles(
                   axisNameSize: 22,
-                  axisNameWidget: const Text('title 2'),
-                  sideTitles: SideTitles(showTitles: false),
+                  axisNameWidget: Text('title 2'),
                 ),
               ),
             ),

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -78,8 +78,8 @@ void main() {
           ScatterSpot(8, 2, radius: 4),
           ScatterSpot(7, 5, radius: 6),
         ],
-        titlesData: FlTitlesData(show: false),
-        clipData: FlClipData.all(),
+        titlesData: const FlTitlesData(show: false),
+        clipData: const FlClipData.all(),
       );
 
       final scatterChartPainter = ScatterChartPainter();
@@ -120,8 +120,8 @@ void main() {
           ScatterSpot(8, 2, show: false),
           ScatterSpot(7, 5, show: false),
         ],
-        titlesData: FlTitlesData(show: false),
-        clipData: FlClipData.none(),
+        titlesData: const FlTitlesData(show: false),
+        clipData: const FlClipData.none(),
       );
 
       final scatterChartPainter = ScatterChartPainter();
@@ -159,8 +159,8 @@ void main() {
           ScatterSpot(7, 5, radius: 20),
           ScatterSpot(4, 6, radius: 24),
         ],
-        titlesData: FlTitlesData(show: false),
-        clipData: FlClipData.all(),
+        titlesData: const FlTitlesData(show: false),
+        clipData: const FlClipData.all(),
         scatterLabelSettings: ScatterLabelSettings(
           showLabel: true,
           getLabelTextStyleFunction: (int index, ScatterSpot spot) =>
@@ -227,7 +227,7 @@ void main() {
           ScatterSpot(7, 5, radius: 6),
         ],
         showingTooltipIndicators: [0, 2, 3],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final scatterChartPainter = ScatterChartPainter();
@@ -278,7 +278,7 @@ void main() {
             getTooltipItems: (spot) => null,
           ),
         ),
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
       );
 
       final scatterChartPainter = ScatterChartPainter();
@@ -326,7 +326,7 @@ void main() {
           scatterSpot4,
         ],
         showingTooltipIndicators: [0, 2, 3],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
@@ -424,7 +424,7 @@ void main() {
           scatterSpot4,
         ],
         showingTooltipIndicators: [0, 2, 3],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
@@ -527,7 +527,7 @@ void main() {
           scatterSpot4,
         ],
         showingTooltipIndicators: [0, 2, 3],
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
@@ -630,7 +630,7 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(show: false),
+        titlesData: const FlTitlesData(show: false),
         scatterSpots: spots,
       );
 
@@ -700,11 +700,10 @@ void main() {
         maxY: 10,
         minX: 0,
         maxX: 10,
-        titlesData: FlTitlesData(
-          show: true,
+        titlesData: const FlTitlesData(
           leftTitles: AxisTitles(
             axisNameSize: 4,
-            axisNameWidget: const Text('ss1'),
+            axisNameWidget: Text('ss1'),
             sideTitles: SideTitles(
               showTitles: true,
               reservedSize: 10,
@@ -724,7 +723,7 @@ void main() {
           ),
           bottomTitles: AxisTitles(
             axisNameSize: 4,
-            axisNameWidget: const Text('ss2'),
+            axisNameWidget: Text('ss2'),
             sideTitles: SideTitles(
               showTitles: true,
               reservedSize: 6,

--- a/test/extensions/side_titles_extension_test.dart
+++ b/test/extensions/side_titles_extension_test.dart
@@ -6,7 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 void main() {
   test('test totalReservedSize', () {
     expect(
-      AxisTitles(
+      const AxisTitles(
         axisNameSize: 12,
         sideTitles: SideTitles(
           showTitles: true,
@@ -17,11 +17,10 @@ void main() {
     );
 
     expect(
-      AxisTitles(
-        axisNameWidget: const Text('asdf'),
+      const AxisTitles(
+        axisNameWidget: Text('asdf'),
         axisNameSize: 12,
         sideTitles: SideTitles(
-          showTitles: false,
           reservedSize: 20,
         ),
       ).totalReservedSize,
@@ -29,8 +28,8 @@ void main() {
     );
 
     expect(
-      AxisTitles(
-        axisNameWidget: const Text('asdf'),
+      const AxisTitles(
+        axisNameWidget: Text('asdf'),
         axisNameSize: 12,
         sideTitles: SideTitles(
           showTitles: true,


### PR DESCRIPTION
Which I did for the most part.

1. Replace  

```dart
LineChartData({
    List<LineChartBarData>? lineBarsData,
  })  : lineBarsData = lineBarsData ?? const [],
```
to
```dart
LineChartData({
    this.lineBarsData = const [],
  });
```

2. Put builders in const if possible
3. Fix CI

:boom: Rename `drawBehindEverything` to `drawBelowEverything`