### PR TITLE
Dynamically changing tooltipBgColor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## newVersion
 * **FEATURE** (by @julien4215) Add direction property to the [HorizontalLineLabel](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#horizontallinelabel) and [VerticalLineLabel](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#verticallinelabel), #1574
-* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change background color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar, Line and Scatter Charts.
 
 ## 0.66.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 ## newVersion
 * **FEATURE** (by @julien4215) Add direction property to the [HorizontalLineLabel](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#horizontallinelabel) and [VerticalLineLabel](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#verticallinelabel), #1574
 
+## 0.67.0
+* **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
+* **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar, Line and Scatter Charts.
+
 ## 0.66.2
 * **BUGFIX** (by @stwarwas) Remove dart.io to fix web platform issue, #1577
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 ## newVersion
 * **FEATURE** (by @julien4215) Add direction property to the [HorizontalLineLabel](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#horizontallinelabel) and [VerticalLineLabel](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/base_chart.md#verticallinelabel), #1574
-
-## 0.67.0
 * **FEATURE**  (by @apekshamehta) Added new method called getTooltipColor for axis charts (bar,line,scatter) to change backgroud color of tooltip dynamically.[issue](https://github.com/imaNNeo/fl_chart/issues/1279).
 * **BREAKING** (by @apekshamehta) Removed tooltipBgColor property from Bar, Line and Scatter Charts.
 

--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -162,7 +162,19 @@ class BarChartSample1State extends State<BarChartSample1> {
     return BarChartData(
       barTouchData: BarTouchData(
         touchTooltipData: BarTouchTooltipData(
-          tooltipBgColor: Colors.blueGrey,
+          getTooltipColor: (group) {
+            Color bgColor = switch (group.x) {
+              0 => AppColors.contentColorPurple.withAlpha(100),
+              1 => AppColors.contentColorYellow.withAlpha(100),
+              2 => AppColors.contentColorBlue.withAlpha(100),
+              3 => AppColors.contentColorOrange.withAlpha(100),
+              4 => AppColors.contentColorPink.withAlpha(100),
+              5 => AppColors.contentColorRed.withAlpha(100),
+              6 => AppColors.contentColorPurple.withAlpha(150),
+              _ => throw Error(),
+            };
+            return bgColor;
+          },
           tooltipHorizontalAlignment: FLHorizontalAlignment.right,
           tooltipMargin: -10,
           getTooltipItem: (group, groupIndex, rod, rodIndex) {
@@ -202,8 +214,8 @@ class BarChartSample1State extends State<BarChartSample1> {
               children: <TextSpan>[
                 TextSpan(
                   text: (rod.toY - 1).toString(),
-                  style: TextStyle(
-                    color: widget.touchedBarColor,
+                  style: const TextStyle(
+                    color: Colors.white, //widget.touchedBarColor,
                     fontSize: 16,
                     fontWeight: FontWeight.w500,
                   ),

--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -162,19 +162,7 @@ class BarChartSample1State extends State<BarChartSample1> {
     return BarChartData(
       barTouchData: BarTouchData(
         touchTooltipData: BarTouchTooltipData(
-          getTooltipColor: (group) {
-            Color bgColor = switch (group.x) {
-              0 => AppColors.contentColorPurple.withAlpha(100),
-              1 => AppColors.contentColorYellow.withAlpha(100),
-              2 => AppColors.contentColorBlue.withAlpha(100),
-              3 => AppColors.contentColorOrange.withAlpha(100),
-              4 => AppColors.contentColorPink.withAlpha(100),
-              5 => AppColors.contentColorRed.withAlpha(100),
-              6 => AppColors.contentColorPurple.withAlpha(150),
-              _ => throw Error(),
-            };
-            return bgColor;
-          },
+          getTooltipColor: (_) => Colors.blueGrey,
           tooltipHorizontalAlignment: FLHorizontalAlignment.right,
           tooltipMargin: -10,
           getTooltipItem: (group, groupIndex, rod, rodIndex) {

--- a/example/lib/presentation/samples/bar/bar_chart_sample2.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample2.dart
@@ -85,7 +85,9 @@ class BarChartSample2State extends State<BarChartSample2> {
                   maxY: 20,
                   barTouchData: BarTouchData(
                     touchTooltipData: BarTouchTooltipData(
-                      tooltipBgColor: Colors.grey,
+                      getTooltipColor: ((group) {
+                        return Colors.grey;
+                      }),
                       getTooltipItem: (a, b, c, d) => null,
                     ),
                     touchCallback: (FlTouchEvent event, response) {

--- a/example/lib/presentation/samples/bar/bar_chart_sample3.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample3.dart
@@ -24,7 +24,7 @@ class _BarChart extends StatelessWidget {
   BarTouchData get barTouchData => BarTouchData(
         enabled: false,
         touchTooltipData: BarTouchTooltipData(
-          tooltipBgColor: Colors.transparent,
+          getTooltipColor: (group) => Colors.transparent,
           tooltipPadding: EdgeInsets.zero,
           tooltipMargin: 8,
           getTooltipItem: (

--- a/example/lib/presentation/samples/bar/bar_chart_sample7.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample7.dart
@@ -122,7 +122,7 @@ class _BarChartSample7State extends State<BarChartSample7> {
               enabled: true,
               handleBuiltInTouches: false,
               touchTooltipData: BarTouchTooltipData(
-                tooltipBgColor: Colors.transparent,
+                getTooltipColor: (group) => Colors.transparent,
                 tooltipMargin: 0,
                 getTooltipItem: (
                   BarChartGroupData group,

--- a/example/lib/presentation/samples/line/line_chart_sample1.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample1.dart
@@ -42,7 +42,7 @@ class _LineChart extends StatelessWidget {
   LineTouchData get lineTouchData1 => LineTouchData(
         handleBuiltInTouches: true,
         touchTooltipData: LineTouchTooltipData(
-          tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
+          getTooltipColor: (touchedSpot) => Colors.blueGrey.withOpacity(0.8),
         ),
       );
 

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,22 +206,7 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
-                    getTooltipColor: (touchedSpot) {
-                      Color bgColor = switch ((
-                        touchedSpot.x.toInt(),
-                        touchedSpot.y.toDouble()
-                      )) {
-                        (0, 1.3) => AppColors.contentColorPurple.withAlpha(100),
-                        (1, 1) => AppColors.contentColorYellow.withAlpha(100),
-                        (2, 1.8) => AppColors.contentColorBlue.withAlpha(100),
-                        (3, 1.5) => AppColors.contentColorOrange.withAlpha(100),
-                        (4, 2.2) => AppColors.contentColorPink.withAlpha(100),
-                        (5, 1.8) => AppColors.contentColorRed.withAlpha(100),
-                        (6, 3) => AppColors.contentColorPurple.withAlpha(150),
-                        _ => throw Error(),
-                      };
-                      return bgColor;
-                    },
+                    getTooltipColor: (touchedSpot) => widget.tooltipBgColor,
                     getTooltipItems: (List<LineBarSpot> touchedBarSpots) {
                       return touchedBarSpots.map((barSpot) {
                         final flSpot = barSpot;

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -206,7 +206,22 @@ class _LineChartSample3State extends State<LineChartSample3> {
                     }).toList();
                   },
                   touchTooltipData: LineTouchTooltipData(
-                    tooltipBgColor: widget.tooltipBgColor,
+                    getTooltipColor: (touchedSpot) {
+                      Color bgColor = switch ((
+                        touchedSpot.x.toInt(),
+                        touchedSpot.y.toDouble()
+                      )) {
+                        (0, 1.3) => AppColors.contentColorPurple.withAlpha(100),
+                        (1, 1) => AppColors.contentColorYellow.withAlpha(100),
+                        (2, 1.8) => AppColors.contentColorBlue.withAlpha(100),
+                        (3, 1.5) => AppColors.contentColorOrange.withAlpha(100),
+                        (4, 2.2) => AppColors.contentColorPink.withAlpha(100),
+                        (5, 1.8) => AppColors.contentColorRed.withAlpha(100),
+                        (6, 3) => AppColors.contentColorPurple.withAlpha(150),
+                        _ => throw Error(),
+                      };
+                      return bgColor;
+                    },
                     getTooltipItems: (List<LineBarSpot> touchedBarSpots) {
                       return touchedBarSpots.map((barSpot) {
                         final flSpot = barSpot;

--- a/example/lib/presentation/samples/line/line_chart_sample5.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample5.dart
@@ -181,7 +181,7 @@ class _LineChartSample5State extends State<LineChartSample5> {
                   }).toList();
                 },
                 touchTooltipData: LineTouchTooltipData(
-                  tooltipBgColor: Colors.pink,
+                  getTooltipColor: (touchedSpot) => Colors.pink,
                   tooltipRoundedRadius: 8,
                   getTooltipItems: (List<LineBarSpot> lineBarsSpot) {
                     return lineBarsSpot.map((lineBarSpot) {

--- a/example/lib/presentation/samples/line/line_chart_sample8.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample8.dart
@@ -238,8 +238,8 @@ class _LineChartSample8State extends State<LineChartSample8> {
             );
           }).toList();
         },
-        touchTooltipData: const LineTouchTooltipData(
-          tooltipBgColor: AppColors.contentColorBlue,
+        touchTooltipData: LineTouchTooltipData(
+          getTooltipColor: (touchedSpot) => AppColors.contentColorBlue,
         ),
       ),
       borderData: FlBorderData(

--- a/example/lib/presentation/samples/line/line_chart_sample9.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample9.dart
@@ -59,7 +59,7 @@ class LineChartSample9 extends StatelessWidget {
                 lineTouchData: LineTouchData(
                   touchTooltipData: LineTouchTooltipData(
                     maxContentWidth: 100,
-                    tooltipBgColor: Colors.black,
+                    getTooltipColor: (touchedSpot) => Colors.black,
                     getTooltipItems: (touchedSpots) {
                       return touchedSpots.map((LineBarSpot touchedSpot) {
                         final textStyle = TextStyle(

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -126,7 +126,23 @@ class _ScatterChartSample2State extends State {
                       : SystemMouseCursors.click;
                 },
                 touchTooltipData: ScatterTouchTooltipData(
-                  tooltipBgColor: Colors.black,
+                  getTooltipColor: (ScatterSpot touchedBarSpot) {
+                    Color bgColor = switch ((
+                      touchedBarSpot.x.toInt(),
+                      touchedBarSpot.y.toInt()
+                    )) {
+                      (4, 4) => AppColors.contentColorPurple.withAlpha(100),
+                      (2, 5) => AppColors.contentColorYellow.withAlpha(100),
+                      (4, 5) => AppColors.contentColorBlue.withAlpha(100),
+                      (8, 6) => AppColors.contentColorOrange.withAlpha(100),
+                      (5, 7) => AppColors.contentColorPink.withAlpha(100),
+                      (7, 2) => AppColors.contentColorRed.withAlpha(100),
+                      (3, 2) => AppColors.contentColorPurple.withAlpha(150),
+                      (2, 8) => AppColors.contentColorYellow.withAlpha(100),
+                      _ => throw Error(),
+                    };
+                    return bgColor;
+                  },
                   getTooltipItems: (ScatterSpot touchedBarSpot) {
                     return ScatterTooltipItem(
                       'X: ',

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -127,21 +127,7 @@ class _ScatterChartSample2State extends State {
                 },
                 touchTooltipData: ScatterTouchTooltipData(
                   getTooltipColor: (ScatterSpot touchedBarSpot) {
-                    Color bgColor = switch ((
-                      touchedBarSpot.x.toInt(),
-                      touchedBarSpot.y.toInt()
-                    )) {
-                      (4, 4) => AppColors.contentColorPurple.withAlpha(100),
-                      (2, 5) => AppColors.contentColorYellow.withAlpha(100),
-                      (4, 5) => AppColors.contentColorBlue.withAlpha(100),
-                      (8, 6) => AppColors.contentColorOrange.withAlpha(100),
-                      (5, 7) => AppColors.contentColorPink.withAlpha(100),
-                      (7, 2) => AppColors.contentColorRed.withAlpha(100),
-                      (3, 2) => AppColors.contentColorPurple.withAlpha(150),
-                      (2, 8) => AppColors.contentColorYellow.withAlpha(100),
-                      _ => throw Error(),
-                    };
-                    return bgColor;
+                    return touchedBarSpot.dotPainter.mainColor;
                   },
                   getTooltipItems: (ScatterSpot touchedBarSpot) {
                     return ScatterTooltipItem(

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -687,7 +687,7 @@ class BarTouchTooltipData with EquatableMixin {
   /// if [BarTouchData.handleBuiltInTouches] is true,
   /// [BarChart] shows a tooltip popup on top of rods automatically when touch happens,
   /// otherwise you can show it manually using [BarChartGroupData.showingTooltipIndicators].
-  /// Tooltip shows on top of rods, with [tooltipBgColor] as a background color,
+  /// Tooltip shows on top of rods, with [getTooltipColor] as a background color,
   /// and you can set corner radius using [tooltipRoundedRadius].
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding],
   /// or If you want to have a bottom margin, set [tooltipMargin].
@@ -698,7 +698,6 @@ class BarTouchTooltipData with EquatableMixin {
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   BarTouchTooltipData({
-    Color? tooltipBgColor,
     double? tooltipRoundedRadius,
     EdgeInsets? tooltipPadding,
     double? tooltipMargin,
@@ -706,13 +705,13 @@ class BarTouchTooltipData with EquatableMixin {
     double? tooltipHorizontalOffset,
     double? maxContentWidth,
     GetBarTooltipItem? getTooltipItem,
+    GetBarTooltipColor? getTooltipColor,
     bool? fitInsideHorizontally,
     bool? fitInsideVertically,
     TooltipDirection? direction,
     double? rotateAngle,
     BorderSide? tooltipBorder,
-  })  : tooltipBgColor = tooltipBgColor ?? Colors.blueGrey.darken(15),
-        tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
+  })  : tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         tooltipMargin = tooltipMargin ?? 16,
@@ -721,15 +720,13 @@ class BarTouchTooltipData with EquatableMixin {
         tooltipHorizontalOffset = tooltipHorizontalOffset ?? 0,
         maxContentWidth = maxContentWidth ?? 120,
         getTooltipItem = getTooltipItem ?? defaultBarTooltipItem,
+        getTooltipColor = getTooltipColor ?? defaultBarTooltipColor,
         fitInsideHorizontally = fitInsideHorizontally ?? false,
         fitInsideVertically = fitInsideVertically ?? false,
         direction = direction ?? TooltipDirection.auto,
         rotateAngle = rotateAngle ?? 0.0,
         tooltipBorder = tooltipBorder ?? BorderSide.none,
         super();
-
-  /// The tooltip background color.
-  final Color tooltipBgColor;
 
   /// Sets a rounded radius for the tooltip.
   final double tooltipRoundedRadius;
@@ -767,10 +764,12 @@ class BarTouchTooltipData with EquatableMixin {
   /// The tooltip border color.
   final BorderSide tooltipBorder;
 
+  /// Retrieves data for setting background color of the tooltip.
+  final GetBarTooltipColor getTooltipColor;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        tooltipBgColor,
         tooltipRoundedRadius,
         tooltipPadding,
         tooltipMargin,
@@ -782,6 +781,7 @@ class BarTouchTooltipData with EquatableMixin {
         fitInsideVertically,
         rotateAngle,
         tooltipBorder,
+        getTooltipColor,
       ];
 }
 
@@ -849,6 +849,20 @@ class BarTooltipItem with EquatableMixin {
         textDirection,
         children,
       ];
+}
+
+//// Provides a [Color] to show different background color for each rod
+///
+/// You can override [BarTouchTooltipData.getTooltipColor], it gives you
+/// [group] that touch happened on, then you should and pass your custom [Color] to set background color
+/// of tooltip popup.
+typedef GetBarTooltipColor = Color Function(
+  BarChartGroupData group,
+);
+
+/// Default implementation for [BarTouchTooltipData.getTooltipColor].
+Color defaultBarTooltipColor(BarChartGroupData group) {
+  return Colors.blueGrey.darken(15);
 }
 
 /// Holds information about touch response in the [BarChart].

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -476,7 +476,9 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+
+    /// set tooltip's background color for each rod
+    _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnBarGroup);
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1030,7 +1030,7 @@ class LineTouchTooltipData with EquatableMixin {
   /// if [LineTouchData.handleBuiltInTouches] is true,
   /// [LineChart] shows a tooltip popup on top of spots automatically when touch happens,
   /// otherwise you can show it manually using [LineChartData.showingTooltipIndicators].
-  /// Tooltip shows on top of spots, with [tooltipBgColor] as a background color,
+  /// Tooltip shows on top of spots, with [getTooltipColor] as a background color,
   /// and you can set corner radius using [tooltipRoundedRadius].
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding],
   /// or If you want to have a bottom margin, set [tooltipMargin].
@@ -1041,7 +1041,6 @@ class LineTouchTooltipData with EquatableMixin {
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   const LineTouchTooltipData({
-    this.tooltipBgColor = const Color.fromRGBO(96, 125, 139, 1),
     this.tooltipRoundedRadius = 4,
     this.tooltipPadding =
         const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -1050,15 +1049,13 @@ class LineTouchTooltipData with EquatableMixin {
     this.tooltipHorizontalOffset = 0,
     this.maxContentWidth = 120,
     this.getTooltipItems = defaultLineTooltipItem,
+    this.getTooltipColor = defaultLineTooltipColor,
     this.fitInsideHorizontally = false,
     this.fitInsideVertically = false,
     this.showOnTopOfTheChartBoxArea = false,
     this.rotateAngle = 0.0,
     this.tooltipBorder = BorderSide.none,
   });
-
-  /// The tooltip background color.
-  final Color tooltipBgColor;
 
   /// Sets a rounded radius for the tooltip.
   final double tooltipRoundedRadius;
@@ -1096,10 +1093,12 @@ class LineTouchTooltipData with EquatableMixin {
   /// The tooltip border color.
   final BorderSide tooltipBorder;
 
+  // /// Retrieves data for setting background color of the tooltip.
+  final GetLineTooltipColor getTooltipColor;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        tooltipBgColor,
         tooltipRoundedRadius,
         tooltipPadding,
         tooltipMargin,
@@ -1112,6 +1111,7 @@ class LineTouchTooltipData with EquatableMixin {
         showOnTopOfTheChartBoxArea,
         rotateAngle,
         tooltipBorder,
+        getTooltipColor,
       ];
 }
 
@@ -1138,6 +1138,21 @@ List<LineTooltipItem> defaultLineTooltipItem(List<LineBarSpot> touchedSpots) {
     );
     return LineTooltipItem(touchedSpot.y.toString(), textStyle);
   }).toList();
+}
+
+//// Provides a [Color] to show different background color for each touched spot
+///
+/// You can override [LineTouchTooltipData.getTooltipColor], it gives you
+/// [touchedSpot] object that touch happened on, then you should and pass your custom [Color] list
+/// (length should be equal to the [touchedSpots.length]), to set background color
+/// of tooltip popup.
+typedef GetLineTooltipColor = Color Function(
+  LineBarSpot touchedSpot,
+);
+
+/// Default implementation for [LineTouchTooltipData.getTooltipColor].
+Color defaultLineTooltipColor(LineBarSpot touchedSpot) {
+  return Colors.blueGrey.darken(15);
 }
 
 /// Represent a targeted spot inside a line bar.

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1126,7 +1126,15 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+
+    var topSpot = showingTooltipSpots.showingSpots[0];
+    for (final barSpot in showingTooltipSpots.showingSpots) {
+      if (barSpot.y > topSpot.y) {
+        topSpot = barSpot;
+      }
+    }
+
+    _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(topSpot);
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -390,7 +390,7 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// if [ScatterTouchData.handleBuiltInTouches] is true,
   /// [ScatterChart] shows a tooltip popup on top of spots automatically when touch happens,
   /// otherwise you can show it manually using [ScatterChartData.showingTooltipIndicators].
-  /// Tooltip shows on top of spots, with [tooltipBgColor] as a background color,
+  /// Tooltip shows on top of spots, with [getTooltipColor] as a background color,
   /// and you can set corner radius using [tooltipRoundedRadius].
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding].
   /// Content of the tooltip will provide using [getTooltipItems] callback, you can override it
@@ -400,7 +400,6 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   ScatterTouchTooltipData({
-    Color? tooltipBgColor,
     double? tooltipRoundedRadius,
     EdgeInsets? tooltipPadding,
     FLHorizontalAlignment? tooltipHorizontalAlignment,
@@ -411,8 +410,8 @@ class ScatterTouchTooltipData with EquatableMixin {
     bool? fitInsideVertically,
     double? rotateAngle,
     BorderSide? tooltipBorder,
-  })  : tooltipBgColor = tooltipBgColor ?? Colors.blueGrey.darken(15),
-        tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
+    GetScatterTooltipColor? getTooltipColor,
+  })  : tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         tooltipHorizontalAlignment =
@@ -424,10 +423,8 @@ class ScatterTouchTooltipData with EquatableMixin {
         fitInsideVertically = fitInsideVertically ?? false,
         rotateAngle = rotateAngle ?? 0.0,
         tooltipBorder = tooltipBorder ?? BorderSide.none,
+        getTooltipColor = getTooltipColor ?? defaultScatterTooltipColor,
         super();
-
-  /// The tooltip background color.
-  final Color tooltipBgColor;
 
   /// Sets a rounded radius for the tooltip.
   final double tooltipRoundedRadius;
@@ -459,10 +456,12 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// The tooltip border color.
   final BorderSide tooltipBorder;
 
+  /// Retrieves data for showing content inside the tooltip.
+  final GetScatterTooltipColor getTooltipColor;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        tooltipBgColor,
         tooltipRoundedRadius,
         tooltipPadding,
         tooltipHorizontalAlignment,
@@ -473,12 +472,12 @@ class ScatterTouchTooltipData with EquatableMixin {
         fitInsideVertically,
         rotateAngle,
         tooltipBorder,
+        getTooltipColor,
       ];
 
   /// Copies current [ScatterTouchTooltipData] to a new [ScatterTouchTooltipData],
   /// and replaces provided values.
   ScatterTouchTooltipData copyWith({
-    Color? tooltipBgColor,
     double? tooltipRoundedRadius,
     EdgeInsets? tooltipPadding,
     FLHorizontalAlignment? tooltipHorizontalAlignment,
@@ -489,9 +488,9 @@ class ScatterTouchTooltipData with EquatableMixin {
     bool? fitInsideVertically,
     double? rotateAngle,
     BorderSide? tooltipBorder,
+    GetScatterTooltipColor? getTooltipColor,
   }) {
     return ScatterTouchTooltipData(
-      tooltipBgColor: tooltipBgColor ?? this.tooltipBgColor,
       tooltipRoundedRadius: tooltipRoundedRadius ?? this.tooltipRoundedRadius,
       tooltipPadding: tooltipPadding ?? this.tooltipPadding,
       tooltipHorizontalAlignment:
@@ -505,6 +504,7 @@ class ScatterTouchTooltipData with EquatableMixin {
       fitInsideVertically: fitInsideVertically ?? this.fitInsideVertically,
       rotateAngle: rotateAngle ?? this.rotateAngle,
       tooltipBorder: tooltipBorder ?? this.tooltipBorder,
+      getTooltipColor: getTooltipColor ?? this.getTooltipColor,
     );
   }
 }
@@ -536,6 +536,21 @@ ScatterTooltipItem? defaultScatterTooltipItem(ScatterSpot touchedSpot) {
     text,
     textStyle: textStyle,
   );
+}
+
+/// Provides a [Color] to show different background color inside the [ScatterTouchTooltipData].
+///
+/// You can override [ScatterTouchTooltipData.getTooltipColor], it gives you
+/// [touchedSpot] that touch happened on,
+/// then you should and pass your custom [Color]
+/// to show it inside the tooltip popup.
+typedef GetScatterTooltipColor = Color Function(
+  ScatterSpot touchedSpot,
+);
+
+/// Default implementation for [ScatterTouchTooltipData.getTooltipItems].
+Color defaultScatterTooltipColor(ScatterSpot touchedSpot) {
+  return Colors.blueGrey.darken(15);
 }
 
 /// Holds data of showing each item in the tooltip popup.

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -311,7 +311,8 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       bottomLeft: radius,
       bottomRight: radius,
     );
-    _bgTouchTooltipPaint.color = tooltipData.tooltipBgColor;
+
+    _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnSpot);
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A highly customizable Flutter chart library that supports Line Chart, Bar Chart, Pie Chart, Scatter Chart, and Radar Chart.
-version: 0.66.2
+version: 0.67.0
 homepage: https://flchart.dev/
 repository: https://github.com/imaNNeo/fl_chart
 issue_tracker: https://github.com/imaNNeo/fl_chart/issues

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A highly customizable Flutter chart library that supports Line Chart, Bar Chart, Pie Chart, Scatter Chart, and Radar Chart.
-version: 0.67.0
+version: 0.66.2
 homepage: https://flchart.dev/
 repository: https://github.com/imaNNeo/fl_chart
 issue_tracker: https://github.com/imaNNeo/fl_chart/issues

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -95,7 +95,6 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
 ### BarTouchTooltipData
  |PropName|Description|default value|
  |:-------|:----------|:------------|
- |tooltipBgColor|background color of the tooltip bubble|Colors.white|
  |tooltipBorder|border of the tooltip bubble|BorderSide.none|
  |tooltipRoundedRadius|background corner radius of the tooltip bubble|4|
  |tooltipPadding|padding of the tooltip|EdgeInsets.symmetric(horizontal: 16, vertical: 8)|
@@ -107,6 +106,7 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |direction| Controls showing tooltip on top or bottom, default is auto.| auto|
+ |getTooltipColor|a callback that retrieves the Color for each rod separately from the given [BarChartGroupData](#BarChartGroupData) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
 
 ### BarTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/handle_touches.md
+++ b/repo_files/documentations/handle_touches.md
@@ -22,7 +22,7 @@ LineChart(
   LineChartData(
     lineTouchData: LineTouchData(
       touchTooltipData: TouchTooltipData (
-        tooltipBgColor: Colors.blueGrey.withOpacity(0.8),
+        getTooltipColor: (touchedSpot) => Colors.blueGrey.withOpacity(0.8),
          .
          .
          .

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -119,7 +119,6 @@ When you change the chart's state, it animates to the new state internally (usin
 ### LineTouchTooltipData
  |PropName|Description|default value|
  |:-------|:----------|:------------|
- |tooltipBgColor|background color of the tooltip bubble|Colors.white|
  |tooltipBorder|border of the tooltip bubble|BorderSide.none|
  |tooltipRoundedRadius|background corner radius of the tooltip bubble|4|
  |tooltipPadding|padding of the tooltip|EdgeInsets.symmetric(horizontal: 16, vertical: 8)|
@@ -131,6 +130,7 @@ When you change the chart's state, it animates to the new state internally (usin
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |showOnTopOfTheChartBoxArea| forces the tooltip container to top of the line| false|
+ |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
 
 ### LineTooltipItem
 |PropName|Description|default value|

--- a/repo_files/documentations/migration_guides/0.67.0/MIGRATION_00_67_00.md
+++ b/repo_files/documentations/migration_guides/0.67.0/MIGRATION_00_67_00.md
@@ -1,0 +1,85 @@
+# Migrate to new version
+
+## Replaced tooltipBgColor
+
+**Breaking: [#1595](https://github.com/imaNNeo/fl_chart/pull/1595)**
+
+We added the ability to customize the tooltip background color for each point.
+
+The property `Color tooltipBgColor` from Bar, Line and Scatter Charts is replaced with a callback `Color Function(spot) getTooltipColor`
+
+#### BarChartData
+
+Previously:
+```dart
+BarChartData(
+  barTouchData: BarTouchData(
+    touchTooltipData: BarTouchTooltipData(
+      tooltipBgColor: Colors.blueGrey,
+    )
+  )
+)
+```
+
+Now in new version:
+
+```dart
+BarChartData(
+  barTouchData: BarTouchData(
+    touchTooltipData: BarTouchTooltipData(
+      getTooltipColor: (BarChartGroupData group) => Colors.blueGrey,
+    )
+  )
+)
+```
+
+#### LineChartData
+
+Previously:
+```dart
+LineChartData(
+  lineTouchData: LineTouchData(
+    touchTooltipData: LineTouchTooltipData(
+      tooltipBgColor: Colors.blueGrey,
+    )
+  )
+)
+```
+
+Now in new version:
+
+```dart
+LineChartData(
+  lineTouchData: LineTouchData(
+    touchTooltipData: LineTouchTooltipData(
+      getTooltipColor: (LineBarSpot touchedSpot) => Colors.blueGrey,
+    )
+  )
+)
+```
+
+#### ScatterChartData
+
+Previously:
+```dart
+ScatterChartData(
+  scatterTouchData: ScatterTouchData(
+    touchTooltipData: ScatterTouchTooltipData(
+      tooltipBgColor: Colors.blueGrey,
+    )
+  )
+)
+```
+
+Now in new version:
+
+```dart
+ScatterChartData(
+  scatterTouchData: ScatterTouchData(
+    touchTooltipData: ScatterTouchTooltipData(
+      getTooltipColor: (ScatterSpot touchedBarSpot) => Colors.blueGrey,
+    )
+  )
+)
+```
+

--- a/repo_files/documentations/migration_guides/INDEX.md
+++ b/repo_files/documentations/migration_guides/INDEX.md
@@ -3,3 +3,5 @@ Here are fl_chart's migration guides:
 #### [Migrate to 0.50.0](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/migration_guides/0.50.0/MIGRATION_00_50_00.md)
 
 #### [Migrate to 0.55.0](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/migration_guides/0.55.0/MIGRATION_00_55_00.md)
+
+#### [Migrate to 0.67.0](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/migration_guides/0.67.0/MIGRATION_00_67_00.md)

--- a/repo_files/documentations/scatter_chart.md
+++ b/repo_files/documentations/scatter_chart.md
@@ -49,7 +49,6 @@ When you change the chart's state, it animates to the new state internally (usin
 ### ScatterTouchTooltipData
 |PropName|Description|default value|
 |:-------|:----------|:------------|
-|tooltipBgColor|background color of the tooltip bubble|Colors.white|
 |tooltipBorder|border of the tooltip bubble|BorderSide.none|
 |tooltipRoundedRadius|background corner radius of the tooltip bubble|4|
 |tooltipPadding|padding of the tooltip|EdgeInsets.symmetric(horizontal: 16, vertical: 8)|
@@ -59,6 +58,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |getTooltipItems|a callback that retrieve a [ScatterTooltipItem](#ScatterTooltipItem) by the given [ScatterSpot](#ScatterSpot) |defaultScatterTooltipItem|
 |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
 |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
+|getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [ScatterSpot](#ScatterSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
 
 ### ScatterTooltipItem
 |PropName|Description|default value|

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1085,7 +1085,7 @@ void main() {
 
       final tooltipData = BarTouchTooltipData(
         tooltipRoundedRadius: 8,
-        tooltipBgColor: const Color(0xf33f33f3),
+        getTooltipColor: (group) => const Color(0xf33f33f3),
         maxContentWidth: 80,
         rotateAngle: 12,
         tooltipBorder: const BorderSide(color: Color(0xf33f33f3), width: 2),
@@ -1282,7 +1282,7 @@ void main() {
 
       final tooltipData = BarTouchTooltipData(
         tooltipRoundedRadius: 8,
-        tooltipBgColor: const Color(0xf33f33f3),
+        getTooltipColor: (group) => const Color(0xf33f33f3),
         maxContentWidth: 80,
         rotateAngle: 12,
         direction: TooltipDirection.bottom,
@@ -1453,7 +1453,7 @@ void main() {
 
       final tooltipData = BarTouchTooltipData(
         tooltipRoundedRadius: 8,
-        tooltipBgColor: const Color(0xf33f33f3),
+        getTooltipColor: (group) => const Color(0xf33f33f3),
         maxContentWidth: 8000,
         rotateAngle: 12,
         fitInsideHorizontally: true,

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -1186,9 +1186,17 @@ List<LineTooltipItem?> lineChartGetTooltipItems(List<LineBarSpot> list) {
   return list.map((s) => lineTooltipItem1).toList();
 }
 
+Color lineChartGetGreenColor(LineBarSpot touchedSpot) {
+  return Colors.green;
+}
+
+Color lineChartGetRedColor(LineBarSpot touchedSpot) {
+  return Colors.red;
+}
+
 const LineTouchTooltipData lineTouchTooltipData1 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1198,7 +1206,7 @@ const LineTouchTooltipData lineTouchTooltipData1 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData1Clone = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1209,7 +1217,7 @@ const LineTouchTooltipData lineTouchTooltipData1Clone = LineTouchTooltipData(
 
 const LineTouchTooltipData lineTouchTooltipData2 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.red,
+  getTooltipColor: lineChartGetRedColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1219,7 +1227,7 @@ const LineTouchTooltipData lineTouchTooltipData2 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData3 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.2),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1230,7 +1238,7 @@ const LineTouchTooltipData lineTouchTooltipData3 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData4 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 13,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1241,7 +1249,7 @@ const LineTouchTooltipData lineTouchTooltipData4 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData5 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1252,7 +1260,7 @@ const LineTouchTooltipData lineTouchTooltipData5 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData6 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -1264,7 +1272,7 @@ const LineTouchTooltipData lineTouchTooltipData6 = LineTouchTooltipData(
 );
 const LineTouchTooltipData lineTouchTooltipData7 = LineTouchTooltipData(
   tooltipPadding: EdgeInsets.all(0.1),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: lineChartGetGreenColor,
   maxContentWidth: 12,
   getTooltipItems: lineChartGetTooltipItems,
   fitInsideHorizontally: true,
@@ -2240,6 +2248,14 @@ ScatterTooltipItem? scatterChartGetTooltipItems(ScatterSpot spots) {
   );
 }
 
+Color scatterChartGetTooltipGreenColor(ScatterSpot spots) {
+  return Colors.green; //Color
+}
+
+Color scatterChartGetTooltipRedColor(ScatterSpot spots) {
+  return Colors.red; //Color
+}
+
 final ScatterSpot scatterSpot1 = ScatterSpot(1, 40);
 final ScatterSpot scatterSpot1Clone = ScatterSpot(1, 40);
 final ScatterSpot scatterSpot2 = ScatterSpot(-4, -8);
@@ -2302,7 +2318,7 @@ final ScatterChartData scatterChartData1 = ScatterChartData(
       fitInsideHorizontally: true,
       fitInsideVertically: false,
       maxContentWidth: 33,
-      tooltipBgColor: Colors.white,
+      getTooltipColor: (touchedSpot) => Colors.white,
       tooltipPadding: const EdgeInsets.all(23),
       tooltipRoundedRadius: 534,
     ),
@@ -2341,7 +2357,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2352,7 +2368,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData1Clone =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2363,7 +2379,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData2 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2375,7 +2391,7 @@ final ScatterTouchTooltipData scatterTouchTooltipData3 =
     ScatterTouchTooltipData(
   tooltipRoundedRadius: 23,
   tooltipPadding: const EdgeInsets.all(11),
-  tooltipBgColor: Colors.green,
+  getTooltipColor: scatterChartGetTooltipGreenColor,
   maxContentWidth: 33,
   fitInsideVertically: true,
   fitInsideHorizontally: false,
@@ -2749,12 +2765,24 @@ BarTooltipItem getTooltipItem(
   return BarTooltipItem(rod.toY.toString(), textStyle);
 }
 
+Color getTooltipGreenColor(
+  BarChartGroupData group,
+) {
+  return Colors.green;
+}
+
+Color getTooltipBlueColor(
+  BarChartGroupData group,
+) {
+  return Colors.blue;
+}
+
 final BarTouchTooltipData barTouchTooltipData1 = BarTouchTooltipData(
   tooltipRoundedRadius: 12,
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2765,7 +2793,7 @@ final BarTouchTooltipData barTouchTooltipData1Clone = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2776,7 +2804,7 @@ final BarTouchTooltipData barTouchTooltipData2 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2788,7 +2816,7 @@ final BarTouchTooltipData barTouchTooltipData3 = BarTouchTooltipData(
   fitInsideVertically: true,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2800,7 +2828,7 @@ final BarTouchTooltipData barTouchTooltipData4 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: false,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2812,7 +2840,7 @@ final BarTouchTooltipData barTouchTooltipData5 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23.00001,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2825,7 +2853,7 @@ final BarTouchTooltipData barTouchTooltipData6 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.blue,
+  getTooltipColor: getTooltipBlueColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2838,7 +2866,7 @@ final BarTouchTooltipData barTouchTooltipData7 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2850,7 +2878,7 @@ final BarTouchTooltipData barTouchTooltipData8 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   tooltipMargin: 12,
   tooltipBorder: const BorderSide(color: Colors.red),
@@ -2860,7 +2888,7 @@ final BarTouchTooltipData barTouchTooltipData9 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 333,
@@ -2871,7 +2899,7 @@ final BarTouchTooltipData barTouchTooltipData10 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,
@@ -2882,7 +2910,7 @@ final BarTouchTooltipData barTouchTooltipData11 = BarTouchTooltipData(
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
-  tooltipBgColor: Colors.green,
+  getTooltipColor: getTooltipGreenColor,
   tooltipPadding: const EdgeInsets.all(23),
   getTooltipItem: getTooltipItem,
   tooltipMargin: 12,

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2394,7 +2394,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        tooltipBgColor: const Color(0x11111111),
+        getTooltipColor: (touchedSpot) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,
@@ -2505,7 +2505,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        tooltipBgColor: const Color(0x11111111),
+        getTooltipColor: (touchedSpot) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,
@@ -2616,7 +2616,7 @@ void main() {
       );
 
       final tooltipData = LineTouchTooltipData(
-        tooltipBgColor: const Color(0x11111111),
+        getTooltipColor: (touchedSpot) => const Color(0x11111111),
         tooltipRoundedRadius: 12,
         rotateAngle: 43,
         maxContentWidth: 100,

--- a/test/chart/scatter_chart/scatter_chart_data_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_data_test.dart
@@ -386,7 +386,7 @@ void main() {
       final sample = ScatterTouchData(
         touchTooltipData: ScatterTouchTooltipData(
           maxContentWidth: 2,
-          tooltipBgColor: Colors.red,
+          getTooltipColor: scatterChartGetTooltipRedColor,
           tooltipPadding: const EdgeInsets.all(11),
         ),
         handleBuiltInTouches: false,
@@ -396,7 +396,7 @@ void main() {
       final sampleClone = ScatterTouchData(
         touchTooltipData: ScatterTouchTooltipData(
           maxContentWidth: 2,
-          tooltipBgColor: Colors.red,
+          getTooltipColor: scatterChartGetTooltipRedColor,
           tooltipPadding: const EdgeInsets.all(11),
         ),
         handleBuiltInTouches: false,

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -397,7 +397,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            tooltipBgColor: const Color(0xFF00FF00),
+            getTooltipColor: (touchedSpot) => const Color(0xFF00FF00),
             tooltipRoundedRadius: 85,
             tooltipPadding: const EdgeInsets.all(12),
             getTooltipItems: (_) {
@@ -499,7 +499,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            tooltipBgColor: const Color(0xFFFFFF00),
+            getTooltipColor: (touchedSpot) => const Color(0xFFFFFF00),
             tooltipRoundedRadius: 22,
             fitInsideHorizontally: false,
             fitInsideVertically: true,
@@ -606,7 +606,7 @@ void main() {
         scatterTouchData: ScatterTouchData(
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
-            tooltipBgColor: const Color(0xFFFFFF00),
+            getTooltipColor: (touchedSpot) => const Color(0xFFFFFF00),
             tooltipRoundedRadius: 22,
             fitInsideHorizontally: false,
             fitInsideVertically: true,


### PR DESCRIPTION
This PR is to replace this one: https://github.com/imaNNeo/fl_chart/pull/1348.

All credits goes to @apekshamehta

### Original description:

**Changes Made:**

In the bar_chart_data.dart file:

Added a new parameter getTooltipColor to the constructor of BarTouchTooltipData.
Defined a new type GetBarTooltipColor, which is a function that takes a BarChartGroupData parameter and returns a Color.
In the bar_chart_painter.dart file:

Assigned the tooltip color to the _bgTouchTooltipPaint.color property using the getTooltipColor function from the tooltipData object.
Additionally, the getTooltipColor function has been utilized in the bar_chart_sample1.dart file within the feature/dynamic-tooltip-bgcolor branch.

Please review the changes for this pull request.