### PR TITLE
Release/0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ ScatterSpot(
 * **IMPROVEMENT** (by @imaNNeo) Add gradient property to the [HorizontalLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#horizontalline) and [VerticalLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#verticalline), #1525
 * **FEATURE** (by @raldhafiri) Add gradient property to the [PieChartSectionData](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/pie_chart.md#piechartsectiondata), #1511
 * **IMPROVEMENT** (by @imaNNeo) Rename default branch `master` to `main`
+* **IMPROVEMENT** (by @imaNNeo) Update flutter sdk constraints to remove the upper bound limit (Read more [here](https://dart.dev/go/flutter-upper-bound-deprecation)).
 
 ## 0.65.0
 * **FEATURE** (by @Dartek12) Added gradient to [FlLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#FlLine), #1197

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## newVersion
+## 0.66.0
 * **IMPROVEMENT** (by @imaNNeo) Add Flutter sdk constraints to the pubspec.yaml to force the user/developer to upgrade the Flutter version to 3.16.0 (latest), #1509
 * **IMPROVEMENT** (by @imaNNeo) Add `dotPainter` property to ScatterSpot to allow customizing the dot painter, #568
 * **BREAKING** (by @imaNNeo) Remove `color` and `radius` properties from ScatterSpot (use `dotPainter` instead), #568

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ ScatterSpot(
 * **BUGFIX** (by @imaNNeo) Fix pieChart drawing single section on iPhone, #1515
 * **IMPROVEMENT** (by @imaNNeo) Add gradient property to the [HorizontalLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#horizontalline) and [VerticalLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#verticalline), #1525
 * **FEATURE** (by @raldhafiri) Add gradient property to the [PieChartSectionData](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/pie_chart.md#piechartsectiondata), #1511
+* **IMPROVEMENT** (by @imaNNeo) Rename default branch `master` to `main`
 
 ## 0.65.0
 * **FEATURE** (by @Dartek12) Added gradient to [FlLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#FlLine), #1197

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ documentation: https://github.com/imaNNeo/fl_chart
 
 environment:
   sdk: ^3.2.0
-  flutter: ^3.16.0
+  flutter: '>=3.16.0'
 
 funding:
   - https://github.com/sponsors/imaNNeo

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A highly customizable Flutter chart library that supports Line Chart, Bar Chart, Pie Chart, Scatter Chart, and Radar Chart.
-version: 0.65.0
+version: 0.66.0
 homepage: https://flchart.dev/
 repository: https://github.com/imaNNeo/fl_chart
 issue_tracker: https://github.com/imaNNeo/fl_chart/issues


### PR DESCRIPTION
* **IMPROVEMENT** (by @imaNNeo) Add Flutter sdk constraints to the pubspec.yaml to force the user/developer to upgrade the Flutter version to 3.16.0 (latest), #1509
* **IMPROVEMENT** (by @imaNNeo) Add `dotPainter` property to ScatterSpot to allow customizing the dot painter, #568
* **BREAKING** (by @imaNNeo) Remove `color` and `radius` properties from ScatterSpot (use `dotPainter` instead), #568
* **BREAKING** (by @imaNNeo) Change the default value of FlDotCirclePainter.`strokeWidth` to 0.0
```dart
/// Migration guide:
/// This is the old way:
ScatterSpot(
  2,
  5,
  color: Colors.red,
  radius: 12,
)

/// This is the new way:
ScatterSpot(
  2,
  8,
  dotPainter: FlDotCirclePainter(
    color: Colors.red,
    radius: 22,
  ),
),
```
* **BUGFIX** (by @imaNNeo) Fix barChart tooltip for values below or above the 0 point, #1462
* **BUGFIX** (by @imaNNeo) Fix pieChart drawing single section on iPhone, #1515
* **IMPROVEMENT** (by @imaNNeo) Add gradient property to the [HorizontalLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#horizontalline) and [VerticalLine](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#verticalline), #1525
* **FEATURE** (by @raldhafiri) Add gradient property to the [PieChartSectionData](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/pie_chart.md#piechartsectiondata), #1511
* **IMPROVEMENT** (by @imaNNeo) Rename default branch `master` to `main`
* **IMPROVEMENT** (by @imaNNeo) Update flutter sdk constraints to remove the upper bound limit (Read more [here](https://dart.dev/go/flutter-upper-bound-deprecation)).
