### PR TITLE
Update of `swapAnimationDuration` and `swapAnimationCurve` in docs

### DIFF
--- a/repo_files/documentations/handle_animations.md
+++ b/repo_files/documentations/handle_animations.md
@@ -8,12 +8,12 @@ We handle all animations Implicitly, This is power of the [ImplicitlyAnimatedWid
 
 
 ##### Properties
-You can change the [Duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [Curve](https://api.flutter.dev/flutter/animation/Curves-class.html) of animation using `swapAnimationDuration` and `swapAnimationCurve` properties respectively.
+You can change the [Duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [Curve](https://api.flutter.dev/flutter/animation/Curves-class.html) of animation using `duration` and `curve` properties respectively.
 
 ```dart
 LineChart(
-  swapAnimationDuration: Duration(milliseconds: 150),
-  swapAnimationCurve = Curves.linear,
+  duration: Duration(milliseconds: 150),
+  curve = Curves.linear,
   LineChartData(
     isShowingMainData ? sampleData1() : sampleData2(),
   ),
@@ -22,4 +22,4 @@ LineChart(
 
 ##### How to disable
 
-If you want to disable the animations, you can set `Duration.zero` as `swapAnimationDuration`.
+If you want to disable the animations, you can set `Duration.zero` as `duration`.

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -8,13 +8,13 @@ LineChart(
   LineChartData(
     // read about it in the LineChartData section
   ),
-  swapAnimationDuration: Duration(milliseconds: 150), // Optional
-  swapAnimationCurve: Curves.linear, // Optional
+  duration: Duration(milliseconds: 150), // Optional
+  curve: Curves.linear, // Optional
 );
 ```
 
 ### Implicit Animations 
-When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `swapAnimationDuration` and `swapAnimationCurve` properties, respectively.
+When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `duration` and `curve` properties, respectively.
 
 ### LineChartData
 |PropName		|Description	|default value|


### PR DESCRIPTION
Update of `swapAnimationDuration` and `swapAnimationCurve` in markdown files due to current deprecation.