### PR TITLE
Removed dependency to dart:io in order to support Web #1577

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -1,19 +1,13 @@
 // coverage:ignore-file
-import 'dart:io';
 import 'dart:math';
 import 'dart:ui';
 
 import 'package:equatable/equatable.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'package:fl_chart/src/chart/bar_chart/bar_chart_helper.dart';
 import 'package:fl_chart/src/extensions/color_extension.dart';
 import 'package:fl_chart/src/utils/lerp.dart';
 import 'package:fl_chart/src/utils/utils.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
-final _isTest = !kIsWeb && Platform.environment.containsKey('FLUTTER_TEST');
-final _axisValues = BarChartHelper().calculateMaxAxisValues;
 
 /// [BarChart] needs this class to render itself.
 ///
@@ -68,10 +62,8 @@ class BarChartData extends AxisChartData with EquatableMixin {
           extraLinesData: extraLinesData ?? const ExtraLinesData(),
           minX: 0,
           maxX: 1,
-          maxY: maxY ??
-              (_isTest ? _axisValues(barGroups ?? []).maxY : double.nan),
-          minY: minY ??
-              (_isTest ? _axisValues(barGroups ?? []).minY : double.nan),
+          maxY: maxY ?? double.nan,
+          minY: minY ?? double.nan,
         );
 
   /// [BarChart] draws [barGroups] that each of them contains a list of [BarChartRodData].

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1,18 +1,12 @@
 // coverage:ignore-file
-import 'dart:io';
 import 'dart:ui';
 
 import 'package:equatable/equatable.dart';
 import 'package:fl_chart/fl_chart.dart';
-import 'package:fl_chart/src/chart/line_chart/line_chart_helper.dart';
 import 'package:fl_chart/src/extensions/color_extension.dart';
 import 'package:fl_chart/src/extensions/gradient_extension.dart';
 import 'package:fl_chart/src/utils/lerp.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart' hide Image;
-
-final _isTest = !kIsWeb && Platform.environment.containsKey('FLUTTER_TEST');
-final _axisValues = LineChartHelper().calculateMaxAxisValues;
 
 /// [LineChart] needs this class to render itself.
 ///
@@ -66,10 +60,10 @@ class LineChartData extends AxisChartData with EquatableMixin {
     super.backgroundColor,
   }) : super(
           touchData: lineTouchData,
-          minX: minX ?? (_isTest ? _axisValues(lineBarsData).minX : double.nan),
-          maxX: maxX ?? (_isTest ? _axisValues(lineBarsData).maxX : double.nan),
-          minY: minY ?? (_isTest ? _axisValues(lineBarsData).minY : double.nan),
-          maxY: maxY ?? (_isTest ? _axisValues(lineBarsData).maxY : double.nan),
+          minX: minX ?? double.nan,
+          maxX: maxX ?? double.nan,
+          minY: minY ?? double.nan,
+          maxY: maxY ?? double.nan,
         );
 
   /// [LineChart] draws some lines in various shapes and overlaps them.

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1,4 +1,5 @@
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart/src/chart/bar_chart/bar_chart_helper.dart';
 import 'package:fl_chart/src/chart/bar_chart/bar_chart_painter.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
 import 'package:fl_chart/src/extensions/bar_chart_data_extension.dart';
@@ -21,27 +22,33 @@ void main() {
     test('test 1', () {
       final utilsMainInstance = Utils();
       const viewSize = Size(400, 400);
+      final barGroups = <BarChartGroupData>[
+        BarChartGroupData(
+          x: 1,
+          barRods: [
+            BarChartRodData(fromY: 1, toY: 10),
+            BarChartRodData(fromY: 2, toY: 10),
+          ],
+          showingTooltipIndicators: [
+            1,
+            2,
+          ],
+        ),
+        BarChartGroupData(
+          x: 2,
+          barRods: [
+            BarChartRodData(fromY: 3, toY: 10),
+            BarChartRodData(fromY: 4, toY: 10),
+          ],
+        ),
+      ];
+
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
-        barGroups: [
-          BarChartGroupData(
-            x: 1,
-            barRods: [
-              BarChartRodData(fromY: 1, toY: 10),
-              BarChartRodData(fromY: 2, toY: 10),
-            ],
-            showingTooltipIndicators: [
-              1,
-              2,
-            ],
-          ),
-          BarChartGroupData(
-            x: 2,
-            barRods: [
-              BarChartRodData(fromY: 3, toY: 10),
-              BarChartRodData(fromY: 4, toY: 10),
-            ],
-          ),
-        ],
+        barGroups: barGroups,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final barChartPainter = BarChartPainter();
@@ -340,11 +347,15 @@ void main() {
         ),
       ];
 
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         titlesData: const FlTitlesData(show: false),
         groupsSpace: 10,
         barGroups: barGroups,
         alignment: BarChartAlignment.center,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final barChartPainter = BarChartPainter();
@@ -601,11 +612,15 @@ void main() {
         ),
       ];
 
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         titlesData: const FlTitlesData(show: false),
         groupsSpace: 10,
         barGroups: barGroups,
         alignment: BarChartAlignment.center,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final barChartPainter = BarChartPainter();
@@ -833,7 +848,13 @@ void main() {
         ),
       ];
 
-      final data = BarChartData(barGroups: barGroups);
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
+      final data = BarChartData(
+        barGroups: barGroups,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
+      );
 
       final barChartPainter = BarChartPainter();
       final holder =
@@ -932,7 +953,13 @@ void main() {
         ),
       ];
 
-      final data = BarChartData(barGroups: barGroups);
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
+      final data = BarChartData(
+        barGroups: barGroups,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
+      );
 
       final barChartPainter = BarChartPainter();
       final holder =
@@ -1081,6 +1108,8 @@ void main() {
         },
       );
 
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         groupsSpace: 10,
         barGroups: barGroups,
@@ -1088,6 +1117,8 @@ void main() {
           touchTooltipData: tooltipData,
         ),
         alignment: BarChartAlignment.center,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final barChartPainter = BarChartPainter();
@@ -1277,6 +1308,8 @@ void main() {
         },
       );
 
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         groupsSpace: 10,
         barGroups: barGroups,
@@ -1284,6 +1317,8 @@ void main() {
           touchTooltipData: tooltipData,
         ),
         alignment: BarChartAlignment.center,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final barChartPainter = BarChartPainter();
@@ -1447,6 +1482,9 @@ void main() {
           );
         },
       );
+
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         groupsSpace: 10,
         barGroups: barGroups,
@@ -1454,6 +1492,8 @@ void main() {
           touchTooltipData: tooltipData,
         ),
         alignment: BarChartAlignment.center,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final barChartPainter = BarChartPainter();
@@ -1574,10 +1614,14 @@ void main() {
         BarChartGroupData(x: 0, barRods: [barRod], barsSpace: 5),
       ];
 
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         groupsSpace: 10,
         barGroups: barGroups,
         barTouchData: BarTouchData(),
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final barChartPainter = BarChartPainter();
@@ -1748,6 +1792,8 @@ void main() {
         ),
       ];
 
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         barGroups: barGroups,
         titlesData: const FlTitlesData(show: false),
@@ -1757,6 +1803,8 @@ void main() {
           handleBuiltInTouches: true,
           touchExtraThreshold: const EdgeInsets.all(1),
         ),
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final painter = BarChartPainter();
@@ -1847,6 +1895,8 @@ void main() {
         ),
       ];
 
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
         barGroups: barGroups,
         titlesData: const FlTitlesData(show: false),
@@ -1856,6 +1906,8 @@ void main() {
           handleBuiltInTouches: true,
           touchExtraThreshold: const EdgeInsets.all(1),
         ),
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
       );
 
       final painter = BarChartPainter();
@@ -2079,27 +2131,34 @@ void main() {
     test('bar chart should not paint vertical lines', () {
       final utilsMainInstance = Utils();
       const viewSize = Size(400, 400);
+
+      final barGroups = <BarChartGroupData>[
+        BarChartGroupData(
+          x: 1,
+          barRods: [
+            BarChartRodData(fromY: 1, toY: 10),
+            BarChartRodData(fromY: 2, toY: 10),
+          ],
+          showingTooltipIndicators: [
+            1,
+            2,
+          ],
+        ),
+        BarChartGroupData(
+          x: 2,
+          barRods: [
+            BarChartRodData(fromY: 3, toY: 10),
+            BarChartRodData(fromY: 4, toY: 10),
+          ],
+        ),
+      ];
+
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
-        barGroups: [
-          BarChartGroupData(
-            x: 1,
-            barRods: [
-              BarChartRodData(fromY: 1, toY: 10),
-              BarChartRodData(fromY: 2, toY: 10),
-            ],
-            showingTooltipIndicators: [
-              1,
-              2,
-            ],
-          ),
-          BarChartGroupData(
-            x: 2,
-            barRods: [
-              BarChartRodData(fromY: 3, toY: 10),
-              BarChartRodData(fromY: 4, toY: 10),
-            ],
-          ),
-        ],
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
+        barGroups: barGroups,
         extraLinesData: ExtraLinesData(
           verticalLines: [verticalLine1],
         ),
@@ -2268,27 +2327,34 @@ void main() {
       );
       final utilsMainInstance = Utils();
       const viewSize = Size(400, 400);
+
+      final barGroups = <BarChartGroupData>[
+        BarChartGroupData(
+          x: 1,
+          barRods: [
+            BarChartRodData(fromY: 1, toY: 10),
+            BarChartRodData(fromY: 2, toY: 10),
+          ],
+          showingTooltipIndicators: [
+            1,
+            2,
+          ],
+        ),
+        BarChartGroupData(
+          x: 2,
+          barRods: [
+            BarChartRodData(fromY: 3, toY: 10),
+            BarChartRodData(fromY: 4, toY: 10),
+          ],
+        ),
+      ];
+
+      final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
       final data = BarChartData(
-        barGroups: [
-          BarChartGroupData(
-            x: 1,
-            barRods: [
-              BarChartRodData(fromY: 1, toY: 10),
-              BarChartRodData(fromY: 2, toY: 10),
-            ],
-            showingTooltipIndicators: [
-              1,
-              2,
-            ],
-          ),
-          BarChartGroupData(
-            x: 2,
-            barRods: [
-              BarChartRodData(fromY: 3, toY: 10),
-              BarChartRodData(fromY: 4, toY: 10),
-            ],
-          ),
-        ],
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
+        barGroups: barGroups,
         extraLinesData: ExtraLinesData(
           horizontalLines: [horizontalLine, horizontalLine1],
         ),

--- a/test/chart/base/axis_chart/side_titles/side_titles_widget_test.dart
+++ b/test/chart/base/axis_chart/side_titles/side_titles_widget_test.dart
@@ -1,4 +1,5 @@
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart/src/chart/bar_chart/bar_chart_helper.dart';
 import 'package:fl_chart/src/chart/base/axis_chart/side_titles/side_titles_widget.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -146,8 +147,8 @@ void main() {
     ),
   );
 
-  final barChartDataWithOnlyRightTitles = BarChartData(
-    barGroups: [
+  BarChartData createBarChartDataWithOnlyRightTitles() {
+    final barGroups = <BarChartGroupData>[
       BarChartGroupData(
         x: 0,
         barRods: [
@@ -166,52 +167,67 @@ void main() {
           BarChartRodData(toY: 10),
         ],
       ),
-    ],
-    titlesData: FlTitlesData(
-      leftTitles: const AxisTitles(),
-      topTitles: const AxisTitles(),
-      rightTitles: AxisTitles(
-        axisNameWidget: const Icon(Icons.arrow_right),
-        sideTitles: SideTitles(
-          showTitles: true,
-          interval: 1,
-          getTitlesWidget: (value, meta) {
-            return TextButton(
-              onPressed: () {},
-              child: Text(
-                value.toInt().toString(),
-              ),
-            );
-          },
-        ),
-      ),
-      bottomTitles: const AxisTitles(),
-    ),
-  );
+    ];
 
-  final barChartDataWithEmptyGroups = BarChartData(
-    barGroups: [],
-    titlesData: FlTitlesData(
-      leftTitles: const AxisTitles(),
-      topTitles: const AxisTitles(),
-      rightTitles: AxisTitles(
-        axisNameWidget: const Icon(Icons.arrow_right),
-        sideTitles: SideTitles(
-          showTitles: true,
-          interval: 1,
-          getTitlesWidget: (value, meta) {
-            return TextButton(
-              onPressed: () {},
-              child: Text(
-                value.toInt().toString(),
-              ),
-            );
-          },
+    final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
+    return BarChartData(
+      barGroups: barGroups,
+      titlesData: FlTitlesData(
+        leftTitles: const AxisTitles(),
+        topTitles: const AxisTitles(),
+        rightTitles: AxisTitles(
+          axisNameWidget: const Icon(Icons.arrow_right),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: 1,
+            getTitlesWidget: (value, meta) {
+              return TextButton(
+                onPressed: () {},
+                child: Text(
+                  value.toInt().toString(),
+                ),
+              );
+            },
+          ),
         ),
+        bottomTitles: const AxisTitles(),
       ),
-      bottomTitles: const AxisTitles(),
-    ),
-  );
+      minY: axisValues.minY,
+      maxY: axisValues.maxY,
+    );
+  }
+
+  BarChartData createBarChartDataWithEmptyGroups() {
+    final barGroups = <BarChartGroupData>[];
+    final axisValues = BarChartHelper().calculateMaxAxisValues(barGroups);
+
+    return BarChartData(
+      barGroups: [],
+      titlesData: FlTitlesData(
+        leftTitles: const AxisTitles(),
+        topTitles: const AxisTitles(),
+        rightTitles: AxisTitles(
+          axisNameWidget: const Icon(Icons.arrow_right),
+          sideTitles: SideTitles(
+            showTitles: true,
+            interval: 1,
+            getTitlesWidget: (value, meta) {
+              return TextButton(
+                onPressed: () {},
+                child: Text(
+                  value.toInt().toString(),
+                ),
+              );
+            },
+          ),
+        ),
+        bottomTitles: const AxisTitles(),
+      ),
+      minY: axisValues.minY,
+      maxY: axisValues.maxY,
+    );
+  }
 
   testWidgets(
     'LineChart with no titles',
@@ -377,7 +393,7 @@ void main() {
                 height: viewSize.height,
                 child: SideTitlesWidget(
                   side: AxisSide.right,
-                  axisChartData: barChartDataWithOnlyRightTitles,
+                  axisChartData: createBarChartDataWithOnlyRightTitles(),
                   parentSize: viewSize,
                 ),
               ),
@@ -406,7 +422,7 @@ void main() {
                 height: viewSize.height,
                 child: SideTitlesWidget(
                   side: AxisSide.right,
-                  axisChartData: barChartDataWithEmptyGroups,
+                  axisChartData: createBarChartDataWithEmptyGroups(),
                   parentSize: viewSize,
                 ),
               ),

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -4,6 +4,7 @@ import 'dart:ui' as ui show Gradient;
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
+import 'package:fl_chart/src/chart/line_chart/line_chart_helper.dart';
 import 'package:fl_chart/src/chart/line_chart/line_chart_painter.dart';
 import 'package:fl_chart/src/extensions/path_extension.dart';
 import 'package:fl_chart/src/utils/canvas_wrapper.dart';
@@ -45,11 +46,18 @@ void main() {
           FlSpot(4, 0),
         ],
       );
+
+      final lineChartBarsData = <LineChartBarData>[bar1, bar2];
+      final axisValues = LineChartHelper().calculateMaxAxisValues(
+        lineChartBarsData,
+      );
+
       final data = LineChartData(
-        lineBarsData: [
-          bar1,
-          bar2,
-        ],
+        minX: axisValues.minX,
+        maxX: axisValues.maxX,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
+        lineBarsData: lineChartBarsData,
         clipData: const FlClipData.all(),
         extraLinesData: ExtraLinesData(
           horizontalLines: [
@@ -137,11 +145,18 @@ void main() {
           FlSpot(4, 3),
         ],
       );
+
+      final lineChartBarsData = <LineChartBarData>[bar1, bar2];
+      final axisValues = LineChartHelper().calculateMaxAxisValues(
+        lineChartBarsData,
+      );
+
       final data = LineChartData(
-        lineBarsData: [
-          bar1,
-          bar2,
-        ],
+        minX: axisValues.minX,
+        maxX: axisValues.maxX,
+        minY: axisValues.minY,
+        maxY: axisValues.maxY,
+        lineBarsData: lineChartBarsData,
         clipData: const FlClipData.all(),
         lineTouchData: LineTouchData(
           getTouchedSpotIndicator:


### PR DESCRIPTION
This PR is related to issue #1577.

Two classes used dart:io to determine whether the code is being executed as part of a test.

This prevented the usage of fl_chart for the Web as the target platform.

I moved the test-related initialization code from the production code to the unit tests.
