### PR TITLE
custom border radius in BarTouchTooltipData

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -714,7 +714,8 @@ class BarTouchTooltipData with EquatableMixin {
   /// [BarChart] shows a tooltip popup on top of rods automatically when touch happens,
   /// otherwise you can show it manually using [BarChartGroupData.showingTooltipIndicators].
   /// Tooltip shows on top of rods, with [getTooltipColor] as a background color,
-  /// and you can set corner radius using [tooltipRoundedRadius].
+  /// and you can set corner radius using [tooltipRoundedRadius], of if you need a custom
+  /// border you can use [tooltipBorderRadius].
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding],
   /// or If you want to have a bottom margin, set [tooltipMargin].
   /// Content of the tooltip will provide using [getTooltipItem] callback, you can override it
@@ -725,6 +726,7 @@ class BarTouchTooltipData with EquatableMixin {
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   BarTouchTooltipData({
     double? tooltipRoundedRadius,
+    BorderRadius? tooltipBorderRadius,
     EdgeInsets? tooltipPadding,
     double? tooltipMargin,
     FLHorizontalAlignment? tooltipHorizontalAlignment,
@@ -738,6 +740,8 @@ class BarTouchTooltipData with EquatableMixin {
     double? rotateAngle,
     BorderSide? tooltipBorder,
   })  : tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
+        tooltipBorderRadius = tooltipBorderRadius ??
+            BorderRadius.circular(tooltipRoundedRadius ?? 4),
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         tooltipMargin = tooltipMargin ?? 16,
@@ -756,6 +760,9 @@ class BarTouchTooltipData with EquatableMixin {
 
   /// Sets a rounded radius for the tooltip.
   final double tooltipRoundedRadius;
+
+  /// Sets a border radius for the tooltip.
+  final BorderRadius tooltipBorderRadius;
 
   /// Applies a padding for showing contents inside the tooltip.
   final EdgeInsets tooltipPadding;
@@ -797,6 +804,7 @@ class BarTouchTooltipData with EquatableMixin {
   @override
   List<Object?> get props => [
         tooltipRoundedRadius,
+        tooltipBorderRadius,
         tooltipPadding,
         tooltipMargin,
         tooltipHorizontalAlignment,

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -713,9 +713,11 @@ class BarTouchTooltipData with EquatableMixin {
   /// if [BarTouchData.handleBuiltInTouches] is true,
   /// [BarChart] shows a tooltip popup on top of rods automatically when touch happens,
   /// otherwise you can show it manually using [BarChartGroupData.showingTooltipIndicators].
-  /// Tooltip shows on top of rods, with [getTooltipColor] as a background color,
-  /// and you can set corner radius using [tooltipRoundedRadius], of if you need a custom
-  /// border you can use [tooltipBorderRadius].
+  /// Tooltip shows on top of rods, with [getTooltipColor] as a background color.
+  /// You can set the corner radius using [tooltipRoundedRadius], 
+  /// or if you need a custom border, you can use [tooltipBorderRadius].
+  /// Note that if both [tooltipRoundedRadius] and [tooltipBorderRadius] are set, 
+  /// the value from [tooltipBorderRadius] will be used.
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding],
   /// or If you want to have a bottom margin, set [tooltipMargin].
   /// Content of the tooltip will provide using [getTooltipItem] callback, you can override it

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -761,6 +761,7 @@ class BarTouchTooltipData with EquatableMixin {
         super();
 
   /// Sets a rounded radius for the tooltip.
+  @Deprecated('use tooltipBorderRadius instead')
   final double tooltipRoundedRadius;
 
   /// Sets a border radius for the tooltip.

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -575,13 +575,12 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       }
     }
 
-    final radius = Radius.circular(tooltipData.tooltipRoundedRadius);
     final roundedRect = RRect.fromRectAndCorners(
       rect,
-      topLeft: radius,
-      topRight: radius,
-      bottomLeft: radius,
-      bottomRight: radius,
+      topLeft: tooltipData.tooltipBorderRadius.topLeft,
+      topRight: tooltipData.tooltipBorderRadius.topRight,
+      bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
+      bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
 
     /// set tooltip's background color for each rod

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1035,8 +1035,11 @@ class LineTouchTooltipData with EquatableMixin {
   /// if [LineTouchData.handleBuiltInTouches] is true,
   /// [LineChart] shows a tooltip popup on top of spots automatically when touch happens,
   /// otherwise you can show it manually using [LineChartData.showingTooltipIndicators].
-  /// Tooltip shows on top of spots, with [getTooltipColor] as a background color,
-  /// and you can set corner radius using [tooltipRoundedRadius].
+  /// Tooltip shows on top of rods, with [getTooltipColor] as a background color.
+  /// You can set the corner radius using [tooltipRoundedRadius],
+  /// or if you need a custom border, you can use [tooltipBorderRadius].
+  /// Note that if both [tooltipRoundedRadius] and [tooltipBorderRadius] are set,
+  /// the value from [tooltipBorderRadius] will be used.
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding],
   /// or If you want to have a bottom margin, set [tooltipMargin].
   /// Content of the tooltip will provide using [getTooltipItems] callback, you can override it
@@ -1046,7 +1049,8 @@ class LineTouchTooltipData with EquatableMixin {
   /// you can set [fitInsideHorizontally] true to force it to shift inside the chart horizontally,
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   const LineTouchTooltipData({
-    this.tooltipRoundedRadius = 4,
+    double? tooltipRoundedRadius = 4,
+    BorderRadius? tooltipBorderRadius,
     this.tooltipPadding =
         const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
     this.tooltipMargin = 16,
@@ -1060,10 +1064,18 @@ class LineTouchTooltipData with EquatableMixin {
     this.showOnTopOfTheChartBoxArea = false,
     this.rotateAngle = 0.0,
     this.tooltipBorder = BorderSide.none,
-  });
+  })  : tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
+        _tooltipBorderRadius = tooltipBorderRadius;
 
   /// Sets a rounded radius for the tooltip.
+  @Deprecated('use tooltipBorderRadius instead')
   final double tooltipRoundedRadius;
+
+  /// Sets a border radius for the tooltip.
+  final BorderRadius? _tooltipBorderRadius;
+
+  BorderRadius get tooltipBorderRadius =>
+      _tooltipBorderRadius ?? BorderRadius.circular(tooltipRoundedRadius);
 
   /// Applies a padding for showing contents inside the tooltip.
   final EdgeInsets tooltipPadding;
@@ -1105,6 +1117,7 @@ class LineTouchTooltipData with EquatableMixin {
   @override
   List<Object?> get props => [
         tooltipRoundedRadius,
+        _tooltipBorderRadius,
         tooltipPadding,
         tooltipMargin,
         tooltipHorizontalAlignment,

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1071,9 +1071,9 @@ class LineTouchTooltipData with EquatableMixin {
   @Deprecated('use tooltipBorderRadius instead')
   final double tooltipRoundedRadius;
 
-  /// Sets a border radius for the tooltip.
   final BorderRadius? _tooltipBorderRadius;
 
+  /// Sets a rounded radius for the tooltip.
   BorderRadius get tooltipBorderRadius =>
       _tooltipBorderRadius ?? BorderRadius.circular(tooltipRoundedRadius);
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1225,13 +1225,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       }
     }
 
-    final radius = Radius.circular(tooltipData.tooltipRoundedRadius);
     final roundedRect = RRect.fromRectAndCorners(
       rect,
-      topLeft: radius,
-      topRight: radius,
-      bottomLeft: radius,
-      bottomRight: radius,
+      topLeft: tooltipData.tooltipBorderRadius.topLeft,
+      topRight: tooltipData.tooltipBorderRadius.topRight,
+      bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
+      bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
 
     var topSpot = showingTooltipSpots.showingSpots[0];

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -433,8 +433,11 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// if [ScatterTouchData.handleBuiltInTouches] is true,
   /// [ScatterChart] shows a tooltip popup on top of spots automatically when touch happens,
   /// otherwise you can show it manually using [ScatterChartData.showingTooltipIndicators].
-  /// Tooltip shows on top of spots, with [getTooltipColor] as a background color,
-  /// and you can set corner radius using [tooltipRoundedRadius].
+  /// Tooltip shows on top of rods, with [getTooltipColor] as a background color.
+  /// You can set the corner radius using [tooltipRoundedRadius],
+  /// or if you need a custom border, you can use [tooltipBorderRadius].
+  /// Note that if both [tooltipRoundedRadius] and [tooltipBorderRadius] are set,
+  /// the value from [tooltipBorderRadius] will be used.
   /// If you want to have a padding inside the tooltip, fill [tooltipPadding].
   /// Content of the tooltip will provide using [getTooltipItems] callback, you can override it
   /// and pass your custom data to show in the tooltip.
@@ -444,6 +447,7 @@ class ScatterTouchTooltipData with EquatableMixin {
   /// also you can set [fitInsideVertically] true to force it to shift inside the chart vertically.
   ScatterTouchTooltipData({
     double? tooltipRoundedRadius,
+    BorderRadius? tooltipBorderRadius,
     EdgeInsets? tooltipPadding,
     FLHorizontalAlignment? tooltipHorizontalAlignment,
     double? tooltipHorizontalOffset,
@@ -455,6 +459,8 @@ class ScatterTouchTooltipData with EquatableMixin {
     BorderSide? tooltipBorder,
     GetScatterTooltipColor? getTooltipColor,
   })  : tooltipRoundedRadius = tooltipRoundedRadius ?? 4,
+        tooltipBorderRadius = tooltipBorderRadius ??
+            BorderRadius.circular(tooltipRoundedRadius ?? 4),
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
         tooltipHorizontalAlignment =
@@ -470,7 +476,11 @@ class ScatterTouchTooltipData with EquatableMixin {
         super();
 
   /// Sets a rounded radius for the tooltip.
+  @Deprecated('use tooltipBorderRadius instead')
   final double tooltipRoundedRadius;
+
+  /// Sets a border radius for the tooltip.
+  final BorderRadius tooltipBorderRadius;
 
   /// Applies a padding for showing contents inside the tooltip.
   final EdgeInsets tooltipPadding;

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -388,13 +388,12 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       }
     }
 
-    final radius = Radius.circular(tooltipData.tooltipRoundedRadius);
     final roundedRect = RRect.fromRectAndCorners(
       rect,
-      topLeft: radius,
-      topRight: radius,
-      bottomLeft: radius,
-      bottomRight: radius,
+      topLeft: tooltipData.tooltipBorderRadius.topLeft,
+      topRight: tooltipData.tooltipBorderRadius.topRight,
+      bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
+      bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
 
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnSpot);

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1789,7 +1789,10 @@ void main() {
       ];
 
       final tooltipData = BarTouchTooltipData(
-        tooltipRoundedRadius: 8,
+        tooltipBorderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(10),
+          topRight: Radius.circular(8),
+        ),
         getTooltipColor: (group) => const Color(0xf33f33f3),
         maxContentWidth: 80,
         rotateAngle: 12,
@@ -1877,7 +1880,10 @@ void main() {
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
             ..called(2);
       final rrect = result1.captured[0] as RRect;
-      expect(rrect.blRadius, const Radius.circular(8));
+      expect(rrect.tlRadius, const Radius.circular(10));
+      expect(rrect.trRadius, const Radius.circular(8));
+      expect(rrect.blRadius, Radius.zero);
+      expect(rrect.brRadius,  Radius.zero);
       expect(rrect.width, 112);
       expect(rrect.height, 90);
       expect(rrect.left, -80);
@@ -1890,7 +1896,10 @@ void main() {
       final rRectBorder = result1.captured[2] as RRect;
       final paintBorder = result1.captured[3] as Paint;
 
-      expect(rRectBorder.blRadius, const Radius.circular(8));
+      expect(rRectBorder.tlRadius, const Radius.circular(10));
+      expect(rRectBorder.trRadius, const Radius.circular(8));
+      expect(rRectBorder.blRadius, Radius.zero);
+      expect(rRectBorder.brRadius,  Radius.zero);
       expect(rRectBorder.width, 112);
       expect(rRectBorder.height, 90);
       expect(rRectBorder.left, -80);

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2815,6 +2815,7 @@ Color getTooltipBlueColor(
 
 final BarTouchTooltipData barTouchTooltipData1 = BarTouchTooltipData(
   tooltipRoundedRadius: 12,
+  tooltipBorderRadius: BorderRadius.circular(12),
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
@@ -2826,6 +2827,7 @@ final BarTouchTooltipData barTouchTooltipData1 = BarTouchTooltipData(
 );
 final BarTouchTooltipData barTouchTooltipData1Clone = BarTouchTooltipData(
   tooltipRoundedRadius: 12,
+  tooltipBorderRadius: BorderRadius.circular(12),
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,
@@ -2837,6 +2839,7 @@ final BarTouchTooltipData barTouchTooltipData1Clone = BarTouchTooltipData(
 );
 final BarTouchTooltipData barTouchTooltipData2 = BarTouchTooltipData(
   tooltipRoundedRadius: 13,
+  tooltipBorderRadius: BorderRadius.circular(13),
   fitInsideVertically: false,
   fitInsideHorizontally: true,
   maxContentWidth: 23,

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2730,7 +2730,10 @@ void main() {
 
       final tooltipData = LineTouchTooltipData(
         getTooltipColor: (touchedSpot) => const Color(0x11111111),
-        tooltipRoundedRadius: 12,
+        tooltipBorderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(10),
+          topRight: Radius.circular(8),
+        ),
         rotateAngle: 43,
         maxContentWidth: 100,
         tooltipMargin: 12,
@@ -2804,14 +2807,28 @@ void main() {
       final paint = result1.captured[1] as Paint;
       expect(
         rRect,
-        RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
+        RRect.fromLTRBAndCorners(
+          0,
+          40,
+          38,
+          78,
+          topLeft: const Radius.circular(10),
+          topRight: const Radius.circular(8),
+        ),
       );
       expect(paint.color, isSameColorAs(const Color(0x11111111)));
       final rRectBorder = result1.captured[2] as RRect;
       final paintBorder = result1.captured[3] as Paint;
       expect(
         rRectBorder,
-        RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
+        RRect.fromLTRBAndCorners(
+          0,
+          40,
+          38,
+          78,
+          topLeft: const Radius.circular(10),
+          topRight: const Radius.circular(8),
+        ),
       );
       expect(paintBorder.color, isSameColorAs(const Color(0x11111111)));
       expect(paintBorder.strokeWidth, 2);

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -398,7 +398,10 @@ void main() {
           touchTooltipData: ScatterTouchTooltipData(
             rotateAngle: 18,
             getTooltipColor: (touchedSpot) => const Color(0xFF00FF00),
-            tooltipRoundedRadius: 85,
+            tooltipBorderRadius: const BorderRadius.only(
+              topLeft: Radius.circular(85),
+              topRight: Radius.circular(8),
+            ),
             tooltipPadding: const EdgeInsets.all(12),
             getTooltipItems: (_) {
               return ScatterTooltipItem(
@@ -462,8 +465,10 @@ void main() {
       final bgPaint = captured2[0][1] as Paint;
       final textPainter = captured2[1][0] as TextPainter;
 
-      expect(rRect.blRadiusX, 85);
+      expect(rRect.blRadiusX, 0);
+      expect(rRect.blRadiusY, 0);
       expect(rRect.tlRadiusY, 85);
+      expect(rRect.trRadiusX, 8);
 
       expect(bgPaint.color, const Color(0xFF00FF00));
       expect(


### PR DESCRIPTION
**IMPROVEMENT** (by @MattiaPispisa) custom border radius in `BarTouchTooltipData`, `LineTouchTooltipData`, `ScatterTouchTooltipData` #1715