### PR TITLE
Fix section with zero problems in PieChart

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -31,8 +31,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
     bool? titleSunbeamLayout,
-  })  : sections = sections?.where((element) => element.value != 0).toList() ??
-            const [],
+  })  : sections = sections ?? const [],
         centerSpaceRadius = centerSpaceRadius ?? double.infinity,
         centerSpaceColor = centerSpaceColor ?? Colors.transparent,
         sectionsSpace = sectionsSpace ?? 2,

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -60,6 +60,10 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     List<PieChartSectionData> sections,
     double sumValue,
   ) {
+    if (sumValue == 0) {
+      return List<double>.filled(sections.length, 0);
+    }
+
     return sections.map((section) {
       return 360 * (section.value / sumValue);
     }).toList();
@@ -100,6 +104,9 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
 
     for (var i = 0; i < data.sections.length; i++) {
       final section = data.sections[i];
+      if (section.value == 0) {
+        continue;
+      }
       final sectionDegree = sectionsAngle[i];
 
       if (sectionDegree == 360) {
@@ -358,6 +365,9 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
 
     for (var i = 0; i < data.sections.length; i++) {
       final section = data.sections[i];
+      if (section.value == 0) {
+        continue;
+      }
       final startAngle = tempAngle;
       final sweepAngle = 360 * (section.value / data.sumValue);
       final sectionCenterAngle = startAngle + (sweepAngle / 2);

--- a/lib/src/chart/pie_chart/pie_chart_renderer.dart
+++ b/lib/src/chart/pie_chart/pie_chart_renderer.dart
@@ -143,7 +143,20 @@ class RenderPieChart extends RenderBaseChart<PieTouchResponse>
       paintHolder,
     );
     canvas.restore();
-    defaultPaint(context, offset);
+    badgeWidgetPaint(context, offset);
+  }
+
+  void badgeWidgetPaint(PaintingContext context, Offset offset) {
+    RenderObject? child = firstChild;
+    var counter = 0;
+    while (child != null) {
+      final childParentData = child.parentData! as MultiChildLayoutParentData;
+      if (data.sections[counter].value > 0) {
+        context.paintChild(child, childParentData.offset + offset);
+      }
+      child = childParentData.nextSibling;
+      counter++;
+    }
   }
 
   @override


### PR DESCRIPTION
### Summary

This pull request addresses issues related to #697, #817 and #1632.

### Changes Made

- Removed the filter that excluded sections with a value of 0 in `PieChartData`.
- Ensured that `calculateSectionsAngle` does not return NaN values.
- Skipped the rendering of sections with a value of 0.
- Created a custom `badgeWidgetPaint` function to skip the rendering of the `badgeWidget` for sections with a value of 0.