### PR TITLE
added detectScale to FlTouchData flag and scale gesture detection option

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -587,6 +587,9 @@ class BackgroundBarChartRodData with EquatableMixin {
 class BarTouchData extends FlTouchData<BarTouchResponse> with EquatableMixin {
   /// You can disable or enable the touch system using [enabled] flag,
   ///
+  /// You can disable or enable the scale detection using [detectScale] flag,
+  /// detecting scale gesture will disable pan gesture detection
+  ///
   /// [touchCallback] notifies you about the happened touch/pointer events.
   /// It gives you a [FlTouchEvent] which is the happened event such as [FlPointerHoverEvent], [FlTapUpEvent], ...
   /// It also gives you a [BarTouchResponse] which contains information
@@ -603,6 +606,7 @@ class BarTouchData extends FlTouchData<BarTouchResponse> with EquatableMixin {
   /// on [BarChartRodData.backDrawRodData] too (by default it only works on the main rods).
   BarTouchData({
     bool? enabled,
+    bool? detectScale,
     BaseTouchCallback<BarTouchResponse>? touchCallback,
     MouseCursorResolver<BarTouchResponse>? mouseCursorResolver,
     Duration? longPressDuration,
@@ -619,6 +623,7 @@ class BarTouchData extends FlTouchData<BarTouchResponse> with EquatableMixin {
           touchCallback,
           mouseCursorResolver,
           longPressDuration,
+          detectScale ?? false,
         );
 
   /// Configs of how touch tooltip popup.

--- a/lib/src/chart/base/base_chart/base_chart_data.dart
+++ b/lib/src/chart/base/base_chart/base_chart_data.dart
@@ -90,10 +90,15 @@ abstract class FlTouchData<R extends BaseTouchResponse> with EquatableMixin {
     this.touchCallback,
     this.mouseCursorResolver,
     this.longPressDuration,
+    this.detectScale,
   );
 
   /// You can disable or enable the touch system using [enabled] flag,
   final bool enabled;
+
+  /// You can disable or enable the scale detection using [detectScale] flag,
+  /// detecting scale gesture will disable pan gesture detection
+  final bool detectScale;
 
   /// [touchCallback] notifies you about the happened touch/pointer events.
   /// It gives you a [FlTouchEvent] which is the happened event such as [FlPointerHoverEvent], [FlTapUpEvent], ...

--- a/lib/src/chart/base/base_chart/fl_touch_event.dart
+++ b/lib/src/chart/base/base_chart/fl_touch_event.dart
@@ -38,6 +38,33 @@ abstract class FlTouchEvent {
   }
 }
 
+class FlScaleStartEvent extends FlTouchEvent {
+  const FlScaleStartEvent(this.details);
+
+  final ScaleStartDetails details;
+
+  @override
+  Offset get localPosition => details.focalPoint;
+}
+
+class FlScaleUpdateEvent extends FlTouchEvent {
+  const FlScaleUpdateEvent(this.details);
+
+  final ScaleUpdateDetails details;
+
+  @override
+  Offset get localPosition => details.focalPoint;
+}
+
+class FlScaleEndEvent extends FlTouchEvent {
+  const FlScaleEndEvent(this.details);
+
+  final ScaleEndDetails details;
+
+  @override
+  Offset get localPosition => Offset.zero;
+}
+
 /// When a pointer has contacted the screen and might begin to move
 ///
 /// The [details] object provides the position of the touch.

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -856,6 +856,9 @@ abstract class FlLineLabel with EquatableMixin {
 class LineTouchData extends FlTouchData<LineTouchResponse> with EquatableMixin {
   /// You can disable or enable the touch system using [enabled] flag,
   ///
+  /// You can disable or enable the scale detection using [detectScale] flag,
+  /// detecting scale gesture will disable pan gesture detection
+  ///
   /// [touchCallback] notifies you about the happened touch/pointer events.
   /// It gives you a [FlTouchEvent] which is the happened event such as [FlPointerHoverEvent], [FlTapUpEvent], ...
   /// It also gives you a [LineTouchResponse] which contains information
@@ -873,6 +876,7 @@ class LineTouchData extends FlTouchData<LineTouchResponse> with EquatableMixin {
   /// If you need to have a distance threshold for handling touches, use [touchSpotThreshold].
   const LineTouchData({
     bool enabled = true,
+    bool detectScale = false,
     BaseTouchCallback<LineTouchResponse>? touchCallback,
     MouseCursorResolver<LineTouchResponse>? mouseCursorResolver,
     Duration? longPressDuration,
@@ -888,6 +892,7 @@ class LineTouchData extends FlTouchData<LineTouchResponse> with EquatableMixin {
           touchCallback,
           mouseCursorResolver,
           longPressDuration,
+          detectScale,
         );
 
   /// Configs of how touch tooltip popup.

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -296,6 +296,9 @@ class PieChartSectionData {
 class PieTouchData extends FlTouchData<PieTouchResponse> with EquatableMixin {
   /// You can disable or enable the touch system using [enabled] flag,
   ///
+  /// You can disable or enable the scale detection using [detectScale] flag,
+  /// detecting scale gesture will disable pan gesture detection
+  ///
   /// [touchCallback] notifies you about the happened touch/pointer events.
   /// It gives you a [FlTouchEvent] which is the happened event such as [FlPointerHoverEvent], [FlTapUpEvent], ...
   /// It also gives you a [PieTouchResponse] which contains information
@@ -305,6 +308,7 @@ class PieTouchData extends FlTouchData<PieTouchResponse> with EquatableMixin {
   /// based on the provided [FlTouchEvent] and [PieTouchResponse]
   PieTouchData({
     bool? enabled,
+    bool? detectScale,
     BaseTouchCallback<PieTouchResponse>? touchCallback,
     MouseCursorResolver<PieTouchResponse>? mouseCursorResolver,
     Duration? longPressDuration,
@@ -313,6 +317,7 @@ class PieTouchData extends FlTouchData<PieTouchResponse> with EquatableMixin {
           touchCallback,
           mouseCursorResolver,
           longPressDuration,
+          detectScale ?? false,
         );
 
   /// Used for equality check, see [EquatableMixin].

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -382,6 +382,12 @@ class RadarTouchData extends FlTouchData<RadarTouchResponse>
     with EquatableMixin {
   /// You can disable or enable the touch system using [enabled] flag,
   ///
+  /// You can disable or enable the scale detection using [detectScale] flag,
+  /// detecting scale gesture will disable pan gesture detection
+  ///
+  /// You can disable or enable the scale detection using [detectScale] flag,
+  /// detecting scale gesture will disable pan gesture detection
+  ///
   /// [touchCallback] notifies you about the happened touch/pointer events.
   /// It gives you a [FlTouchEvent] which is the happened event such as [FlPointerHoverEvent], [FlTapUpEvent], ...
   /// It also gives you a [RadarTouchResponse] which contains information
@@ -391,6 +397,7 @@ class RadarTouchData extends FlTouchData<RadarTouchResponse>
   /// based on the provided [FlTouchEvent] and [RadarTouchResponse]
   RadarTouchData({
     bool? enabled,
+    bool? detectScale = false,
     BaseTouchCallback<RadarTouchResponse>? touchCallback,
     MouseCursorResolver<RadarTouchResponse>? mouseCursorResolver,
     Duration? longPressDuration,
@@ -401,6 +408,7 @@ class RadarTouchData extends FlTouchData<RadarTouchResponse>
           touchCallback,
           mouseCursorResolver,
           longPressDuration,
+          detectScale ?? false,
         );
 
   /// we find the nearest spots on touched position based on this threshold

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -263,6 +263,9 @@ class ScatterTouchData extends FlTouchData<ScatterTouchResponse>
     with EquatableMixin {
   /// You can disable or enable the touch system using [enabled] flag,
   ///
+  /// You can disable or enable the scale detection using [detectScale] flag,
+  /// detecting scale gesture will disable pan gesture detection
+  ///
   /// [touchCallback] notifies you about the happened touch/pointer events.
   /// It gives you a [FlTouchEvent] which is the happened event such as [FlPointerHoverEvent], [FlTapUpEvent], ...
   /// It also gives you a [ScatterTouchResponse] which contains information
@@ -278,6 +281,7 @@ class ScatterTouchData extends FlTouchData<ScatterTouchResponse>
   /// If you need to have a distance threshold for handling touches, use [touchSpotThreshold].
   ScatterTouchData({
     bool? enabled,
+    bool? detectScale,
     BaseTouchCallback<ScatterTouchResponse>? touchCallback,
     MouseCursorResolver<ScatterTouchResponse>? mouseCursorResolver,
     Duration? longPressDuration,
@@ -292,6 +296,7 @@ class ScatterTouchData extends FlTouchData<ScatterTouchResponse>
           touchCallback,
           mouseCursorResolver,
           longPressDuration,
+          detectScale ?? false,
         );
 
   /// show a tooltip on touched spots


### PR DESCRIPTION
added detectScale to FlTouchData flag and scale gesture detection option in the touch callback to all charts.

enabling scale detection and pan gesture detection is not supported, so enabling scale detection will disable pan detection and vice versa

related issues:
This PR addresses the problem described in issue #1720 and #71




