### PR TITLE
fixed touch detection to select topmost scatterspot 

### DIFF
--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -364,7 +364,8 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
   ) {
     final data = holder.data;
 
-    for (var i = 0; i < data.scatterSpots.length; i++) {
+    for (var i = data.scatterSpots.length - 1; i >= 0; i--) {
+      // Reverse the loop to check the topmost spot first
       final spot = data.scatterSpots[i];
 
       final spotPixelX = getPixelX(spot.x, viewSize, holder);


### PR DESCRIPTION
### Summary

This pull request fixes an issue with the touch detection logic in the scatter chart where the incorrect scatter spot is selected when multiple spots overlap. The current implementation selects the first matching spot in the list, which is visibly behind other spots, as the spots are rendered in chronological order (last spot in list rendered on "top). This change ensures that the topmost spot is selected when multiple spots overlap.

### Changes Made

- Updated the `handleTouch` method in `scatter_chart_painter.dart` to iterate through the scatter spots in reverse order. This ensures that the topmost spot is selected when multiple spots overlap.

### Rationale

In scatter charts, when multiple spots overlap, users expect to select the topmost spot. The previous implementation selected the first matching spot, which could be behind others if there are intersecting spots. By iterating through the spots in reverse order, the touch detection logic now correctly selects the topmost spot.

### Testing
- Verified that the touch detection now selects the topmost spot correctly when multiple spots overlap.

### Screenshots (if applicable)
In the below screenshot, the light blue spot was not previously selectable as the larger orange spot (being rendered earlier) was always returned first by handleTouch. With this change, the spots are able to be selected as one would expect (topmost first). 

<img width="1004" alt="Screenshot 2024-05-29 at 12 43 19 PM" src="https://github.com/imaNNeo/fl_chart/assets/12536871/6bf6457f-fb34-4ea8-928f-5191fba5c170">


### Checklist

- [x] I have tested the changes locally and they work as expected.
- [x] I have ensured that my code follows the code style of this project.



