### PR TITLE
Fix unsupported environment access on web

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -9,9 +9,10 @@ import 'package:fl_chart/src/chart/bar_chart/bar_chart_helper.dart';
 import 'package:fl_chart/src/extensions/color_extension.dart';
 import 'package:fl_chart/src/utils/lerp.dart';
 import 'package:fl_chart/src/utils/utils.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-final _isTest = Platform.environment.containsKey('FLUTTER_TEST');
+final _isTest = !kIsWeb && Platform.environment.containsKey('FLUTTER_TEST');
 final _axisValues = BarChartHelper().calculateMaxAxisValues;
 
 /// [BarChart] needs this class to render itself.

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -8,9 +8,10 @@ import 'package:fl_chart/src/chart/line_chart/line_chart_helper.dart';
 import 'package:fl_chart/src/extensions/color_extension.dart';
 import 'package:fl_chart/src/extensions/gradient_extension.dart';
 import 'package:fl_chart/src/utils/lerp.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Image;
 
-final _isTest = Platform.environment.containsKey('FLUTTER_TEST');
+final _isTest = !kIsWeb && Platform.environment.containsKey('FLUTTER_TEST');
 final _axisValues = LineChartHelper().calculateMaxAxisValues;
 
 /// [LineChart] needs this class to render itself.


### PR DESCRIPTION
The Platform.environment can not be be accessed in flutter web. Remove the check when running on web to prevent an exception.

Fixes #1565.