### PR TITLE
Add isMinValueAtCenter property to RadarChartData

### DIFF
--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -203,6 +203,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? tickBorderData,
     BorderSide? gridBorderData,
     RadarTouchData? radarTouchData,
+    bool? isMinValueAtCenter,
     FlBorderData? borderData,
   }) =>
       RadarChartData(
@@ -219,6 +220,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         tickBorderData: tickBorderData ?? this.tickBorderData,
         gridBorderData: gridBorderData ?? this.gridBorderData,
         radarTouchData: radarTouchData ?? this.radarTouchData,
+        isMinValueAtCenter: isMinValueAtCenter ?? this.isMinValueAtCenter,
         borderData: borderData ?? this.borderData,
       );
 
@@ -245,6 +247,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         radarShape: b.radarShape,
         tickBorderData: BorderSide.lerp(a.tickBorderData, b.tickBorderData, t),
         borderData: FlBorderData.lerp(a.borderData, b.borderData, t),
+        isMinValueAtCenter: b.isMinValueAtCenter,
         radarTouchData: b.radarTouchData,
       );
     } else {
@@ -269,6 +272,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         tickBorderData,
         gridBorderData,
         radarTouchData,
+        isMinValueAtCenter,
       ];
 }
 

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -70,6 +70,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? tickBorderData,
     BorderSide? gridBorderData,
     RadarTouchData? radarTouchData,
+    this.isMinValueAtCenter = false,
     super.borderData,
   })  : assert(dataSets != null && dataSets.hasEqualDataEntriesLength),
         assert(
@@ -153,6 +154,9 @@ class RadarChartData extends BaseChartData with EquatableMixin {
 
   /// Handles touch behaviors and responses.
   final RadarTouchData radarTouchData;
+
+  /// If [isMinValueAtCenter] is true, the minimum value of the [RadarChart] will be at the center of the chart.
+  final bool isMinValueAtCenter;
 
   /// [titleCount] we use this value to determine number of [RadarChart] grid or lines.
   int get titleCount => dataSets[0].dataEntries.length;

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -76,6 +76,11 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
   double getChartCenterValue(RadarChartData data) {
     final dataSetMaxValue = data.maxEntry.value;
     final dataSetMinValue = data.minEntry.value;
+
+    if (data.isMinValueAtCenter) {
+      return dataSetMinValue;
+    }
+
     final tickSpace = getSpaceBetweenTicks(data);
     final centerValue = dataSetMinValue - tickSpace;
 
@@ -100,6 +105,10 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
   @visibleForTesting
   double getFirstTickValue(RadarChartData data) {
     final defaultCenterValue = getDefaultChartCenterValue();
+    if (data.isMinValueAtCenter) {
+      return defaultCenterValue;
+    }
+
     final dataSetMaxValue = data.maxEntry.value;
     final dataSetMinValue = data.minEntry.value;
 
@@ -111,9 +120,14 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
 
   @visibleForTesting
   double getSpaceBetweenTicks(RadarChartData data) {
-    final defaultCenterValue = getDefaultChartCenterValue();
     final dataSetMaxValue = data.maxEntry.value;
     final dataSetMinValue = data.minEntry.value;
+
+    if (data.isMinValueAtCenter) {
+      return (dataSetMaxValue - dataSetMinValue) / (data.tickCount);
+    }
+
+    final defaultCenterValue = getDefaultChartCenterValue();
     final tickSpace = (dataSetMaxValue - dataSetMinValue) / data.tickCount;
     final defaultTickSpace =
         (dataSetMaxValue - defaultCenterValue) / (data.tickCount + 1);
@@ -171,7 +185,9 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
       tickValue += tickSpace;
     }
 
-    final tickDistance = radius / (ticks.length);
+    final tickDistance = data.isMinValueAtCenter
+        ? radius / (ticks.length - 1)
+        : radius / ticks.length;
 
     _tickPaint
       ..color = data.tickBorderData.color
@@ -180,7 +196,8 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
     /// draw radar ticks
     ticks.sublist(0, ticks.length - 1).asMap().forEach(
       (index, tick) {
-        final tickRadius = tickDistance * (index + 1);
+        final tickRadius =
+            tickDistance * (index + (data.isMinValueAtCenter ? 0 : 1));
         if (data.radarShape == RadarShape.circle) {
           canvasWrapper.drawCircle(centerOffset, tickRadius, _tickPaint);
         } else {

--- a/repo_files/documentations/radar_chart.md
+++ b/repo_files/documentations/radar_chart.md
@@ -31,6 +31,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |tickBorderData|Style of the tick borders|BorderSide(color: Colors.black, width: 2)|
 |gridBorderData|Style of the grid borders|BorderSide(color: Colors.black, width: 2)|
 |radarTouchData|[RadarTouchData](#radartouchdata-read-about-touch-handling) handles the touch behaviors and responses.|RadarTouchData()|
+|isMinValueAtCenter|If true, the minimum value of the [RadarChart] will be at the center of the chart.|false|
 
 ### RadarDataSet
 |PropName		|Description	|default value|


### PR DESCRIPTION
### Summary
This PR adds the `isMinValueAtCenter` flag to the `RadarChartPainter` class to allow the minimum value to be centered in the RadarChart.

### Related Issues
- Fixes #1351 
- Fixes #1442

### Changes
- Added `isMinValueAtCenter` flag to `RadarChartData`
- Updated `RadarChartPainter` methods to support centering the minimum value when `isMinValueAtCenter` is true

### isMinValueAtCenter Comparison

<table>
  <tr>
    <td><strong>isMinValueAtCenter is false</strong></td>
    <td><strong>isMinValueAtCenter is true</strong></td>
  </tr>
  <tr>
    <td><img src="https://github.com/imaNNeo/fl_chart/assets/17955947/5c505453-9ef6-4b79-a03b-2bcf1369d8fe" alt="isMinValueAtCenter is false" width="300"/></td>
    <td><img src="https://github.com/imaNNeo/fl_chart/assets/17955947/83ac2f04-f78f-4781-acce-47ea54cf24dc" alt="isMinValueAtCenter is true" width="300"/></td>
  </tr>
</table>
