### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
-## newVersion
-* **BUGFIX** Fix a memory leak issue in the axis-based charts, there was a logic to calculate and cache the minX, maxX, minY and maxY properties to reduce the computation cost. But it caused some memory issues, as we don't have a quick solution for this, we disabled the caching logic for now, later we can move the calculation logic to the render objects to keep and update them only when the data is changed, #1106, #1693
-* **BUGFIX** Fix showing grid lines even when there is no line to show in the LineChart, #1691
+## 0.69.0
+* **BUGFIX** (by @imaNNeo) Fix a memory leak issue in the axis-based charts, there was a logic to calculate and cache the minX, maxX, minY and maxY properties to reduce the computation cost. But it caused some memory issues, as we don't have a quick solution for this, we disabled the caching logic for now, later we can move the calculation logic to the render objects to keep and update them only when the data is changed, #1106, #1693
+* **BUGFIX**  (by @imaNNeo) Fix showing grid lines even when there is no line to show in the LineChart, #1691
 * **IMPROVEMENT** (by @sczesla) Allow users to control minIncluded and maxIncluded using SideTitles, #906
 * **IMPROVEMENT** (by @elizabethzhenliu) Reverse the touch order in ScatterChart, so now the top spots are touched first, #1675
 * **IMPROVEMENT** (by @ksw2000) Remove redundant math import, #1683


### PR DESCRIPTION
## 0.69.0
* **BUGFIX** (by @imaNNeo) Fix a memory leak issue in the axis-based charts, there was a logic to calculate and cache the minX, maxX, minY and maxY properties to reduce the computation cost. But it caused some memory issues, as we don't have a quick solution for this, we disabled the caching logic for now, later we can move the calculation logic to the render objects to keep and update them only when the data is changed, #1106, #1693
* **BUGFIX**  (by @imaNNeo) Fix showing grid lines even when there is no line to show in the LineChart, #1691
* **IMPROVEMENT** (by @sczesla) Allow users to control minIncluded and maxIncluded using SideTitles, #906
* **IMPROVEMENT** (by @elizabethzhenliu) Reverse the touch order in ScatterChart, so now the top spots are touched first, #1675
* **IMPROVEMENT** (by @ksw2000) Remove redundant math import, #1683
* **IMPROVEMENT** (by @Neer-Pathak) Fix linux example build issue, #1668
* **IMPROVEMENT** (by @TobiasRump) Update the bar chart documentation, #1662
