### PR TITLE
Upgrade Kotlin version from 1.6.10 to 1.7.10

### DIFF
--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.6.10'
+    ext.kotlin_version = '1.7.10'
     repositories {
         google()
         mavenCentral()
@@ -26,6 +26,6 @@ subprojects {
     project.evaluationDependsOn(':app')
 }
 
-task clean(type: Delete) {
+tasks.register("clean", Delete) {
     delete rootProject.buildDir
 }


### PR DESCRIPTION
I am using Android Studio Giraffe | 2022.3.1 Patch 2
when building the fl_chart example, I got an error about Kotlin version. So I upgraded Kotlin version in build.gradle and fl_chart builds and runs fine.