### PR TITLE
Fix bar line shadow crash when we have only one (or zero) spot, #1466

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## nextVersion
 * **FEATURE** (by @Dartek12): Added gradient to [FlLine](https://github.com/imaNNeo/fl_chart/blob/master/repo_files/documentations/base_chart.md#FlLine), #1197
+* **BUGFIX** (by @imaNNeo): Fix bar line shadow crash when we have only one (or zero) spot, #1466
 
 ## 0.64.0
 * **BUGFIX** (by @Anas35) Fix Tooltip not displaying when value from BackgroundBarChartRodData is less than zero. #1345.

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -909,6 +909,9 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     if (!barData.show || barData.shadow.color.opacity == 0.0) {
       return;
     }
+    if (barPath.computeMetrics().isEmpty) {
+      return;
+    }
 
     _barPaint
       ..strokeCap = barData.isStrokeCapRound ? StrokeCap.round : StrokeCap.butt


### PR DESCRIPTION
Fixes #1466