### PR TITLE
Remove the changelog section from CONTRIBUTING.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -85,29 +85,6 @@ When you push something in your PR (after approving your PR by one of us), you s
 
 Please make sure that your code is **not decreasing** the coverage.
 
-## Changelog
-We have a file called [CHANGELOG.md](https://github.com/imaNNeo/fl_chart/blob/master/CHANGELOG.md) which contains the history of our versions.
-
-Please check it to understand how it works and how is the convention. Simply new versions added at the top of the CHANGELOG.md file. You can find the [first version (oldest)](https://github.com/imaNNeo/fl_chart/blob/master/CHANGELOG.md#001---released-on-2019-june-4) at the bottom of the file.
-
-When you are done in your PR, it's time to write a changelog for you changes. 
-
-Most of the times, there will be a [newVersion](https://github.com/imaNNeo/fl_chart/blob/master/CHANGELOG.md#newversion) tag at the top of the `CHANGELOG.md` file in the `master` branch. If it doesn't exist, you can write it and write your change below that.
-
-Each change should be started with one of the following prefixes:
-1. **IMPROVEMENT** (When you are improving something, for example improving performance)
-
-2. **BREAKING** (When it breaks something, for example renaming something to something else, or removing something, ...)
-
-3. **BUGFIX** (When you fix a bug or an issue)
-
-4. **FEATURE** (When you are adding a feature to the library, for example allowing user to change the stroke color of something, or when you add a new concept or anything else)
-
-In front of a prefix, you should write about your change. Don't forget to mention the related issues.
-
-If your change has two (or more) prefixes, describe them in separate lines independently.
-
-
 ## Creating a Pull Request
 
 Congratulations! Your code meets all of our guidelines :100:. Now you have to


### PR DESCRIPTION
Remove the changelog section from CONTRIBUTING. Because it is a file which changes by all the users who create a PR, so they get conflict everytime. That's why I decided to handle the CHANGELOG in another way.