### PR TITLE
added custom properties attribute to line chart bar data

### DIFF
--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -244,6 +244,7 @@ class LineChartBarData with EquatableMixin {
     this.shadow = const Shadow(color: Colors.transparent),
     this.isStepLineChart = false,
     this.lineChartStepData = const LineChartStepData(),
+    this.properties = const {},
   })  : color =
             color ?? ((color == null && gradient == null) ? Colors.cyan : null),
         belowBarData = belowBarData ?? BarAreaData(),
@@ -366,6 +367,9 @@ class LineChartBarData with EquatableMixin {
   /// Holds data for representing a Step Line Chart, and works only if [isStepChart] is true.
   final LineChartStepData lineChartStepData;
 
+  /// Holds custom properties for this [LineChartBarData], like curve title, subtitle that can be used in the tooltip, etc.
+  final Map<String, dynamic> properties;
+
   /// Lerps a [LineChartBarData] based on [t] value, check [Tween.lerp].
   static LineChartBarData lerp(
     LineChartBarData a,
@@ -397,6 +401,9 @@ class LineChartBarData with EquatableMixin {
       isStepLineChart: b.isStepLineChart,
       lineChartStepData:
           LineChartStepData.lerp(a.lineChartStepData, b.lineChartStepData, t),
+      properties: {}
+        ..addAll(a.properties)
+        ..addAll(b.properties),
     );
   }
 
@@ -422,6 +429,7 @@ class LineChartBarData with EquatableMixin {
     Shadow? shadow,
     bool? isStepLineChart,
     LineChartStepData? lineChartStepData,
+    Map<String, dynamic>? properties,
   }) {
     return LineChartBarData(
       spots: spots ?? this.spots,
@@ -445,6 +453,7 @@ class LineChartBarData with EquatableMixin {
       shadow: shadow ?? this.shadow,
       isStepLineChart: isStepLineChart ?? this.isStepLineChart,
       lineChartStepData: lineChartStepData ?? this.lineChartStepData,
+      properties: properties ?? this.properties,
     );
   }
 
@@ -470,6 +479,7 @@ class LineChartBarData with EquatableMixin {
         shadow,
         isStepLineChart,
         lineChartStepData,
+        properties,
       ];
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fl_chart
 description: A highly customizable Flutter chart library that supports Line Chart, Bar Chart, Pie Chart, Scatter Chart, and Radar Chart.
-version: 0.68.0
+version: 0.69.0
 homepage: https://flchart.dev/
 repository: https://github.com/imaNNeo/fl_chart
 issue_tracker: https://github.com/imaNNeo/fl_chart/issues


### PR DESCRIPTION
Hi, thanks for providing this awesome library. 
In this PR, I added a `properties` attribute as `Map<string, dynamic>` in order to store optional line curve parameters, like name or any other curve setting. by this change if you have multiple curves in a chart, now it's possible to show the name of each curve next to the value on the tooltip message.
![image](https://github.com/imaNNeo/fl_chart/assets/10116275/d9b9a0bf-d799-4a1e-8181-8052559afc8a)
