### PR TITLE
Add external touch handler for Pie Chart

### DIFF
--- a/example/lib/presentation/samples/chart_samples.dart
+++ b/example/lib/presentation/samples/chart_samples.dart
@@ -22,6 +22,7 @@ import 'line/line_chart_sample9.dart';
 import 'pie/pie_chart_sample1.dart';
 import 'pie/pie_chart_sample2.dart';
 import 'pie/pie_chart_sample3.dart';
+import 'pie/pie_chart_sample4.dart';
 import 'radar/radar_chart_sample1.dart';
 import 'scatter/scatter_chart_sample1.dart';
 import 'scatter/scatter_chart_sample2.dart';
@@ -54,6 +55,7 @@ class ChartSamples {
       PieChartSample(1, (context) => const PieChartSample1()),
       PieChartSample(2, (context) => const PieChartSample2()),
       PieChartSample(3, (context) => const PieChartSample3()),
+      PieChartSample(4, (context) => const PieChartSample4()),
     ],
     ChartType.scatter: [
       ScatterChartSample(1, (context) => ScatterChartSample1()),

--- a/example/lib/presentation/samples/pie/pie_chart_sample1.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample1.dart
@@ -10,13 +10,11 @@ class PieChartSample1 extends StatefulWidget {
   State<StatefulWidget> createState() => PieChartSample1State();
 }
 
-class PieChartSample1State extends State<PieChartSample1> {
+class PieChartSample1State extends State {
   int touchedIndex = -1;
-  Offset? touchOffset;
 
   @override
   Widget build(BuildContext context) {
-    print('touchedIndex: ${touchedIndex}');
     return AspectRatio(
       aspectRatio: 1.3,
       child: Column(
@@ -71,42 +69,29 @@ class PieChartSample1State extends State<PieChartSample1> {
           Expanded(
             child: AspectRatio(
               aspectRatio: 1,
-              child: MouseRegion(
-                onHover: (event) {
-                  setState(() {
-                    touchOffset = event.localPosition;
-                  });
-                },
-                child: PieChart(
-                  PieChartData(
-                    pieTouchData: PieTouchData(
-                      externalTouchPosition: touchOffset,
-                      externalTouchCallback: (response) {
-                        WidgetsBinding.instance
-                            .addPostFrameCallback((timeStamp) {
-                          if (mounted) {
-                            int newTouchedIndex =
-                                response?.touchedSection?.touchedSectionIndex ??
-                                    -1;
-                            if (newTouchedIndex != touchedIndex) {
-                              setState(() {
-                                touchedIndex = newTouchedIndex;
-                              });
-                            }
-                          }
-                        });
-                        // print(
-                        //     'touchedSectionIndex: ${response?.touchedSection!.touchedSectionIndex}');
-                      },
-                    ),
-                    startDegreeOffset: 180,
-                    borderData: FlBorderData(
-                      show: false,
-                    ),
-                    sectionsSpace: 1,
-                    centerSpaceRadius: 0,
-                    sections: showingSections(),
+              child: PieChart(
+                PieChartData(
+                  pieTouchData: PieTouchData(
+                    touchCallback: (FlTouchEvent event, pieTouchResponse) {
+                      setState(() {
+                        if (!event.isInterestedForInteractions ||
+                            pieTouchResponse == null ||
+                            pieTouchResponse.touchedSection == null) {
+                          touchedIndex = -1;
+                          return;
+                        }
+                        touchedIndex = pieTouchResponse
+                            .touchedSection!.touchedSectionIndex;
+                      });
+                    },
                   ),
+                  startDegreeOffset: 180,
+                  borderData: FlBorderData(
+                    show: false,
+                  ),
+                  sectionsSpace: 1,
+                  centerSpaceRadius: 0,
+                  sections: showingSections(),
                 ),
               ),
             ),

--- a/example/lib/presentation/samples/pie/pie_chart_sample1.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample1.dart
@@ -10,11 +10,13 @@ class PieChartSample1 extends StatefulWidget {
   State<StatefulWidget> createState() => PieChartSample1State();
 }
 
-class PieChartSample1State extends State {
+class PieChartSample1State extends State<PieChartSample1> {
   int touchedIndex = -1;
+  Offset? touchOffset;
 
   @override
   Widget build(BuildContext context) {
+    print('touchedIndex: ${touchedIndex}');
     return AspectRatio(
       aspectRatio: 1.3,
       child: Column(
@@ -69,29 +71,42 @@ class PieChartSample1State extends State {
           Expanded(
             child: AspectRatio(
               aspectRatio: 1,
-              child: PieChart(
-                PieChartData(
-                  pieTouchData: PieTouchData(
-                    touchCallback: (FlTouchEvent event, pieTouchResponse) {
-                      setState(() {
-                        if (!event.isInterestedForInteractions ||
-                            pieTouchResponse == null ||
-                            pieTouchResponse.touchedSection == null) {
-                          touchedIndex = -1;
-                          return;
-                        }
-                        touchedIndex = pieTouchResponse
-                            .touchedSection!.touchedSectionIndex;
-                      });
-                    },
+              child: MouseRegion(
+                onHover: (event) {
+                  setState(() {
+                    touchOffset = event.localPosition;
+                  });
+                },
+                child: PieChart(
+                  PieChartData(
+                    pieTouchData: PieTouchData(
+                      externalTouchPosition: touchOffset,
+                      externalTouchCallback: (response) {
+                        WidgetsBinding.instance
+                            .addPostFrameCallback((timeStamp) {
+                          if (mounted) {
+                            int newTouchedIndex =
+                                response?.touchedSection?.touchedSectionIndex ??
+                                    -1;
+                            if (newTouchedIndex != touchedIndex) {
+                              setState(() {
+                                touchedIndex = newTouchedIndex;
+                              });
+                            }
+                          }
+                        });
+                        // print(
+                        //     'touchedSectionIndex: ${response?.touchedSection!.touchedSectionIndex}');
+                      },
+                    ),
+                    startDegreeOffset: 180,
+                    borderData: FlBorderData(
+                      show: false,
+                    ),
+                    sectionsSpace: 1,
+                    centerSpaceRadius: 0,
+                    sections: showingSections(),
                   ),
-                  startDegreeOffset: 180,
-                  borderData: FlBorderData(
-                    show: false,
-                  ),
-                  sectionsSpace: 1,
-                  centerSpaceRadius: 0,
-                  sections: showingSections(),
                 ),
               ),
             ),

--- a/example/lib/presentation/samples/pie/pie_chart_sample4.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample4.dart
@@ -1,0 +1,282 @@
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
+import 'package:fl_chart_app/presentation/widgets/indicator.dart';
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+class PieChartSample4 extends StatefulWidget {
+  const PieChartSample4({super.key});
+
+  @override
+  State<StatefulWidget> createState() => PieChartSample4State();
+}
+
+class PieChartSample4State extends State {
+  int innerTouchedIndex = -1;
+  int outerTouchedIndex = -1;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1.3,
+      child: Column(
+        children: <Widget>[
+          const SizedBox(
+            height: 28,
+          ),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            children: <Widget>[
+              Indicator(
+                color: AppColors.contentColorBlue,
+                text: 'One',
+                isSquare: false,
+                size:
+                    innerTouchedIndex == 0 || outerTouchedIndex == 0 ? 18 : 16,
+                textColor: innerTouchedIndex == 0 || outerTouchedIndex == 0
+                    ? AppColors.mainTextColor1
+                    : AppColors.mainTextColor3,
+              ),
+              Indicator(
+                color: AppColors.contentColorYellow,
+                text: 'Two',
+                isSquare: false,
+                size:
+                    innerTouchedIndex == 1 || outerTouchedIndex == 1 ? 18 : 16,
+                textColor: innerTouchedIndex == 1 || outerTouchedIndex == 1
+                    ? AppColors.mainTextColor1
+                    : AppColors.mainTextColor3,
+              ),
+              Indicator(
+                color: AppColors.contentColorPink,
+                text: 'Three',
+                isSquare: false,
+                size:
+                    innerTouchedIndex == 2 || outerTouchedIndex == 2 ? 18 : 16,
+                textColor: innerTouchedIndex == 2 || outerTouchedIndex == 2
+                    ? AppColors.mainTextColor1
+                    : AppColors.mainTextColor3,
+              ),
+              Indicator(
+                color: AppColors.contentColorGreen,
+                text: 'Four',
+                isSquare: false,
+                size:
+                    innerTouchedIndex == 3 || outerTouchedIndex == 3 ? 18 : 16,
+                textColor: innerTouchedIndex == 3 || outerTouchedIndex == 3
+                    ? AppColors.mainTextColor1
+                    : AppColors.mainTextColor3,
+              ),
+            ],
+          ),
+          const SizedBox(
+            height: 18,
+          ),
+          Expanded(
+            child: AspectRatio(
+                aspectRatio: 1,
+                child: Stack(
+                  children: [
+                    Positioned.fill(
+                      child: PieChart(
+                        PieChartData(
+                          pieTouchData: PieTouchData(
+                            touchCallback:
+                                (FlTouchEvent event, pieTouchResponse) {
+                              setState(() {
+                                if (!event.isInterestedForInteractions ||
+                                    pieTouchResponse == null ||
+                                    pieTouchResponse.touchedSection == null) {
+                                  innerTouchedIndex = -1;
+                                  return;
+                                }
+                                innerTouchedIndex = pieTouchResponse
+                                    .touchedSection!.touchedSectionIndex;
+                              });
+                            },
+                          ),
+                          startDegreeOffset: 180,
+                          borderData: FlBorderData(
+                            show: false,
+                          ),
+                          sectionsSpace: 1,
+                          centerSpaceRadius: 0,
+                          sections: showingInnerSections(),
+                        ),
+                      ),
+                    ),
+                    Positioned.fill(
+                      child: PieChart(
+                        PieChartData(
+                          pieTouchData: PieTouchData(
+                            touchCallback:
+                                (FlTouchEvent event, pieTouchResponse) {
+                              setState(() {
+                                if (!event.isInterestedForInteractions ||
+                                    pieTouchResponse == null ||
+                                    pieTouchResponse.touchedSection == null) {
+                                  outerTouchedIndex = -1;
+                                  return;
+                                }
+                                outerTouchedIndex = pieTouchResponse
+                                    .touchedSection!.touchedSectionIndex;
+                              });
+                            },
+                          ),
+                          startDegreeOffset: 180,
+                          borderData: FlBorderData(
+                            show: false,
+                          ),
+                          sectionsSpace: 1,
+                          centerSpaceRadius: 50,
+                          sections: showingOuterSections(),
+                        ),
+                      ),
+                    ),
+                  ],
+                )),
+          ),
+        ],
+      ),
+    );
+  }
+
+  List<PieChartSectionData> showingInnerSections() {
+    return List.generate(
+      4,
+      (i) {
+        final isTouched = i == innerTouchedIndex;
+        const color0 = AppColors.contentColorBlue;
+        const color1 = AppColors.contentColorYellow;
+        const color2 = AppColors.contentColorPink;
+        const color3 = AppColors.contentColorGreen;
+
+        switch (i) {
+          case 0:
+            return PieChartSectionData(
+              color: color0,
+              value: 25,
+              title: '',
+              radius: 45,
+              titlePositionPercentageOffset: 0.55,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          case 1:
+            return PieChartSectionData(
+              color: color1,
+              value: 30,
+              title: '',
+              radius: 45,
+              titlePositionPercentageOffset: 0.55,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          case 2:
+            return PieChartSectionData(
+              color: color2,
+              value: 25,
+              title: '',
+              radius: 45,
+              titlePositionPercentageOffset: 0.6,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          case 3:
+            return PieChartSectionData(
+              color: color3,
+              value: 40,
+              title: '',
+              radius: 45,
+              titlePositionPercentageOffset: 0.55,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          default:
+            throw Error();
+        }
+      },
+    );
+  }
+
+  List<PieChartSectionData> showingOuterSections() {
+    return List.generate(
+      4,
+      (i) {
+        final isTouched = i == outerTouchedIndex;
+        const color0 = AppColors.contentColorBlue;
+        const color1 = AppColors.contentColorYellow;
+        const color2 = AppColors.contentColorPink;
+        const color3 = AppColors.contentColorGreen;
+
+        switch (i) {
+          case 0:
+            return PieChartSectionData(
+              color: color0,
+              value: 25,
+              title: '',
+              radius: 30,
+              titlePositionPercentageOffset: 0.55,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          case 1:
+            return PieChartSectionData(
+              color: color1,
+              value: 25,
+              title: '',
+              radius: 15,
+              titlePositionPercentageOffset: 0.55,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          case 2:
+            return PieChartSectionData(
+              color: color2,
+              value: 25,
+              title: '',
+              radius: 10,
+              titlePositionPercentageOffset: 0.6,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          case 3:
+            return PieChartSectionData(
+              color: color3,
+              value: 25,
+              title: '',
+              radius: 20,
+              titlePositionPercentageOffset: 0.55,
+              borderSide: isTouched
+                  ? const BorderSide(
+                      color: AppColors.contentColorWhite, width: 6)
+                  : BorderSide(
+                      color: AppColors.contentColorWhite.withOpacity(0)),
+            );
+          default:
+            throw Error();
+        }
+      },
+    );
+  }
+}

--- a/example/lib/presentation/samples/pie/pie_chart_sample4.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample4.dart
@@ -11,6 +11,7 @@ class PieChartSample4 extends StatefulWidget {
 }
 
 class PieChartSample4State extends State {
+  Offset? hoveredOffset;
   int innerTouchedIndex = -1;
   int outerTouchedIndex = -1;
 
@@ -74,65 +75,74 @@ class PieChartSample4State extends State {
           Expanded(
             child: AspectRatio(
                 aspectRatio: 1,
-                child: Stack(
-                  children: [
-                    Positioned.fill(
-                      child: PieChart(
-                        PieChartData(
-                          pieTouchData: PieTouchData(
-                            touchCallback:
-                                (FlTouchEvent event, pieTouchResponse) {
-                              setState(() {
-                                if (!event.isInterestedForInteractions ||
-                                    pieTouchResponse == null ||
-                                    pieTouchResponse.touchedSection == null) {
-                                  innerTouchedIndex = -1;
-                                  return;
-                                }
-                                innerTouchedIndex = pieTouchResponse
-                                    .touchedSection!.touchedSectionIndex;
-                              });
-                            },
+                child: MouseRegion(
+                  onHover: (event) {
+                    setState(() {
+                      hoveredOffset = event.localPosition;
+                    });
+                  },
+                  child: Stack(
+                    children: [
+                      Positioned.fill(
+                        child: PieChart(
+                          PieChartData(
+                            pieTouchData: PieTouchData(
+                              externalTouchPosition: hoveredOffset,
+                              externalTouchCallback: (pieTouchResponse) {
+                                int? newTouchedIndex = pieTouchResponse
+                                    ?.touchedSection?.touchedSectionIndex;
+                                WidgetsBinding.instance
+                                    .addPostFrameCallback((timeStamp) {
+                                  if (mounted &&
+                                      newTouchedIndex != innerTouchedIndex) {
+                                    setState(() {
+                                      innerTouchedIndex = newTouchedIndex ?? -1;
+                                    });
+                                  }
+                                });
+                              },
+                            ),
+                            startDegreeOffset: 180,
+                            borderData: FlBorderData(
+                              show: false,
+                            ),
+                            sectionsSpace: 1,
+                            centerSpaceRadius: 0,
+                            sections: showingInnerSections(),
                           ),
-                          startDegreeOffset: 180,
-                          borderData: FlBorderData(
-                            show: false,
-                          ),
-                          sectionsSpace: 1,
-                          centerSpaceRadius: 0,
-                          sections: showingInnerSections(),
                         ),
                       ),
-                    ),
-                    Positioned.fill(
-                      child: PieChart(
-                        PieChartData(
-                          pieTouchData: PieTouchData(
-                            touchCallback:
-                                (FlTouchEvent event, pieTouchResponse) {
-                              setState(() {
-                                if (!event.isInterestedForInteractions ||
-                                    pieTouchResponse == null ||
-                                    pieTouchResponse.touchedSection == null) {
-                                  outerTouchedIndex = -1;
-                                  return;
-                                }
-                                outerTouchedIndex = pieTouchResponse
-                                    .touchedSection!.touchedSectionIndex;
-                              });
-                            },
+                      Positioned.fill(
+                        child: PieChart(
+                          PieChartData(
+                            pieTouchData: PieTouchData(
+                              externalTouchPosition: hoveredOffset,
+                              externalTouchCallback: (pieTouchResponse) {
+                                int? newTouchedIndex = pieTouchResponse
+                                    ?.touchedSection?.touchedSectionIndex;
+                                WidgetsBinding.instance
+                                    .addPostFrameCallback((timeStamp) {
+                                  if (mounted &&
+                                      newTouchedIndex != outerTouchedIndex) {
+                                    setState(() {
+                                      outerTouchedIndex = newTouchedIndex ?? -1;
+                                    });
+                                  }
+                                });
+                              },
+                            ),
+                            startDegreeOffset: 180,
+                            borderData: FlBorderData(
+                              show: false,
+                            ),
+                            sectionsSpace: 1,
+                            centerSpaceRadius: 50,
+                            sections: showingOuterSections(),
                           ),
-                          startDegreeOffset: 180,
-                          borderData: FlBorderData(
-                            show: false,
-                          ),
-                          sectionsSpace: 1,
-                          centerSpaceRadius: 50,
-                          sections: showingOuterSections(),
                         ),
                       ),
-                    ),
-                  ],
+                    ],
+                  ),
                 )),
           ),
         ],

--- a/lib/src/chart/base/base_chart/base_chart_data.dart
+++ b/lib/src/chart/base/base_chart/base_chart_data.dart
@@ -89,8 +89,10 @@ abstract class FlTouchData<R extends BaseTouchResponse> with EquatableMixin {
     this.enabled,
     this.touchCallback,
     this.mouseCursorResolver,
-    this.longPressDuration,
-  );
+    this.longPressDuration, [
+    this.externalTouchPosition,
+    this.externalTouchCallback,
+  ]);
 
   /// You can disable or enable the touch system using [enabled] flag,
   final bool enabled;
@@ -109,6 +111,14 @@ abstract class FlTouchData<R extends BaseTouchResponse> with EquatableMixin {
   /// default to 500 milliseconds refer to [kLongPressTimeout].
   final Duration? longPressDuration;
 
+  /// If you will use an external touch handlers, you will need to pass the position.
+  final Offset? externalTouchPosition;
+
+  /// [externalTouchCallback] notifies you about the happened touch/pointer events.
+  /// It gives you a [BaseTouchResponse] which is the chart specific type and contains information
+  /// about the elements that has touched.
+  final BaseExternalTouchCallback<R>? externalTouchCallback;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
@@ -116,6 +126,8 @@ abstract class FlTouchData<R extends BaseTouchResponse> with EquatableMixin {
         touchCallback,
         mouseCursorResolver,
         longPressDuration,
+        externalTouchCallback,
+        externalTouchPosition,
       ];
 }
 
@@ -177,6 +189,11 @@ class FlClipData with EquatableMixin {
 /// Chart's touch callback.
 typedef BaseTouchCallback<R extends BaseTouchResponse> = void Function(
   FlTouchEvent,
+  R?,
+);
+
+/// Chart's touch callback.
+typedef BaseExternalTouchCallback<R extends BaseTouchResponse> = void Function(
   R?,
 );
 

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -292,11 +292,15 @@ class PieTouchData extends FlTouchData<PieTouchResponse> with EquatableMixin {
     BaseTouchCallback<PieTouchResponse>? touchCallback,
     MouseCursorResolver<PieTouchResponse>? mouseCursorResolver,
     Duration? longPressDuration,
+    Offset? externalTouchPosition,
+    BaseExternalTouchCallback<PieTouchResponse>? externalTouchCallback,
   }) : super(
           enabled ?? true,
           touchCallback,
           mouseCursorResolver,
           longPressDuration,
+          externalTouchPosition,
+          externalTouchCallback,
         );
 
   /// Used for equality check, see [EquatableMixin].

--- a/lib/src/chart/pie_chart/pie_chart_renderer.dart
+++ b/lib/src/chart/pie_chart/pie_chart_renderer.dart
@@ -36,6 +36,13 @@ class PieChartLeaf extends MultiChildRenderObjectWidget {
       ..targetData = targetData
       ..textScale = MediaQuery.of(context).textScaleFactor
       ..buildContext = context;
+    data.pieTouchData.externalTouchCallback?.call(
+      data.pieTouchData.externalTouchPosition != null
+          ? renderObject.getResponseAtLocation(
+              data.pieTouchData.externalTouchPosition!,
+            )
+          : null,
+    );
   }
 }
 // coverage:ignore-end


### PR DESCRIPTION
Regarding the case of stacked pie charts on each other, the touch handler will work on one of them only, check this issue #1307 as well.

To try this case and understand the issue, you can go to this commit ceb4e18 and check sample 4.
![image](https://github.com/imaNNeo/fl_chart/assets/18621699/2a2d09b0-1ff3-4ff7-a33f-a056af233197)

This PR fixes this by adding the ability to calculate the touch response based on external parameter for the touched position, now you can use MouseRegion widget for example and add the stacked Pie charts inside it then pass the touched position to the charts and get the calculated response (check pie chart sample 4).