### PR TITLE
Dynamically changing tooltipBgColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
+## 0.64.0
+* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955
 * **BUGFIX** (by @imaNNeo) Fix ScatterChart long-press interaction bug (disappears when long-pressing on the chart), #1318

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
 ## 0.64.0
-* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,8 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
-<<<<<<< HEAD
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
-=======
-## 0.64.0
-* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,6 @@
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
-## 0.64.0
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
+## 0.64.0
+* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955
 * **BUGFIX** (by @imaNNeo) Fix ScatterChart long-press interaction bug (disappears when long-pressing on the chart), #1318

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
 ## 0.64.0
-* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
 ## nextVersion
 * **FEATURE** (by @Dartek12): Added gradient to [FlLine](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#FlLine), #1197
+* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
+
 
 ## 0.64.0
 * **BUGFIX** (by @Anas35) Fix Tooltip not displaying when value from BackgroundBarChartRodData is less than zero. #1345.
 * **BUGFIX** (by @imaNNeo) Fix Negative BarChartRodStackItem are not drawn correctly bug, #1347
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
-
-* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
-* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,8 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
-<<<<<<< HEAD
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
-=======
-## 0.64.0
-* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
-## 0.64.0
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
+<<<<<<< HEAD
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
+=======
+## 0.64.0
+* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,6 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
-* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
-* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
-
-* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
-* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
-
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955
 * **BUGFIX** (by @imaNNeo) Fix ScatterChart long-press interaction bug (disappears when long-pressing on the chart), #1318

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
-## 0.64.0
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
+<<<<<<< HEAD
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
+=======
+## 0.64.0
+* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,8 @@
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
 ## 0.64.0
-* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,13 @@
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
+<<<<<<< HEAD
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
+=======
+## 0.64.0
+* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * **BUGFIX** (by @imaNNeo) Fix bar_chart_helper minY calculation bug, #1388
 * **IMPROVEMENT** (by @imaNNeo) Consider fraction digits when formatting chart side titles, #1267
 
+## 0.64.0
+* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955
 * **BUGFIX** (by @imaNNeo) Fix ScatterChart long-press interaction bug (disappears when long-pressing on the chart), #1318

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,13 +13,8 @@
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
 
-<<<<<<< HEAD
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar,Line and Scatter Charts.
-=======
-## 0.64.0
-* **FEATURE** (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ## 0.63.0
 * **BUGFIX** (by @imaNNeo) Fix PieChart crash on web-renderer html by ignoring `sectionsSpace` when `Path.combine()` does not work (it's flutter engine [issue](https://github.com/flutter/flutter/issues/44572)), #955

--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -163,32 +163,16 @@ class BarChartSample1State extends State<BarChartSample1> {
       barTouchData: BarTouchData(
         touchTooltipData: BarTouchTooltipData(
           getTooltipColor: (group) {
-            Color bgColor;
-            switch (group.x) {
-              case 0:
-                bgColor = AppColors.contentColorPurple.withAlpha(100);
-                break;
-              case 1:
-                bgColor = AppColors.contentColorYellow.withAlpha(100);
-                break;
-              case 2:
-                bgColor = AppColors.contentColorBlue.withAlpha(100);
-                break;
-              case 3:
-                bgColor = AppColors.contentColorOrange.withAlpha(100);
-                break;
-              case 4:
-                bgColor = AppColors.contentColorPink.withAlpha(100);
-                break;
-              case 5:
-                bgColor = AppColors.contentColorRed.withAlpha(100);
-                break;
-              case 6:
-                bgColor = AppColors.contentColorPurple.withAlpha(150);
-                break;
-              default:
-                throw Error();
-            }
+            Color bgColor = switch (group.x) {
+              0 => AppColors.contentColorPurple.withAlpha(100),
+              1 => AppColors.contentColorYellow.withAlpha(100),
+              2 => AppColors.contentColorBlue.withAlpha(100),
+              3 => AppColors.contentColorOrange.withAlpha(100),
+              4 => AppColors.contentColorPink.withAlpha(100),
+              5 => AppColors.contentColorRed.withAlpha(100),
+              6 => AppColors.contentColorPurple.withAlpha(150),
+              _ => throw Error(),
+            };
             return bgColor;
           },
           tooltipHorizontalAlignment: FLHorizontalAlignment.right,

--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -162,7 +162,35 @@ class BarChartSample1State extends State<BarChartSample1> {
     return BarChartData(
       barTouchData: BarTouchData(
         touchTooltipData: BarTouchTooltipData(
-          tooltipBgColor: Colors.blueGrey,
+          getTooltipColor: (group) {
+            Color bgColor;
+            switch (group.x) {
+              case 0:
+                bgColor = AppColors.contentColorPurple.withAlpha(100);
+                break;
+              case 1:
+                bgColor = AppColors.contentColorYellow.withAlpha(100);
+                break;
+              case 2:
+                bgColor = AppColors.contentColorBlue.withAlpha(100);
+                break;
+              case 3:
+                bgColor = AppColors.contentColorOrange.withAlpha(100);
+                break;
+              case 4:
+                bgColor = AppColors.contentColorPink.withAlpha(100);
+                break;
+              case 5:
+                bgColor = AppColors.contentColorRed.withAlpha(100);
+                break;
+              case 6:
+                bgColor = AppColors.contentColorPurple.withAlpha(150);
+                break;
+              default:
+                throw Error();
+            }
+            return bgColor;
+          },
           tooltipHorizontalAlignment: FLHorizontalAlignment.right,
           tooltipMargin: -10,
           getTooltipItem: (group, groupIndex, rod, rodIndex) {
@@ -202,8 +230,8 @@ class BarChartSample1State extends State<BarChartSample1> {
               children: <TextSpan>[
                 TextSpan(
                   text: (rod.toY - 1).toString(),
-                  style: TextStyle(
-                    color: widget.touchedBarColor,
+                  style: const TextStyle(
+                    color: Colors.white, //widget.touchedBarColor,
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
                   ),

--- a/example/lib/presentation/samples/bar/bar_chart_sample2.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample2.dart
@@ -85,7 +85,9 @@ class BarChartSample2State extends State<BarChartSample2> {
                   maxY: 20,
                   barTouchData: BarTouchData(
                     touchTooltipData: BarTouchTooltipData(
-                      tooltipBgColor: Colors.grey,
+                      getTooltipColor: ((group) {
+                        return Colors.grey;
+                      }),
                       getTooltipItem: (a, b, c, d) => null,
                     ),
                     touchCallback: (FlTouchEvent event, response) {

--- a/example/lib/presentation/samples/bar/bar_chart_sample3.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample3.dart
@@ -24,7 +24,7 @@ class _BarChart extends StatelessWidget {
   BarTouchData get barTouchData => BarTouchData(
         enabled: false,
         touchTooltipData: BarTouchTooltipData(
-          tooltipBgColor: Colors.transparent,
+          getTooltipColor: (group) => Colors.transparent,
           tooltipPadding: EdgeInsets.zero,
           tooltipMargin: 8,
           getTooltipItem: (

--- a/example/lib/presentation/samples/bar/bar_chart_sample7.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample7.dart
@@ -122,7 +122,7 @@ class _BarChartSample7State extends State<BarChartSample7> {
               enabled: true,
               handleBuiltInTouches: false,
               touchTooltipData: BarTouchTooltipData(
-                tooltipBgColor: Colors.transparent,
+                getTooltipColor: (group) => Colors.transparent,
                 tooltipMargin: 0,
                 getTooltipItem: (
                   BarChartGroupData group,

--- a/example/lib/presentation/samples/line/line_chart_sample1.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample1.dart
@@ -42,7 +42,7 @@ class _LineChart extends StatelessWidget {
   LineTouchData get lineTouchData1 => LineTouchData(
         handleBuiltInTouches: true,
         touchTooltipData: LineTouchTooltipData(
-          tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
+          getTooltipColor: (touchedSpots) => Colors.blueGrey.withOpacity(0.8),
         ),
       );
 

--- a/example/lib/presentation/samples/line/line_chart_sample1.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample1.dart
@@ -42,7 +42,7 @@ class _LineChart extends StatelessWidget {
   LineTouchData get lineTouchData1 => LineTouchData(
         handleBuiltInTouches: true,
         touchTooltipData: LineTouchTooltipData(
-          getTooltipColor: (touchedSpots) => Colors.blueGrey.withOpacity(0.8),
+          getTooltipColor: (touchedSpot) => Colors.blueGrey.withOpacity(0.8),
         ),
       );
 

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,6 +206,10 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
+<<<<<<< HEAD
+=======
+                    // tooltipBgColor: widget.tooltipBgColor,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
                     getTooltipColor: (touchedSpot) {
                       Color bgColor = Colors.white;
                       switch ((

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,29 +206,32 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
-                    tooltipBgColor: widget.tooltipBgColor,
+                    // tooltipBgColor: widget.tooltipBgColor,
                     getTooltipColor: (touchedSpot) {
                       Color bgColor = Colors.white;
-                      switch (touchedSpot.x.toInt()) {
-                        case 0:
+                      switch ((
+                        touchedSpot.x.toInt(),
+                        touchedSpot.y.toDouble()
+                      )) {
+                        case (0, 1.3):
                           bgColor = AppColors.contentColorPurple.withAlpha(100);
                           break;
-                        case 1:
+                        case (1, 1):
                           bgColor = AppColors.contentColorYellow.withAlpha(100);
                           break;
-                        case 2:
+                        case (2, 1.8):
                           bgColor = AppColors.contentColorBlue.withAlpha(100);
                           break;
-                        case 3:
+                        case (3, 1.5):
                           bgColor = AppColors.contentColorOrange.withAlpha(100);
                           break;
-                        case 4:
+                        case (4, 2.2):
                           bgColor = AppColors.contentColorPink.withAlpha(100);
                           break;
-                        case 5:
+                        case (5, 1.8):
                           bgColor = AppColors.contentColorRed.withAlpha(100);
                           break;
-                        case 6:
+                        case (6, 3):
                           bgColor = AppColors.contentColorPurple.withAlpha(150);
                           break;
                         default:

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,10 +206,6 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
-<<<<<<< HEAD
-=======
-                    // tooltipBgColor: widget.tooltipBgColor,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
                     getTooltipColor: (touchedSpot) {
                       Color bgColor = switch ((
                         touchedSpot.x.toInt(),

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -207,6 +207,35 @@ class _LineChartSample3State extends State<LineChartSample3> {
                   },
                   touchTooltipData: LineTouchTooltipData(
                     tooltipBgColor: widget.tooltipBgColor,
+                    getTooltipColor: (touchedSpot) {
+                      Color bgColor = Colors.white;
+                      switch (touchedSpot.x.toInt()) {
+                        case 0:
+                          bgColor = AppColors.contentColorPurple.withAlpha(100);
+                          break;
+                        case 1:
+                          bgColor = AppColors.contentColorYellow.withAlpha(100);
+                          break;
+                        case 2:
+                          bgColor = AppColors.contentColorBlue.withAlpha(100);
+                          break;
+                        case 3:
+                          bgColor = AppColors.contentColorOrange.withAlpha(100);
+                          break;
+                        case 4:
+                          bgColor = AppColors.contentColorPink.withAlpha(100);
+                          break;
+                        case 5:
+                          bgColor = AppColors.contentColorRed.withAlpha(100);
+                          break;
+                        case 6:
+                          bgColor = AppColors.contentColorPurple.withAlpha(150);
+                          break;
+                        default:
+                          throw Error();
+                      }
+                      return bgColor;
+                    },
                     getTooltipItems: (List<LineBarSpot> touchedBarSpots) {
                       return touchedBarSpots.map((barSpot) {
                         final flSpot = barSpot;

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,6 +206,10 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
+<<<<<<< HEAD
+=======
+                    // tooltipBgColor: widget.tooltipBgColor,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
                     getTooltipColor: (touchedSpot) {
                       Color bgColor = switch ((
                         touchedSpot.x.toInt(),

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -207,35 +207,19 @@ class _LineChartSample3State extends State<LineChartSample3> {
                   },
                   touchTooltipData: LineTouchTooltipData(
                     getTooltipColor: (touchedSpot) {
-                      Color bgColor = Colors.white;
-                      switch ((
+                      Color bgColor = switch ((
                         touchedSpot.x.toInt(),
                         touchedSpot.y.toDouble()
                       )) {
-                        case (0, 1.3):
-                          bgColor = AppColors.contentColorPurple.withAlpha(100);
-                          break;
-                        case (1, 1):
-                          bgColor = AppColors.contentColorYellow.withAlpha(100);
-                          break;
-                        case (2, 1.8):
-                          bgColor = AppColors.contentColorBlue.withAlpha(100);
-                          break;
-                        case (3, 1.5):
-                          bgColor = AppColors.contentColorOrange.withAlpha(100);
-                          break;
-                        case (4, 2.2):
-                          bgColor = AppColors.contentColorPink.withAlpha(100);
-                          break;
-                        case (5, 1.8):
-                          bgColor = AppColors.contentColorRed.withAlpha(100);
-                          break;
-                        case (6, 3):
-                          bgColor = AppColors.contentColorPurple.withAlpha(150);
-                          break;
-                        default:
-                          throw Error();
-                      }
+                        (0, 1.3) => AppColors.contentColorPurple.withAlpha(100),
+                        (1, 1) => AppColors.contentColorYellow.withAlpha(100),
+                        (2, 1.8) => AppColors.contentColorBlue.withAlpha(100),
+                        (3, 1.5) => AppColors.contentColorOrange.withAlpha(100),
+                        (4, 2.2) => AppColors.contentColorPink.withAlpha(100),
+                        (5, 1.8) => AppColors.contentColorRed.withAlpha(100),
+                        (6, 3) => AppColors.contentColorPurple.withAlpha(150),
+                        _ => throw Error(),
+                      };
                       return bgColor;
                     },
                     getTooltipItems: (List<LineBarSpot> touchedBarSpots) {

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,7 +206,6 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
-                    // tooltipBgColor: widget.tooltipBgColor,
                     getTooltipColor: (touchedSpot) {
                       Color bgColor = Colors.white;
                       switch ((

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,10 +206,6 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
-<<<<<<< HEAD
-=======
-                    // tooltipBgColor: widget.tooltipBgColor,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
                     getTooltipColor: (touchedSpot) {
                       Color bgColor = Colors.white;
                       switch ((

--- a/example/lib/presentation/samples/line/line_chart_sample5.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample5.dart
@@ -181,7 +181,7 @@ class _LineChartSample5State extends State<LineChartSample5> {
                   }).toList();
                 },
                 touchTooltipData: LineTouchTooltipData(
-                  tooltipBgColor: Colors.pink,
+                  getTooltipColor: (touchedSpot) => Colors.pink,
                   tooltipRoundedRadius: 8,
                   getTooltipItems: (List<LineBarSpot> lineBarsSpot) {
                     return lineBarsSpot.map((lineBarSpot) {

--- a/example/lib/presentation/samples/line/line_chart_sample8.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample8.dart
@@ -237,8 +237,8 @@ class _LineChartSample8State extends State<LineChartSample8> {
             );
           }).toList();
         },
-        touchTooltipData: const LineTouchTooltipData(
-          tooltipBgColor: AppColors.contentColorBlue,
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipColor: (touchedSpot) => AppColors.contentColorBlue,
         ),
       ),
       borderData: FlBorderData(

--- a/example/lib/presentation/samples/line/line_chart_sample9.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample9.dart
@@ -59,7 +59,7 @@ class LineChartSample9 extends StatelessWidget {
                 lineTouchData: LineTouchData(
                   touchTooltipData: LineTouchTooltipData(
                     maxContentWidth: 100,
-                    tooltipBgColor: Colors.black,
+                    getTooltipColor: (touchedSpots) => Colors.black,
                     getTooltipItems: (touchedSpots) {
                       return touchedSpots.map((LineBarSpot touchedSpot) {
                         final textStyle = TextStyle(

--- a/example/lib/presentation/samples/line/line_chart_sample9.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample9.dart
@@ -59,7 +59,7 @@ class LineChartSample9 extends StatelessWidget {
                 lineTouchData: LineTouchData(
                   touchTooltipData: LineTouchTooltipData(
                     maxContentWidth: 100,
-                    getTooltipColor: (touchedSpots) => Colors.black,
+                    getTooltipColor: (touchedSpot) => Colors.black,
                     getTooltipItems: (touchedSpots) {
                       return touchedSpots.map((LineBarSpot touchedSpot) {
                         final textStyle = TextStyle(

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -121,7 +121,6 @@ class _ScatterChartSample2State extends State {
                   : SystemMouseCursors.click;
             },
             touchTooltipData: ScatterTouchTooltipData(
-              //   tooltipBgColor: Colors.black,
               getTooltipColor: (ScatterSpot touchedBarSpot) {
                 Color bgColor;
 

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -121,10 +121,6 @@ class _ScatterChartSample2State extends State {
                   : SystemMouseCursors.click;
             },
             touchTooltipData: ScatterTouchTooltipData(
-<<<<<<< HEAD
-=======
-              //   tooltipBgColor: Colors.black,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
               getTooltipColor: (ScatterSpot touchedBarSpot) {
                 Color bgColor;
 

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -121,6 +121,10 @@ class _ScatterChartSample2State extends State {
                   : SystemMouseCursors.click;
             },
             touchTooltipData: ScatterTouchTooltipData(
+<<<<<<< HEAD
+=======
+              //   tooltipBgColor: Colors.black,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
               getTooltipColor: (ScatterSpot touchedBarSpot) {
                 Color bgColor = switch ((
                   touchedBarSpot.x.toInt(),

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -121,6 +121,10 @@ class _ScatterChartSample2State extends State {
                   : SystemMouseCursors.click;
             },
             touchTooltipData: ScatterTouchTooltipData(
+<<<<<<< HEAD
+=======
+              //   tooltipBgColor: Colors.black,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
               getTooltipColor: (ScatterSpot touchedBarSpot) {
                 Color bgColor;
 

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -122,36 +122,20 @@ class _ScatterChartSample2State extends State {
             },
             touchTooltipData: ScatterTouchTooltipData(
               getTooltipColor: (ScatterSpot touchedBarSpot) {
-                Color bgColor;
-
-                switch ((touchedBarSpot.x.toInt(), touchedBarSpot.y.toInt())) {
-                  case (4, 4):
-                    bgColor = AppColors.contentColorPurple.withAlpha(100);
-                    break;
-                  case (2, 5):
-                    bgColor = AppColors.contentColorYellow.withAlpha(100);
-                    break;
-                  case (4, 5):
-                    bgColor = AppColors.contentColorBlue.withAlpha(100);
-                    break;
-                  case (8, 6):
-                    bgColor = AppColors.contentColorOrange.withAlpha(100);
-                    break;
-                  case (5, 7):
-                    bgColor = AppColors.contentColorPink.withAlpha(100);
-                    break;
-                  case (7, 2):
-                    bgColor = AppColors.contentColorRed.withAlpha(100);
-                    break;
-                  case (3, 2):
-                    bgColor = AppColors.contentColorPurple.withAlpha(150);
-                    break;
-                  case (2, 8):
-                    bgColor = AppColors.contentColorYellow.withAlpha(100);
-                    break;
-                  default:
-                    throw Error();
-                }
+                Color bgColor = switch ((
+                  touchedBarSpot.x.toInt(),
+                  touchedBarSpot.y.toInt()
+                )) {
+                  (4, 4) => AppColors.contentColorPurple.withAlpha(100),
+                  (2, 5) => AppColors.contentColorYellow.withAlpha(100),
+                  (4, 5) => AppColors.contentColorBlue.withAlpha(100),
+                  (8, 6) => AppColors.contentColorOrange.withAlpha(100),
+                  (5, 7) => AppColors.contentColorPink.withAlpha(100),
+                  (7, 2) => AppColors.contentColorRed.withAlpha(100),
+                  (3, 2) => AppColors.contentColorPurple.withAlpha(150),
+                  (2, 8) => AppColors.contentColorYellow.withAlpha(100),
+                  _ => throw Error(),
+                };
                 return bgColor;
               },
               getTooltipItems: (ScatterSpot touchedBarSpot) {

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -121,7 +121,40 @@ class _ScatterChartSample2State extends State {
                   : SystemMouseCursors.click;
             },
             touchTooltipData: ScatterTouchTooltipData(
-              tooltipBgColor: Colors.black,
+              //   tooltipBgColor: Colors.black,
+              getTooltipColor: (ScatterSpot touchedBarSpot) {
+                Color bgColor;
+
+                switch ((touchedBarSpot.x.toInt(), touchedBarSpot.y.toInt())) {
+                  case (4, 4):
+                    bgColor = AppColors.contentColorPurple.withAlpha(100);
+                    break;
+                  case (2, 5):
+                    bgColor = AppColors.contentColorYellow.withAlpha(100);
+                    break;
+                  case (4, 5):
+                    bgColor = AppColors.contentColorBlue.withAlpha(100);
+                    break;
+                  case (8, 6):
+                    bgColor = AppColors.contentColorOrange.withAlpha(100);
+                    break;
+                  case (5, 7):
+                    bgColor = AppColors.contentColorPink.withAlpha(100);
+                    break;
+                  case (7, 2):
+                    bgColor = AppColors.contentColorRed.withAlpha(100);
+                    break;
+                  case (3, 2):
+                    bgColor = AppColors.contentColorPurple.withAlpha(150);
+                    break;
+                  case (2, 8):
+                    bgColor = AppColors.contentColorYellow.withAlpha(100);
+                    break;
+                  default:
+                    throw Error();
+                }
+                return bgColor;
+              },
               getTooltipItems: (ScatterSpot touchedBarSpot) {
                 return ScatterTooltipItem(
                   'X: ',

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -121,10 +121,6 @@ class _ScatterChartSample2State extends State {
                   : SystemMouseCursors.click;
             },
             touchTooltipData: ScatterTouchTooltipData(
-<<<<<<< HEAD
-=======
-              //   tooltipBgColor: Colors.black,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
               getTooltipColor: (ScatterSpot touchedBarSpot) {
                 Color bgColor = switch ((
                   touchedBarSpot.x.toInt(),

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -765,7 +765,6 @@ class BarTouchTooltipData with EquatableMixin {
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        // tooltipBgColor,
         tooltipRoundedRadius,
         tooltipPadding,
         tooltipMargin,
@@ -777,6 +776,7 @@ class BarTouchTooltipData with EquatableMixin {
         fitInsideVertically,
         rotateAngle,
         tooltipBorder,
+        getTooltipColor,
       ];
 }
 

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -681,7 +681,7 @@ class BarTouchTooltipData with EquatableMixin {
   /// if [BarTouchData.handleBuiltInTouches] is true,
   /// [BarChart] shows a tooltip popup on top of rods automatically when touch happens,
   /// otherwise you can show it manually using [BarChartGroupData.showingTooltipIndicators].
-  /// Tooltip shows on top of rods, with [tooltipBgColor] as a background color,
+  /// Tooltip shows on top of rods, with [getTooltipColor] as a background color,
   /// and you can set corner radius using [tooltipRoundedRadius].
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding],
   /// or If you want to have a bottom margin, set [tooltipMargin].
@@ -692,7 +692,6 @@ class BarTouchTooltipData with EquatableMixin {
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   BarTouchTooltipData({
-    Color? tooltipBgColor,
     double? tooltipRoundedRadius,
     EdgeInsets? tooltipPadding,
     double? tooltipMargin,
@@ -706,8 +705,7 @@ class BarTouchTooltipData with EquatableMixin {
     TooltipDirection? direction,
     double? rotateAngle,
     BorderSide? tooltipBorder,
-  })  : tooltipBgColor = tooltipBgColor ?? Colors.blueGrey.darken(15),
-        tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
+  })  : tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         tooltipMargin = tooltipMargin ?? 16,
@@ -717,17 +715,13 @@ class BarTouchTooltipData with EquatableMixin {
         maxContentWidth = maxContentWidth ?? 120,
         getTooltipItem = getTooltipItem ?? defaultBarTooltipItem,
         getTooltipColor = getTooltipColor ??
-            ((BarChartGroupData? group) =>
-                tooltipBgColor ?? Colors.blueGrey.darken(15)),
+            ((BarChartGroupData? group) => Colors.blueGrey.darken(15)),
         fitInsideHorizontally = fitInsideHorizontally ?? false,
         fitInsideVertically = fitInsideVertically ?? false,
         direction = direction ?? TooltipDirection.auto,
         rotateAngle = rotateAngle ?? 0.0,
         tooltipBorder = tooltipBorder ?? BorderSide.none,
         super();
-
-  /// The tooltip background color.
-  final Color tooltipBgColor;
 
   /// Sets a rounded radius for the tooltip.
   final double tooltipRoundedRadius;
@@ -771,7 +765,7 @@ class BarTouchTooltipData with EquatableMixin {
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        tooltipBgColor,
+        // tooltipBgColor,
         tooltipRoundedRadius,
         tooltipPadding,
         tooltipMargin,

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -714,8 +714,7 @@ class BarTouchTooltipData with EquatableMixin {
         tooltipHorizontalOffset = tooltipHorizontalOffset ?? 0,
         maxContentWidth = maxContentWidth ?? 120,
         getTooltipItem = getTooltipItem ?? defaultBarTooltipItem,
-        getTooltipColor = getTooltipColor ??
-            ((BarChartGroupData? group) => Colors.blueGrey.darken(15)),
+        getTooltipColor = getTooltipColor ?? defaultBarTooltipColor,
         fitInsideHorizontally = fitInsideHorizontally ?? false,
         fitInsideVertically = fitInsideVertically ?? false,
         direction = direction ?? TooltipDirection.auto,
@@ -854,6 +853,11 @@ class BarTooltipItem with EquatableMixin {
 typedef GetBarTooltipColor = Color Function(
   BarChartGroupData group,
 );
+
+/// Default implementation for [BarTouchTooltipData.getTooltipColor].
+Color defaultBarTooltipColor(BarChartGroupData group) {
+  return Colors.blueGrey.darken(15);
+}
 
 /// Holds information about touch response in the [BarChart].
 ///

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -750,9 +750,6 @@ class BarTouchTooltipData with EquatableMixin {
   /// Retrieves data for showing content inside the tooltip.
   final GetBarTooltipItem getTooltipItem;
 
-  /// Retrieves data for setting background color of the tooltip.
-  final GetBarTooltipColor getTooltipColor;
-
   /// Forces the tooltip to shift horizontally inside the chart, if overflow happens.
   final bool fitInsideHorizontally;
 
@@ -767,6 +764,9 @@ class BarTouchTooltipData with EquatableMixin {
 
   /// The tooltip border color.
   final BorderSide tooltipBorder;
+
+  /// Retrieves data for setting background color of the tooltip.
+  final GetBarTooltipColor getTooltipColor;
 
   /// Used for equality check, see [EquatableMixin].
   @override
@@ -796,15 +796,6 @@ typedef GetBarTooltipItem = BarTooltipItem? Function(
   int groupIndex,
   BarChartRodData rod,
   int rodIndex,
-);
-
-//// Provides a [Color] to show different background color for each rod
-///
-/// You can override [BarTouchTooltipData.getTooltipColor], it gives you
-/// [group] that touch happened on, then you should and pass your custom [Color] to set background color
-/// of tooltip popup.
-typedef GetBarTooltipColor = Color Function(
-  BarChartGroupData group,
 );
 
 /// Default implementation for [BarTouchTooltipData.getTooltipItem].
@@ -860,6 +851,15 @@ class BarTooltipItem with EquatableMixin {
         children,
       ];
 }
+
+//// Provides a [Color] to show different background color for each rod
+///
+/// You can override [BarTouchTooltipData.getTooltipColor], it gives you
+/// [group] that touch happened on, then you should and pass your custom [Color] to set background color
+/// of tooltip popup.
+typedef GetBarTooltipColor = Color Function(
+  BarChartGroupData group,
+);
 
 /// Holds information about touch response in the [BarChart].
 ///

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -743,6 +743,9 @@ class BarTouchTooltipData with EquatableMixin {
   /// Retrieves data for showing content inside the tooltip.
   final GetBarTooltipItem getTooltipItem;
 
+  /// Retrieves data for setting background color of the tooltip.
+  final GetBarTooltipColor getTooltipColor;
+
   /// Forces the tooltip to shift horizontally inside the chart, if overflow happens.
   final bool fitInsideHorizontally;
 
@@ -789,6 +792,15 @@ typedef GetBarTooltipItem = BarTooltipItem? Function(
   int groupIndex,
   BarChartRodData rod,
   int rodIndex,
+);
+
+//// Provides a [Color] to show different background color for each rod
+///
+/// You can override [BarTouchTooltipData.getTooltipColor], it gives you
+/// [group] that touch happened on, then you should and pass your custom [Color] to set background color
+/// of tooltip popup.
+typedef GetBarTooltipColor = Color Function(
+  BarChartGroupData group,
 );
 
 /// Default implementation for [BarTouchTooltipData.getTooltipItem].

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -700,6 +700,7 @@ class BarTouchTooltipData with EquatableMixin {
     double? tooltipHorizontalOffset,
     double? maxContentWidth,
     GetBarTooltipItem? getTooltipItem,
+    GetBarTooltipColor? getTooltipColor,
     bool? fitInsideHorizontally,
     bool? fitInsideVertically,
     TooltipDirection? direction,
@@ -715,6 +716,9 @@ class BarTouchTooltipData with EquatableMixin {
         tooltipHorizontalOffset = tooltipHorizontalOffset ?? 0,
         maxContentWidth = maxContentWidth ?? 120,
         getTooltipItem = getTooltipItem ?? defaultBarTooltipItem,
+        getTooltipColor = getTooltipColor ??
+            ((BarChartGroupData? group) =>
+                tooltipBgColor ?? Colors.blueGrey.darken(15)),
         fitInsideHorizontally = fitInsideHorizontally ?? false,
         fitInsideVertically = fitInsideVertically ?? false,
         direction = direction ?? TooltipDirection.auto,
@@ -745,6 +749,9 @@ class BarTouchTooltipData with EquatableMixin {
 
   /// Retrieves data for showing content inside the tooltip.
   final GetBarTooltipItem getTooltipItem;
+
+  /// Retrieves data for setting background color of the tooltip.
+  final GetBarTooltipColor getTooltipColor;
 
   /// Forces the tooltip to shift horizontally inside the chart, if overflow happens.
   final bool fitInsideHorizontally;
@@ -789,6 +796,15 @@ typedef GetBarTooltipItem = BarTooltipItem? Function(
   int groupIndex,
   BarChartRodData rod,
   int rodIndex,
+);
+
+//// Provides a [Color] to show different background color for each rod
+///
+/// You can override [BarTouchTooltipData.getTooltipColor], it gives you
+/// [group] that touch happened on, then you should and pass your custom [Color] to set background color
+/// of tooltip popup.
+typedef GetBarTooltipColor = Color Function(
+  BarChartGroupData group,
 );
 
 /// Default implementation for [BarTouchTooltipData.getTooltipItem].

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -743,9 +743,6 @@ class BarTouchTooltipData with EquatableMixin {
   /// Retrieves data for showing content inside the tooltip.
   final GetBarTooltipItem getTooltipItem;
 
-  /// Retrieves data for setting background color of the tooltip.
-  final GetBarTooltipColor getTooltipColor;
-
   /// Forces the tooltip to shift horizontally inside the chart, if overflow happens.
   final bool fitInsideHorizontally;
 
@@ -792,15 +789,6 @@ typedef GetBarTooltipItem = BarTooltipItem? Function(
   int groupIndex,
   BarChartRodData rod,
   int rodIndex,
-);
-
-//// Provides a [Color] to show different background color for each rod
-///
-/// You can override [BarTouchTooltipData.getTooltipColor], it gives you
-/// [group] that touch happened on, then you should and pass your custom [Color] to set background color
-/// of tooltip popup.
-typedef GetBarTooltipColor = Color Function(
-  BarChartGroupData group,
 );
 
 /// Default implementation for [BarTouchTooltipData.getTooltipItem].

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -463,7 +463,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+    _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnBarGroup);
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -463,6 +463,9 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
+    // _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+
+    /// set tooltip's background color for each rod
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnBarGroup);
 
     final rotateAngle = tooltipData.rotateAngle;

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -463,9 +463,6 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    // _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
-
-    /// set tooltip's background color for each rod
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnBarGroup);
 
     final rotateAngle = tooltipData.rotateAngle;

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -463,6 +463,8 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
+
+    /// set tooltip's background color for each rod
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnBarGroup);
 
     final rotateAngle = tooltipData.rotateAngle;

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1338,8 +1338,8 @@ List<LineTooltipItem> defaultLineTooltipItem(List<LineBarSpot> touchedSpots) {
 
 //// Provides a [Color] to show different background color for each touched spot
 ///
-/// You can override [LineTouchTooltipData.getTooltipColors], it gives you
-/// [touchedSpots] list that touch happened on, then you should and pass your custom [Color] list
+/// You can override [LineTouchTooltipData.getTooltipColor], it gives you
+/// [touchedSpot] object that touch happened on, then you should and pass your custom [Color] list
 /// (length should be equal to the [touchedSpots.length]), to set background color
 /// of tooltip popup.
 typedef GetLineTooltipColor = Color Function(

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1246,6 +1246,7 @@ class LineTouchTooltipData with EquatableMixin {
     this.tooltipHorizontalOffset = 0,
     this.maxContentWidth = 120,
     this.getTooltipItems = defaultLineTooltipItem,
+    this.getTooltipColor = defaultLineTooltipColor,
     this.fitInsideHorizontally = false,
     this.fitInsideVertically = false,
     this.showOnTopOfTheChartBoxArea = false,
@@ -1292,6 +1293,9 @@ class LineTouchTooltipData with EquatableMixin {
   /// The tooltip border color.
   final BorderSide tooltipBorder;
 
+  // /// Retrieves data for setting background color of the tooltip.
+  final GetLineTooltipColor getTooltipColor;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
@@ -1308,6 +1312,7 @@ class LineTouchTooltipData with EquatableMixin {
         showOnTopOfTheChartBoxArea,
         rotateAngle,
         tooltipBorder,
+        getTooltipColor,
       ];
 }
 
@@ -1334,6 +1339,21 @@ List<LineTooltipItem> defaultLineTooltipItem(List<LineBarSpot> touchedSpots) {
     );
     return LineTooltipItem(touchedSpot.y.toString(), textStyle);
   }).toList();
+}
+
+//// Provides a [Color] to show different background color for each touched spot
+///
+/// You can override [LineTouchTooltipData.getTooltipColors], it gives you
+/// [touchedSpots] list that touch happened on, then you should and pass your custom [Color] list
+/// (length should be equal to the [touchedSpots.length]), to set background color
+/// of tooltip popup.
+typedef GetLineTooltipColor = Color Function(
+  LineBarSpot touchedSpot,
+);
+
+/// Default implementation for [LineTouchTooltipData.getTooltipItems].
+Color defaultLineTooltipColor(LineBarSpot touchedSpots) {
+  return const Color.fromRGBO(96, 125, 139, 1);
 }
 
 /// Represent a targeted spot inside a line bar.

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1348,7 +1348,7 @@ typedef GetLineTooltipColor = Color Function(
 
 /// Default implementation for [LineTouchTooltipData.getTooltipItems].
 Color defaultLineTooltipColor(LineBarSpot touchedSpots) {
-  return const Color.fromRGBO(96, 125, 139, 1);
+  return Colors.blueGrey.darken(15);
 }
 
 /// Represent a targeted spot inside a line bar.

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1226,7 +1226,7 @@ class LineTouchTooltipData with EquatableMixin {
   /// if [LineTouchData.handleBuiltInTouches] is true,
   /// [LineChart] shows a tooltip popup on top of spots automatically when touch happens,
   /// otherwise you can show it manually using [LineChartData.showingTooltipIndicators].
-  /// Tooltip shows on top of spots, with [tooltipBgColor] as a background color,
+  /// Tooltip shows on top of spots, with [getTooltipColor] as a background color,
   /// and you can set corner radius using [tooltipRoundedRadius].
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding],
   /// or If you want to have a bottom margin, set [tooltipMargin].
@@ -1237,7 +1237,6 @@ class LineTouchTooltipData with EquatableMixin {
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   const LineTouchTooltipData({
-    this.tooltipBgColor = const Color.fromRGBO(96, 125, 139, 1),
     this.tooltipRoundedRadius = 4,
     this.tooltipPadding =
         const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -1253,9 +1252,6 @@ class LineTouchTooltipData with EquatableMixin {
     this.rotateAngle = 0.0,
     this.tooltipBorder = BorderSide.none,
   });
-
-  /// The tooltip background color.
-  final Color tooltipBgColor;
 
   /// Sets a rounded radius for the tooltip.
   final double tooltipRoundedRadius;
@@ -1299,7 +1295,6 @@ class LineTouchTooltipData with EquatableMixin {
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        tooltipBgColor,
         tooltipRoundedRadius,
         tooltipPadding,
         tooltipMargin,

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1346,8 +1346,8 @@ typedef GetLineTooltipColor = Color Function(
   LineBarSpot touchedSpot,
 );
 
-/// Default implementation for [LineTouchTooltipData.getTooltipItems].
-Color defaultLineTooltipColor(LineBarSpot touchedSpots) {
+/// Default implementation for [LineTouchTooltipData.getTooltipColor].
+Color defaultLineTooltipColor(LineBarSpot touchedSpot) {
   return Colors.blueGrey.darken(15);
 }
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -4,7 +4,6 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_extensions.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_painter.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
-import 'package:fl_chart/src/chart/base/line.dart';
 import 'package:fl_chart/src/extensions/paint_extension.dart';
 import 'package:fl_chart/src/extensions/path_extension.dart';
 import 'package:fl_chart/src/extensions/text_align_extension.dart';

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1120,8 +1120,15 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    _bgTouchTooltipPaint.color =
-        tooltipData.getTooltipColor(showOnSpot as LineBarSpot);
+
+    var topSpot = showingTooltipSpots.showingSpots[0];
+    for (final barSpot in showingTooltipSpots.showingSpots) {
+      if (barSpot.y > topSpot.y) {
+        topSpot = barSpot;
+      }
+    }
+
+    _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(topSpot);
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_extensions.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_painter.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
+import 'package:fl_chart/src/chart/base/line.dart';
 import 'package:fl_chart/src/extensions/paint_extension.dart';
 import 'package:fl_chart/src/extensions/path_extension.dart';
 import 'package:fl_chart/src/extensions/text_align_extension.dart';
@@ -1120,7 +1121,8 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+    _bgTouchTooltipPaint.color =
+        tooltipData.getTooltipColor(showOnSpot as LineBarSpot);
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -4,6 +4,7 @@ import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_extensions.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_painter.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
+import 'package:fl_chart/src/chart/base/line.dart';
 import 'package:fl_chart/src/extensions/paint_extension.dart';
 import 'package:fl_chart/src/extensions/path_extension.dart';
 import 'package:fl_chart/src/extensions/text_align_extension.dart';

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -385,7 +385,7 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// if [ScatterTouchData.handleBuiltInTouches] is true,
   /// [ScatterChart] shows a tooltip popup on top of spots automatically when touch happens,
   /// otherwise you can show it manually using [ScatterChartData.showingTooltipIndicators].
-  /// Tooltip shows on top of spots, with [tooltipBgColor] as a background color,
+  /// Tooltip shows on top of spots, with [getTooltipColor] as a background color,
   /// and you can set corner radius using [tooltipRoundedRadius].
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding].
   /// Content of the tooltip will provide using [getTooltipItems] callback, you can override it
@@ -395,7 +395,6 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   ScatterTouchTooltipData({
-    Color? tooltipBgColor,
     double? tooltipRoundedRadius,
     EdgeInsets? tooltipPadding,
     FLHorizontalAlignment? tooltipHorizontalAlignment,
@@ -406,8 +405,8 @@ class ScatterTouchTooltipData with EquatableMixin {
     bool? fitInsideVertically,
     double? rotateAngle,
     BorderSide? tooltipBorder,
-  })  : tooltipBgColor = tooltipBgColor ?? Colors.blueGrey.darken(15),
-        tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
+    GetScatterTooltipColor? getTooltipColor,
+  })  : tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         tooltipHorizontalAlignment =
@@ -419,10 +418,8 @@ class ScatterTouchTooltipData with EquatableMixin {
         fitInsideVertically = fitInsideVertically ?? false,
         rotateAngle = rotateAngle ?? 0.0,
         tooltipBorder = tooltipBorder ?? BorderSide.none,
+        getTooltipColor = getTooltipColor ?? defaultScatterTooltipColor,
         super();
-
-  /// The tooltip background color.
-  final Color tooltipBgColor;
 
   /// Sets a rounded radius for the tooltip.
   final double tooltipRoundedRadius;
@@ -460,7 +457,6 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        tooltipBgColor,
         tooltipRoundedRadius,
         tooltipPadding,
         tooltipHorizontalAlignment,
@@ -477,7 +473,6 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// Copies current [ScatterTouchTooltipData] to a new [ScatterTouchTooltipData],
   /// and replaces provided values.
   ScatterTouchTooltipData copyWith({
-    Color? tooltipBgColor,
     double? tooltipRoundedRadius,
     EdgeInsets? tooltipPadding,
     FLHorizontalAlignment? tooltipHorizontalAlignment,
@@ -488,9 +483,9 @@ class ScatterTouchTooltipData with EquatableMixin {
     bool? fitInsideVertically,
     double? rotateAngle,
     BorderSide? tooltipBorder,
+    GetScatterTooltipColor? getTooltipColor,
   }) {
     return ScatterTouchTooltipData(
-      tooltipBgColor: tooltipBgColor ?? this.tooltipBgColor,
       tooltipRoundedRadius: tooltipRoundedRadius ?? this.tooltipRoundedRadius,
       tooltipPadding: tooltipPadding ?? this.tooltipPadding,
       tooltipHorizontalAlignment:
@@ -538,12 +533,12 @@ ScatterTooltipItem? defaultScatterTooltipItem(ScatterSpot touchedSpot) {
 /// [touchedSpot] that touch happened on,
 /// then you should and pass your custom [Color]
 /// to show it inside the tooltip popup.
-typedef GetScatterTooltipColor = Color? Function(
+typedef GetScatterTooltipColor = Color Function(
   ScatterSpot touchedSpot,
 );
 
 /// Default implementation for [ScatterTouchTooltipData.getTooltipItems].
-Color? defaultScatterTooltipColor(ScatterSpot touchedSpot) {
+Color defaultScatterTooltipColor(ScatterSpot touchedSpot) {
   return Colors.blueGrey.darken(15);
 }
 

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -454,6 +454,9 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// The tooltip border color.
   final BorderSide tooltipBorder;
 
+  /// Retrieves data for showing content inside the tooltip.
+  final GetScatterTooltipColor getTooltipColor;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
@@ -468,6 +471,7 @@ class ScatterTouchTooltipData with EquatableMixin {
         fitInsideVertically,
         rotateAngle,
         tooltipBorder,
+        getTooltipColor,
       ];
 
   /// Copies current [ScatterTouchTooltipData] to a new [ScatterTouchTooltipData],
@@ -500,6 +504,7 @@ class ScatterTouchTooltipData with EquatableMixin {
       fitInsideVertically: fitInsideVertically ?? this.fitInsideVertically,
       rotateAngle: rotateAngle ?? this.rotateAngle,
       tooltipBorder: tooltipBorder ?? this.tooltipBorder,
+      getTooltipColor: getTooltipColor ?? this.getTooltipColor,
     );
   }
 }
@@ -525,6 +530,21 @@ ScatterTooltipItem? defaultScatterTooltipItem(ScatterSpot touchedSpot) {
     '${touchedSpot.radius.toInt()}',
     textStyle: textStyle,
   );
+}
+
+/// Provides a [Color] to show different background color inside the [ScatterTouchTooltipData].
+///
+/// You can override [ScatterTouchTooltipData.getTooltipColor], it gives you
+/// [touchedSpot] that touch happened on,
+/// then you should and pass your custom [Color]
+/// to show it inside the tooltip popup.
+typedef GetScatterTooltipColor = Color? Function(
+  ScatterSpot touchedSpot,
+);
+
+/// Default implementation for [ScatterTouchTooltipData.getTooltipItems].
+Color? defaultScatterTooltipColor(ScatterSpot touchedSpot) {
+  return Colors.blueGrey.darken(15);
 }
 
 /// Holds data of showing each item in the tooltip popup.

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -320,7 +320,8 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+    // _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+    _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnSpot);
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -320,7 +320,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    // _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnSpot);
 
     final rotateAngle = tooltipData.rotateAngle;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A highly customizable Flutter chart library that supports Line Chart, Bar Chart, Pie Chart, Scatter Chart, and Radar Chart.
-version: 0.63.0
+version: 0.64.0
 homepage: https://flchart.dev/
 repository: https://github.com/imaNNeo/fl_chart
 issue_tracker: https://github.com/imaNNeo/fl_chart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A highly customizable Flutter chart library that supports Line Chart, Bar Chart, Pie Chart, Scatter Chart, and Radar Chart.
-version: 0.64.0
+version: 0.63.0
 homepage: https://flchart.dev/
 repository: https://github.com/imaNNeo/fl_chart
 issue_tracker: https://github.com/imaNNeo/fl_chart/issues

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -94,7 +94,6 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
 ### BarTouchTooltipData
  |PropName|Description|default value|
  |:-------|:----------|:------------|
- |tooltipBgColor|background color of the tooltip bubble|Colors.white|
  |tooltipBorder|border of the tooltip bubble|BorderSide.none|
  |tooltipRoundedRadius|background corner radius of the tooltip bubble|4|
  |tooltipPadding|padding of the tooltip|EdgeInsets.symmetric(horizontal: 16, vertical: 8)|

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -106,6 +106,7 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |direction| Controls showing tooltip on top or bottom, default is auto.| auto|
+ |getTooltipColor|a callback that retrieves the Color for each rod separately from the given [BarChartGroupData](#BarChartGroupData) to set the background color of the tooltip bubble|Colors.white| 
 
 ### BarTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -105,7 +105,7 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |direction| Controls showing tooltip on top or bottom, default is auto.| auto|
- |getTooltipColor|a callback that retrieves the Color for each rod separately from the given [BarChartGroupData](#BarChartGroupData) to set the background color of the tooltip bubble|Colors.white| 
+ |getTooltipColor|a callback that retrieves the Color for each rod separately from the given [BarChartGroupData](#BarChartGroupData) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
 
 ### BarTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/handle_touches.md
+++ b/repo_files/documentations/handle_touches.md
@@ -22,7 +22,7 @@ LineChart(
   LineChartData(
     lineTouchData: LineTouchData(
       touchTooltipData: TouchTooltipData (
-        tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
+        getTooltipColor: (touchedSpot) => Colors.blueGrey.withOpacity(0.8),
          .
          .
          .

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -130,7 +130,7 @@ When you change the chart's state, it animates to the new state internally (usin
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |showOnTopOfTheChartBoxArea| forces the tooltip container to top of the line| false|
- |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.white| 
+ |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
 
 ### LineTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -130,7 +130,11 @@ When you change the chart's state, it animates to the new state internally (usin
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |showOnTopOfTheChartBoxArea| forces the tooltip container to top of the line| false|
+<<<<<<< HEAD
  |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
+=======
+ |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.white| 
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ### LineTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -119,7 +119,6 @@ When you change the chart's state, it animates to the new state internally (usin
 ### LineTouchTooltipData
  |PropName|Description|default value|
  |:-------|:----------|:------------|
- |tooltipBgColor|background color of the tooltip bubble|Colors.white|
  |tooltipBorder|border of the tooltip bubble|BorderSide.none|
  |tooltipRoundedRadius|background corner radius of the tooltip bubble|4|
  |tooltipPadding|padding of the tooltip|EdgeInsets.symmetric(horizontal: 16, vertical: 8)|
@@ -131,6 +130,7 @@ When you change the chart's state, it animates to the new state internally (usin
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |showOnTopOfTheChartBoxArea| forces the tooltip container to top of the line| false|
+ |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.white| 
 
 ### LineTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -130,11 +130,7 @@ When you change the chart's state, it animates to the new state internally (usin
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |showOnTopOfTheChartBoxArea| forces the tooltip container to top of the line| false|
-<<<<<<< HEAD
  |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
-=======
- |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.white| 
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ### LineTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/scatter_chart.md
+++ b/repo_files/documentations/scatter_chart.md
@@ -58,7 +58,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |getTooltipItems|a callback that retrieve a [ScatterTooltipItem](#ScatterTooltipItem) by the given [ScatterSpot](#ScatterSpot) |defaultScatterTooltipItem|
 |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
 |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
-|getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.white| 
+|getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
 
 ### ScatterTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/scatter_chart.md
+++ b/repo_files/documentations/scatter_chart.md
@@ -49,7 +49,6 @@ When you change the chart's state, it animates to the new state internally (usin
 ### ScatterTouchTooltipData
 |PropName|Description|default value|
 |:-------|:----------|:------------|
-|tooltipBgColor|background color of the tooltip bubble|Colors.white|
 |tooltipBorder|border of the tooltip bubble|BorderSide.none|
 |tooltipRoundedRadius|background corner radius of the tooltip bubble|4|
 |tooltipPadding|padding of the tooltip|EdgeInsets.symmetric(horizontal: 16, vertical: 8)|
@@ -59,6 +58,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |getTooltipItems|a callback that retrieve a [ScatterTooltipItem](#ScatterTooltipItem) by the given [ScatterSpot](#ScatterSpot) |defaultScatterTooltipItem|
 |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
 |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
+|getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.white| 
 
 ### ScatterTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/scatter_chart.md
+++ b/repo_files/documentations/scatter_chart.md
@@ -58,11 +58,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |getTooltipItems|a callback that retrieve a [ScatterTooltipItem](#ScatterTooltipItem) by the given [ScatterSpot](#ScatterSpot) |defaultScatterTooltipItem|
 |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
 |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
-<<<<<<< HEAD
 |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
-=======
-|getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.white| 
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ### ScatterTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/scatter_chart.md
+++ b/repo_files/documentations/scatter_chart.md
@@ -58,7 +58,11 @@ When you change the chart's state, it animates to the new state internally (usin
 |getTooltipItems|a callback that retrieve a [ScatterTooltipItem](#ScatterTooltipItem) by the given [ScatterSpot](#ScatterSpot) |defaultScatterTooltipItem|
 |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
 |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
+<<<<<<< HEAD
 |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
+=======
+|getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.white| 
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
 
 ### ScatterTooltipItem
 |PropName|Description|default value|

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -854,7 +854,7 @@ void main() {
 
       final tooltipData = BarTouchTooltipData(
         tooltipRoundedRadius: 8,
-        tooltipBgColor: const Color(0xf33f33f3),
+        getTooltipColor: (group) => const Color(0xf33f33f3),
         maxContentWidth: 80,
         rotateAngle: 12,
         tooltipBorder: const BorderSide(color: Color(0xf33f33f3), width: 2),
@@ -1046,7 +1046,7 @@ void main() {
 
       final tooltipData = BarTouchTooltipData(
         tooltipRoundedRadius: 8,
-        tooltipBgColor: const Color(0xf33f33f3),
+        getTooltipColor: (group) => const Color(0xf33f33f3),
         maxContentWidth: 80,
         rotateAngle: 12,
         direction: TooltipDirection.bottom,
@@ -1212,7 +1212,7 @@ void main() {
 
       final tooltipData = BarTouchTooltipData(
         tooltipRoundedRadius: 8,
-        tooltipBgColor: const Color(0xf33f33f3),
+        getTooltipColor: (group) => const Color(0xf33f33f3),
         maxContentWidth: 8000,
         rotateAngle: 12,
         fitInsideHorizontally: true,

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2317,7 +2317,11 @@ final ScatterTouchTooltipData scatterTouchTooltipData1 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
+<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
+=======
+  getTooltipColor: (touchedSpots) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2328,7 +2332,11 @@ final ScatterTouchTooltipData scatterTouchTooltipData1Clone =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
+<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
+=======
+  getTooltipColor: (touchedSpots) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2339,7 +2347,11 @@ final ScatterTouchTooltipData scatterTouchTooltipData2 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
+<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
+=======
+  getTooltipColor: (touchedSpots) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2351,7 +2363,11 @@ final ScatterTouchTooltipData scatterTouchTooltipData3 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
+<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
+=======
+  getTooltipColor: (touchedSpots) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2742,7 +2758,11 @@ final BarTouchTooltipData barTouchTooltipData1 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2753,7 +2773,11 @@ final BarTouchTooltipData barTouchTooltipData1Clone = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2764,7 +2788,11 @@ final BarTouchTooltipData barTouchTooltipData2 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2776,7 +2804,11 @@ final BarTouchTooltipData barTouchTooltipData3 = BarTouchTooltipData(
   fitInsideVertically: true,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2788,7 +2820,11 @@ final BarTouchTooltipData barTouchTooltipData4 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: false,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2800,7 +2836,11 @@ final BarTouchTooltipData barTouchTooltipData5 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23.00001,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2813,7 +2853,11 @@ final BarTouchTooltipData barTouchTooltipData6 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipBlueColor,
+=======
+  getTooltipColor: (group) => Colors.blue,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2826,7 +2870,11 @@ final BarTouchTooltipData barTouchTooltipData7 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2838,7 +2886,11 @@ final BarTouchTooltipData barTouchTooltipData8 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2848,7 +2900,11 @@ final BarTouchTooltipData barTouchTooltipData9 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 333,
@@ -2859,7 +2915,11 @@ final BarTouchTooltipData barTouchTooltipData10 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2870,7 +2930,11 @@ final BarTouchTooltipData barTouchTooltipData11 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
+<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
+=======
+  getTooltipColor: (group) => Colors.green,
+>>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2317,11 +2317,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
-=======
-  getTooltipColor: (touchedSpots) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2332,11 +2328,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1Clone =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
-=======
-  getTooltipColor: (touchedSpots) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2347,11 +2339,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData2 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
-=======
-  getTooltipColor: (touchedSpots) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2363,11 +2351,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData3 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-<<<<<<< HEAD
   getTooltipColor: scatterChartGetTooltipGreenColor,
-=======
-  getTooltipColor: (touchedSpots) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2758,11 +2742,7 @@ final BarTouchTooltipData barTouchTooltipData1 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2773,11 +2753,7 @@ final BarTouchTooltipData barTouchTooltipData1Clone = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2788,11 +2764,7 @@ final BarTouchTooltipData barTouchTooltipData2 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2804,11 +2776,7 @@ final BarTouchTooltipData barTouchTooltipData3 = BarTouchTooltipData(
   fitInsideVertically: true,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2820,11 +2788,7 @@ final BarTouchTooltipData barTouchTooltipData4 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: false,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2836,11 +2800,7 @@ final BarTouchTooltipData barTouchTooltipData5 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23.00001,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2853,11 +2813,7 @@ final BarTouchTooltipData barTouchTooltipData6 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipBlueColor,
-=======
-  getTooltipColor: (group) => Colors.blue,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2870,11 +2826,7 @@ final BarTouchTooltipData barTouchTooltipData7 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2886,11 +2838,7 @@ final BarTouchTooltipData barTouchTooltipData8 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2900,11 +2848,7 @@ final BarTouchTooltipData barTouchTooltipData9 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 333,
@@ -2915,11 +2859,7 @@ final BarTouchTooltipData barTouchTooltipData10 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2930,11 +2870,7 @@ final BarTouchTooltipData barTouchTooltipData11 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-<<<<<<< HEAD
   getTooltipColor: getTooltipGreenColor,
-=======
-  getTooltipColor: (group) => Colors.green,
->>>>>>> f501b62a (feat: Remove old property called tooltipBgColor for Bar,Line and Scatter Charts, Added new method called getTooltipColor for which user can provide their own custom implementation to change backgroud color for each tooltip of given chart, Updated sample charts, Updated test cases, Updated bar_chart.md,line_chart.md and scatter_chart.md files for the brief description about new method, Updated version code in pubspec)
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -1162,9 +1162,17 @@ List<LineTooltipItem?> lineChartGetTooltipItems(List<LineBarSpot> list) {
   return list.map((s) => lineTooltipItem1).toList();
 }
 
+Color lineChartGetGreenColor(LineBarSpot touchedSpots) {
+  return Colors.green;
+}
+
+Color lineChartGetRedColor(LineBarSpot touchedSpots) {
+  return Colors.red;
+}
+
 const LineTouchTooltipData lineTouchTooltipData1 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1174,7 +1182,7 @@ const LineTouchTooltipData lineTouchTooltipData1 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData1Clone = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1185,7 +1193,7 @@ const LineTouchTooltipData lineTouchTooltipData1Clone = LineTouchTooltipData(
 
 const LineTouchTooltipData lineTouchTooltipData2 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.red,
+  getTooltipColor: lineChartGetRedColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1195,7 +1203,7 @@ const LineTouchTooltipData lineTouchTooltipData2 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData3 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.2),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1206,7 +1214,7 @@ const LineTouchTooltipData lineTouchTooltipData3 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData4 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 13,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1217,7 +1225,7 @@ const LineTouchTooltipData lineTouchTooltipData4 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData5 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1228,7 +1236,7 @@ const LineTouchTooltipData lineTouchTooltipData5 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData6 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1240,7 +1248,7 @@ const LineTouchTooltipData lineTouchTooltipData6 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData7 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -2262,7 +2270,7 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
       fitInsideHorizontally: true,
       fitInsideVertically: false,
       maxContentWidth: 33,
-      tooltipBgColor: Colors.white,
+      getTooltipColor: (touchedSpots) => Colors.white,
       tooltipPadding: const EdgeInsets.all(23),
       tooltipRoundedRadius: 534,
     ),
@@ -2301,7 +2309,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (touchedSpots) => Colors.green,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2312,7 +2320,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1Clone =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (touchedSpots) => Colors.green,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2323,7 +2331,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData2 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (touchedSpots) => Colors.green,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2335,7 +2343,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData3 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (touchedSpots) => Colors.green,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2714,7 +2722,7 @@ final BarTouchTooltipData barTouchTooltipData1 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2725,7 +2733,7 @@ final BarTouchTooltipData barTouchTooltipData1Clone = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2736,7 +2744,7 @@ final BarTouchTooltipData barTouchTooltipData2 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2748,7 +2756,7 @@ final BarTouchTooltipData barTouchTooltipData3 = BarTouchTooltipData(
   fitInsideVertically: true,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2760,7 +2768,7 @@ final BarTouchTooltipData barTouchTooltipData4 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: false,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2772,7 +2780,7 @@ final BarTouchTooltipData barTouchTooltipData5 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23.00001,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2785,7 +2793,7 @@ final BarTouchTooltipData barTouchTooltipData6 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.blue,
+  getTooltipColor: (group) => Colors.blue,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2798,7 +2806,7 @@ final BarTouchTooltipData barTouchTooltipData7 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2810,7 +2818,7 @@ final BarTouchTooltipData barTouchTooltipData8 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2820,7 +2828,7 @@ final BarTouchTooltipData barTouchTooltipData9 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 333,
@@ -2831,7 +2839,7 @@ final BarTouchTooltipData barTouchTooltipData10 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2842,7 +2850,7 @@ final BarTouchTooltipData barTouchTooltipData11 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: (group) => Colors.green,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -1162,11 +1162,11 @@ List<LineTooltipItem?> lineChartGetTooltipItems(List<LineBarSpot> list) {
   return list.map((s) => lineTooltipItem1).toList();
 }
 
-Color lineChartGetGreenColor(LineBarSpot touchedSpots) {
+Color lineChartGetGreenColor(LineBarSpot touchedSpot) {
   return Colors.green;
 }
 
-Color lineChartGetRedColor(LineBarSpot touchedSpots) {
+Color lineChartGetRedColor(LineBarSpot touchedSpot) {
   return Colors.red;
 }
 
@@ -2278,7 +2278,7 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
       fitInsideHorizontally: true,
       fitInsideVertically: false,
       maxContentWidth: 33,
-      getTooltipColor: (touchedSpots) => Colors.white,
+      getTooltipColor: (touchedSpot) => Colors.white,
       tooltipPadding: const EdgeInsets.all(23),
       tooltipRoundedRadius: 534,
     ),

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2223,6 +2223,14 @@ ScatterTooltipItem? scatterChartGetTooltipItems(ScatterSpot spots) {
   );
 }
 
+Color scatterChartGetTooltipGreenColor(ScatterSpot spots) {
+  return Colors.green; //Color
+}
+
+Color scatterChartGetTooltipRedColor(ScatterSpot spots) {
+  return Colors.red; //Color
+}
+
 final ScatterSpot scatterSpot1 = ScatterSpot(1, 40);
 final ScatterSpot scatterSpot1Clone = ScatterSpot(1, 40);
 final ScatterSpot scatterSpot2 = ScatterSpot(-4, -8);
@@ -2309,7 +2317,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  getTooltipColor: (touchedSpots) => Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2320,7 +2328,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1Clone =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  getTooltipColor: (touchedSpots) => Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2331,7 +2339,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData2 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  getTooltipColor: (touchedSpots) => Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2343,7 +2351,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData3 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  getTooltipColor: (touchedSpots) => Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2717,12 +2725,24 @@ BarTooltipItem getTooltipItem(
   return BarTooltipItem(rod.toY.toString(), textStyle);
 }
 
+Color getTooltipGreenColor(
+  BarChartGroupData group,
+) {
+  return Colors.green;
+}
+
+Color getTooltipBlueColor(
+  BarChartGroupData group,
+) {
+  return Colors.blue;
+}
+
 final BarTouchTooltipData barTouchTooltipData1 = BarTouchTooltipData(
   tooltipRoundedRadius: 12,
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2733,7 +2753,7 @@ final BarTouchTooltipData barTouchTooltipData1Clone = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2744,7 +2764,7 @@ final BarTouchTooltipData barTouchTooltipData2 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2756,7 +2776,7 @@ final BarTouchTooltipData barTouchTooltipData3 = BarTouchTooltipData(
   fitInsideVertically: true,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2768,7 +2788,7 @@ final BarTouchTooltipData barTouchTooltipData4 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: false,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2780,7 +2800,7 @@ final BarTouchTooltipData barTouchTooltipData5 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23.00001,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2793,7 +2813,7 @@ final BarTouchTooltipData barTouchTooltipData6 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.blue,
+  getTooltipColor: getTooltipBlueColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2806,7 +2826,7 @@ final BarTouchTooltipData barTouchTooltipData7 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2818,7 +2838,7 @@ final BarTouchTooltipData barTouchTooltipData8 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2828,7 +2848,7 @@ final BarTouchTooltipData barTouchTooltipData9 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 333,
@@ -2839,7 +2859,7 @@ final BarTouchTooltipData barTouchTooltipData10 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2850,7 +2870,7 @@ final BarTouchTooltipData barTouchTooltipData11 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  getTooltipColor: (group) => Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2257,7 +2257,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        tooltipBgColor: const Color(0x11111111),
+        getTooltipColor: (tochedSpots) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,
@@ -2367,7 +2367,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        tooltipBgColor: const Color(0x11111111),
+        getTooltipColor: (tochedSpots) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,
@@ -2477,7 +2477,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        tooltipBgColor: const Color(0x11111111),
+        getTooltipColor: (tochedSpots) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2257,7 +2257,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        getTooltipColor: (tochedSpots) => const Color(0x11111111),
+        getTooltipColor: (touchedSpot) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,
@@ -2367,7 +2367,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        getTooltipColor: (tochedSpots) => const Color(0x11111111),
+        getTooltipColor: (touchedSpot) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,
@@ -2477,7 +2477,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        getTooltipColor: (tochedSpots) => const Color(0x11111111),
+        getTooltipColor: (touchedSpot) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,

--- a/test/chart/scatter_chart/scatter_chart_data_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_data_test.dart
@@ -362,7 +362,7 @@ void main() {
       final sample = ScatterTouchData(
         touchTooltipData: ScatterTouchTooltipData(
           maxContentWidth: 2,
-          getTooltipColor: (touchedSpots) => Colors.red,
+          getTooltipColor: scatterChartGetTooltipRedColor,
           tooltipPadding: const EdgeInsets.all(11),
         ),
         handleBuiltInTouches: false,
@@ -372,7 +372,7 @@ void main() {
       final sampleClone = ScatterTouchData(
         touchTooltipData: ScatterTouchTooltipData(
           maxContentWidth: 2,
-          getTooltipColor: (touchedSpots) => Colors.red,
+          getTooltipColor: scatterChartGetTooltipRedColor,
           tooltipPadding: const EdgeInsets.all(11),
         ),
         handleBuiltInTouches: false,

--- a/test/chart/scatter_chart/scatter_chart_data_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_data_test.dart
@@ -362,7 +362,7 @@ void main() {
       final sample = ScatterTouchData(
         touchTooltipData: ScatterTouchTooltipData(
           maxContentWidth: 2,
-          tooltipBgColor: Colors.red,
+          getTooltipColor: (touchedSpots) => Colors.red,
           tooltipPadding: const EdgeInsets.all(11),
         ),
         handleBuiltInTouches: false,
@@ -372,7 +372,7 @@ void main() {
       final sampleClone = ScatterTouchData(
         touchTooltipData: ScatterTouchTooltipData(
           maxContentWidth: 2,
-          tooltipBgColor: Colors.red,
+          getTooltipColor: (touchedSpots) => Colors.red,
           tooltipPadding: const EdgeInsets.all(11),
         ),
         handleBuiltInTouches: false,

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -330,7 +330,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            tooltipBgColor: const Color(0xFF00FF00),
+            getTooltipColor: (touchedSpots) => const Color(0xFF00FF00),
             tooltipRoundedRadius: 85,
             tooltipPadding: const EdgeInsets.all(12),
             getTooltipItems: (_) {
@@ -428,7 +428,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            tooltipBgColor: const Color(0xFFFFFF00),
+            getTooltipColor: (touchedSpots) => const Color(0xFFFFFF00),
             tooltipRoundedRadius: 22,
             fitInsideHorizontally: false,
             fitInsideVertically: true,
@@ -531,7 +531,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            tooltipBgColor: const Color(0xFFFFFF00),
+            getTooltipColor: (touchedSpots) => const Color(0xFFFFFF00),
             tooltipRoundedRadius: 22,
             fitInsideHorizontally: false,
             fitInsideVertically: true,

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -330,7 +330,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            getTooltipColor: (touchedSpots) => const Color(0xFF00FF00),
+            getTooltipColor: (touchedSpot) => const Color(0xFF00FF00),
             tooltipRoundedRadius: 85,
             tooltipPadding: const EdgeInsets.all(12),
             getTooltipItems: (_) {
@@ -428,7 +428,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            getTooltipColor: (touchedSpots) => const Color(0xFFFFFF00),
+            getTooltipColor: (touchedSpot) => const Color(0xFFFFFF00),
             tooltipRoundedRadius: 22,
             fitInsideHorizontally: false,
             fitInsideVertically: true,
@@ -531,7 +531,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            getTooltipColor: (touchedSpots) => const Color(0xFFFFFF00),
+            getTooltipColor: (touchedSpot) => const Color(0xFFFFFF00),
             tooltipRoundedRadius: 22,
             fitInsideHorizontally: false,
             fitInsideVertically: true,


### PR DESCRIPTION
**Changes Made:**

In the `bar_chart_data.dart` file:
- Added a new parameter `getTooltipColor` to the constructor of `BarTouchTooltipData`.
- Defined a new type `GetBarTooltipColor`, which is a function that takes a `BarChartGroupData` parameter and returns a `Color`.

In the `bar_chart_painter.dart` file:
- Assigned the tooltip color to the `_bgTouchTooltipPaint.color` property using the `getTooltipColor` function from the `tooltipData` object.

Additionally, the `getTooltipColor` function has been utilized in the `bar_chart_sample1.dart` file within the `feature/dynamic-tooltip-bgcolor` branch.

Please review the changes for this pull request.