### PR TITLE
Fixed line chart shows negative values

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -974,6 +974,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       ..transparentIfWidthIsZero();
 
     barPath = barPath.toDashedPath(barData.dashArray);
+    barPath = adjustPath(barPath, rectAroundTheLine);
     canvasWrapper.drawPath(barPath, _barPaint);
   }
 
@@ -1290,6 +1291,42 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     } else {
       return null;
     }
+  }
+
+  Path adjustPath(Path barPath, Rect rectAroundTheLine) {
+    final newPath = Path();
+    final pathMetrics = barPath.computeMetrics();
+
+    for (final pathMetric in pathMetrics) {
+      for (var i = 0.0; i < pathMetric.length; i++) {
+        final tangent = pathMetric.getTangentForOffset(i);
+        if (tangent != null) {
+          var point = tangent.position;
+
+          if (!rectAroundTheLine.contains(point)) {
+            if (point.dx < rectAroundTheLine.left) {
+              point = Offset(rectAroundTheLine.left, point.dy);
+            } else if (point.dx > rectAroundTheLine.right) {
+              point = Offset(rectAroundTheLine.right, point.dy);
+            }
+
+            if (point.dy < rectAroundTheLine.top) {
+              point = Offset(point.dx, rectAroundTheLine.top);
+            } else if (point.dy > rectAroundTheLine.bottom) {
+              point = Offset(point.dx, rectAroundTheLine.bottom);
+            }
+          }
+
+          if (i == 0.0) {
+            newPath.moveTo(point.dx, point.dy);
+          } else {
+            newPath.lineTo(point.dx, point.dy);
+          }
+        }
+      }
+    }
+
+    return newPath;
   }
 }
 


### PR DESCRIPTION
fix: Adjust bar path to fit within a specified rectangular area, #1593

This commit adds a new function called `adjustPath` that takes a `Path` and a `Rect` as parameters. The function adjusts the given path to fit within the specified rectangular area by clamping the path's points to the rect's boundaries. This ensures that the bar path is always fully visible within the chart area.

The function iterates over the path metrics of the input path and for each path metric, it iterates over its length. For each iteration, it gets the tangent at the current offset and checks if the tangent's position is within the rectangular area. If it's not, the position is clamped to the rect's boundaries. Finally, the adjusted path is returned.
