### PR TITLE
Fixed Link on Example Readme

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -1,4 +1,4 @@
 This is the FL Chart App.
 Check it out live here:
 
-[app.flchart.dev](app.flchart.dev)
+[app.flchart.dev](https://app.flchart.dev)


### PR DESCRIPTION
Just a link typo fix (from github, links without the scheme go to `https://github.com/imaNNeo/fl_chart/blob/master/example/app.flchart.dev`), thanks for the library!