### PR TITLE
Add shadow to line chart's tooltip

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -736,6 +736,7 @@ class BarTouchTooltipData with EquatableMixin {
     TooltipDirection? direction,
     double? rotateAngle,
     BorderSide? tooltipBorder,
+    Shadow? shadow,
   })  : _tooltipBorderRadius = tooltipBorderRadius,
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -751,6 +752,7 @@ class BarTouchTooltipData with EquatableMixin {
         direction = direction ?? TooltipDirection.auto,
         rotateAngle = rotateAngle ?? 0.0,
         tooltipBorder = tooltipBorder ?? BorderSide.none,
+        shadow = shadow ?? const Shadow(color: Colors.transparent),
         super();
 
   /// Sets a rounded radius for the tooltip.
@@ -795,6 +797,9 @@ class BarTouchTooltipData with EquatableMixin {
 
   /// Retrieves data for setting background color of the tooltip.
   final GetBarTooltipColor getTooltipColor;
+
+  /// The shadow of the tooltip.
+  final Shadow shadow;
 
   /// Used for equality check, see [EquatableMixin].
   @override

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -36,6 +36,10 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       ..strokeWidth = 1.0;
 
     _clipPaint = Paint();
+
+    _shadowTouchTooltipPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = Colors.black;
   }
 
   late Paint _barPaint;
@@ -43,6 +47,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
   late Paint _bgTouchTooltipPaint;
   late Paint _borderTouchTooltipPaint;
   late Paint _clipPaint;
+  late Paint _shadowTouchTooltipPaint;
 
   List<GroupBarsPosition>? _groupBarsPosition;
 
@@ -582,9 +587,23 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
       bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
+    final shadowRoundedRect = RRect.fromRectAndCorners(
+      rect.shift(tooltipData.shadow.offset),
+      topLeft: tooltipData.tooltipBorderRadius.topLeft,
+      topRight: tooltipData.tooltipBorderRadius.topRight,
+      bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
+      bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
+    );
 
     /// set tooltip's background color for each rod
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnBarGroup);
+
+    _shadowTouchTooltipPaint
+      ..color = tooltipData.shadow.color
+      ..maskFilter = MaskFilter.blur(
+        BlurStyle.normal,
+        tooltipData.shadow.blurRadius,
+      );
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =
@@ -615,6 +634,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       angle: reverseQuarterTurnsAngle + rotateAngle,
       drawCallback: () {
         canvasWrapper
+          ..drawRRect(shadowRoundedRect, _shadowTouchTooltipPaint)
           ..drawRRect(roundedRect, _bgTouchTooltipPaint)
           ..drawRRect(roundedRect, _borderTouchTooltipPaint)
           ..drawText(tp, drawOffset);

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1059,6 +1059,9 @@ class LineTouchTooltipData with EquatableMixin {
     this.showOnTopOfTheChartBoxArea = false,
     this.rotateAngle = 0.0,
     this.tooltipBorder = BorderSide.none,
+    this.shadowColor = Colors.transparent,
+    this.shadowBlur = 5,
+    this.shadowOffset = Offset.zero,
   }) : _tooltipBorderRadius = tooltipBorderRadius;
 
   /// Sets a rounded radius for the tooltip.
@@ -1104,6 +1107,15 @@ class LineTouchTooltipData with EquatableMixin {
   // /// Retrieves data for setting background color of the tooltip.
   final GetLineTooltipColor getTooltipColor;
 
+  /// The shadow color of the tooltip.
+  final Color shadowColor;
+
+  /// The sigma value of shadow blur of the tooltip.
+  final double shadowBlur;
+
+  /// The shadow offset of the tooltip.
+  final Offset shadowOffset;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
@@ -1120,6 +1132,9 @@ class LineTouchTooltipData with EquatableMixin {
         rotateAngle,
         tooltipBorder,
         getTooltipColor,
+        shadowColor,
+        shadowBlur,
+        shadowOffset,
       ];
 }
 

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1059,9 +1059,7 @@ class LineTouchTooltipData with EquatableMixin {
     this.showOnTopOfTheChartBoxArea = false,
     this.rotateAngle = 0.0,
     this.tooltipBorder = BorderSide.none,
-    this.shadowColor = Colors.transparent,
-    this.shadowBlur = 5,
-    this.shadowOffset = Offset.zero,
+    this.shadow = const Shadow(color: Colors.transparent),
   }) : _tooltipBorderRadius = tooltipBorderRadius;
 
   /// Sets a rounded radius for the tooltip.
@@ -1107,14 +1105,8 @@ class LineTouchTooltipData with EquatableMixin {
   // /// Retrieves data for setting background color of the tooltip.
   final GetLineTooltipColor getTooltipColor;
 
-  /// The shadow color of the tooltip.
-  final Color shadowColor;
-
-  /// The sigma value of shadow blur of the tooltip.
-  final double shadowBlur;
-
-  /// The shadow offset of the tooltip.
-  final Offset shadowOffset;
+  /// The shadow of the tooltip.
+  final Shadow shadow;
 
   /// Used for equality check, see [EquatableMixin].
   @override
@@ -1132,9 +1124,7 @@ class LineTouchTooltipData with EquatableMixin {
         rotateAngle,
         tooltipBorder,
         getTooltipColor,
-        shadowColor,
-        shadowBlur,
-        shadowOffset,
+        shadow,
       ];
 }
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -47,6 +47,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       ..strokeWidth = 1.0;
 
     _clipPaint = Paint();
+
+    _shadowTouchTooltipPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = Colors.black;
   }
 
   late Paint _barPaint;

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1238,7 +1238,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
     final shadowRoundedRect = RRect.fromRectAndRadius(
-      rect.shift(tooltipData.shadowOffset),
+      rect.shift(tooltipData.shadow.offset),
       radius,
     );
 
@@ -1251,10 +1251,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
 
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(topSpot);
     _shadowTouchTooltipPaint
-      ..color = tooltipData.shadowColor
+      ..color = tooltipData.shadow.color
       ..maskFilter = MaskFilter.blur(
         BlurStyle.normal,
-        tooltipData.shadowBlur,
+        Utils().convertRadiusToSigma(tooltipData.shadow.blurRadius),
       );
 
     final rotateAngle = tooltipData.rotateAngle;

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1233,6 +1233,10 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
       bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
+    final shadowRoundedRect = RRect.fromRectAndRadius(
+      rect.shift(tooltipData.shadowOffset),
+      radius,
+    );
 
     var topSpot = showingTooltipSpots.showingSpots[0];
     for (final barSpot in showingTooltipSpots.showingSpots) {
@@ -1242,6 +1246,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     }
 
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(topSpot);
+    _shadowTouchTooltipPaint
+      ..color = tooltipData.shadowColor
+      ..maskFilter = MaskFilter.blur(
+        BlurStyle.normal,
+        tooltipData.shadowBlur,
+      );
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =
@@ -1264,6 +1274,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       angle: reverseQuarterTurnsAngle + rotateAngle,
       drawCallback: () {
         canvasWrapper
+          ..drawRRect(shadowRoundedRect, _shadowTouchTooltipPaint)
           ..drawRRect(roundedRect, _bgTouchTooltipPaint)
           ..drawRRect(roundedRect, _borderTouchTooltipPaint);
       },

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1237,9 +1237,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
       bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
-    final shadowRoundedRect = RRect.fromRectAndRadius(
+    final shadowRoundedRect = RRect.fromRectAndCorners(
       rect.shift(tooltipData.shadow.offset),
-      radius,
+      topLeft: tooltipData.tooltipBorderRadius.topLeft,
+      topRight: tooltipData.tooltipBorderRadius.topRight,
+      bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
+      bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
 
     var topSpot = showingTooltipSpots.showingSpots[0];

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -1254,7 +1254,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       ..color = tooltipData.shadow.color
       ..maskFilter = MaskFilter.blur(
         BlurStyle.normal,
-        Utils().convertRadiusToSigma(tooltipData.shadow.blurRadius),
+        tooltipData.shadow.blurSigma,
       );
 
     final rotateAngle = tooltipData.rotateAngle;

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -57,6 +57,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
   late Paint _bgTouchTooltipPaint;
   late Paint _borderTouchTooltipPaint;
   late Paint _clipPaint;
+  late Paint _shadowTouchTooltipPaint;
 
   /// Paints [LineChartData] into the provided canvas.
   @override

--- a/lib/src/chart/scatter_chart/scatter_chart_data.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_data.dart
@@ -462,6 +462,7 @@ class ScatterTouchTooltipData with EquatableMixin {
     double? rotateAngle,
     BorderSide? tooltipBorder,
     GetScatterTooltipColor? getTooltipColor,
+    Shadow? shadow,
   })  : _tooltipBorderRadius = tooltipBorderRadius,
         tooltipPadding = tooltipPadding ??
             const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
@@ -475,6 +476,7 @@ class ScatterTouchTooltipData with EquatableMixin {
         rotateAngle = rotateAngle ?? 0.0,
         tooltipBorder = tooltipBorder ?? BorderSide.none,
         getTooltipColor = getTooltipColor ?? defaultScatterTooltipColor,
+        shadow = shadow ?? const Shadow(color: Colors.transparent),
         super();
 
   /// Sets a rounded radius for the tooltip.
@@ -513,6 +515,9 @@ class ScatterTouchTooltipData with EquatableMixin {
 
   /// Retrieves data for showing content inside the tooltip.
   final GetScatterTooltipColor getTooltipColor;
+
+  /// The shadow of the tooltip.
+  final Shadow shadow;
 
   /// Used for equality check, see [EquatableMixin].
   @override

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -26,11 +26,16 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       ..strokeWidth = 1.0;
 
     _clipPaint = Paint();
+
+    _shadowTouchTooltipPaint = Paint()
+      ..style = PaintingStyle.fill
+      ..color = Colors.black;
   }
 
   late Paint _bgTouchTooltipPaint;
   late Paint _borderTouchTooltipPaint;
   late Paint _clipPaint;
+  late Paint _shadowTouchTooltipPaint;
 
   /// Paints [ScatterChartData] into the provided canvas.
   @override
@@ -396,7 +401,22 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
     );
 
+    final shadowRoundedRect = RRect.fromRectAndCorners(
+      rect.shift(tooltipData.shadow.offset),
+      topLeft: tooltipData.tooltipBorderRadius.topLeft,
+      topRight: tooltipData.tooltipBorderRadius.topRight,
+      bottomLeft: tooltipData.tooltipBorderRadius.bottomLeft,
+      bottomRight: tooltipData.tooltipBorderRadius.bottomRight,
+    );
+
     _bgTouchTooltipPaint.color = tooltipData.getTooltipColor(showOnSpot);
+
+    _shadowTouchTooltipPaint
+      ..color = tooltipData.shadow.color
+      ..maskFilter = MaskFilter.blur(
+        BlurStyle.normal,
+        tooltipData.shadow.blurRadius,
+      );
 
     final rotateAngle = tooltipData.rotateAngle;
     final rectRotationOffset =
@@ -428,6 +448,7 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
       angle: reverseQuarterTurnsAngle + rotateAngle,
       drawCallback: () {
         canvasWrapper
+          ..drawRRect(shadowRoundedRect, _shadowTouchTooltipPaint)
           ..drawRRect(roundedRect, _bgTouchTooltipPaint)
           ..drawRRect(roundedRect, _borderTouchTooltipPaint)
           ..drawText(drawingTextPainter, drawOffset);

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1675,20 +1675,35 @@ void main() {
       );
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rrect = result1.captured[0] as RRect;
+            ..called(3);
+
+      final rRectShadow = result1.captured[0] as RRect;
+      final shadowPaint = result1.captured[1] as Paint;
+      expect(rRectShadow.blRadius, const Radius.circular(8));
+      expect(rRectShadow.width, 112);
+      expect(rRectShadow.height, 90);
+      expect(rRectShadow.left, -22.5);
+      expect(rRectShadow.top, -106);
+      expect(shadowPaint.color, isSameColorAs(const Color(0x00000000)));
+      expect(shadowPaint.style, PaintingStyle.fill);
+      expect(
+        shadowPaint.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+
+      final rrect = result1.captured[2] as RRect;
       expect(rrect.blRadius, const Radius.circular(8));
       expect(rrect.width, 112);
       expect(rrect.height, 90);
       expect(rrect.left, -22.5);
       expect(rrect.top, -106);
 
-      final bgTooltipPaint = result1.captured[1] as Paint;
+      final bgTooltipPaint = result1.captured[3] as Paint;
       expect(bgTooltipPaint.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(bgTooltipPaint.style, PaintingStyle.fill);
 
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
 
       expect(rRectBorder.blRadius, const Radius.circular(8));
       expect(rRectBorder.width, 112);
@@ -1817,6 +1832,7 @@ void main() {
             ],
           );
         },
+        shadow: const Shadow(),
       );
 
       final (minY, maxY) = BarChartHelper().calculateMaxAxisValues(barGroups);
@@ -1878,8 +1894,26 @@ void main() {
       );
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rrect = result1.captured[0] as RRect;
+            ..called(3);
+
+      final rRectShadow = result1.captured[0] as RRect;
+      final shadowPaint = result1.captured[1] as Paint;
+      expect(rRectShadow.tlRadius, const Radius.circular(10));
+      expect(rRectShadow.trRadius, const Radius.circular(8));
+      expect(rRectShadow.blRadius, Radius.zero);
+      expect(rRectShadow.brRadius, Radius.zero);
+      expect(rRectShadow.width, 112);
+      expect(rRectShadow.height, 90);
+      expect(rRectShadow.left, -80);
+      expect(rRectShadow.top, 116);
+      expect(shadowPaint.color, isSameColorAs(const Color(0xFF000000)));
+      expect(shadowPaint.style, PaintingStyle.fill);
+      expect(
+        shadowPaint.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+
+      final rrect = result1.captured[2] as RRect;
       expect(rrect.tlRadius, const Radius.circular(10));
       expect(rrect.trRadius, const Radius.circular(8));
       expect(rrect.blRadius, Radius.zero);
@@ -1889,12 +1923,12 @@ void main() {
       expect(rrect.left, -80);
       expect(rrect.top, 116);
 
-      final bgTooltipPaint = result1.captured[1] as Paint;
+      final bgTooltipPaint = result1.captured[3] as Paint;
       expect(bgTooltipPaint.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(bgTooltipPaint.style, PaintingStyle.fill);
 
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
 
       expect(rRectBorder.tlRadius, const Radius.circular(10));
       expect(rRectBorder.trRadius, const Radius.circular(8));
@@ -1998,6 +2032,10 @@ void main() {
             ),
           );
         },
+        shadow: Shadow(
+          color: Colors.black.withValues(alpha: 0.25),
+          offset: const Offset(0, 3),
+        ),
       );
 
       final (minY, maxY) = BarChartHelper().calculateMaxAxisValues(barGroups);
@@ -2059,20 +2097,35 @@ void main() {
       );
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rrect = result1.captured[0] as RRect;
+            ..called(3);
+
+      final rRectShadow = result1.captured[0] as RRect;
+      final shadowPaint = result1.captured[1] as Paint;
+      expect(rRectShadow.blRadius, const Radius.circular(8));
+      expect(rRectShadow.width, 2636);
+      expect(rRectShadow.height, 7034.0);
+      expect(rRectShadow.left, -2436);
+      expect(rRectShadow.top, -6934.0 + 3);
+      expect(shadowPaint.color, isSameColorAs(const Color(0x40000000)));
+      expect(shadowPaint.style, PaintingStyle.fill);
+      expect(
+        shadowPaint.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+
+      final rrect = result1.captured[2] as RRect;
       expect(rrect.blRadius, const Radius.circular(8));
       expect(rrect.width, 2636);
       expect(rrect.height, 7034.0);
       expect(rrect.left, -2436);
       expect(rrect.top, -6934.0);
 
-      final bgTooltipPaint = result1.captured[1] as Paint;
+      final bgTooltipPaint = result1.captured[3] as Paint;
       expect(bgTooltipPaint.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(bgTooltipPaint.style, PaintingStyle.fill);
 
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
 
       expect(rRectBorder.blRadius, const Radius.circular(8));
       expect(rRectBorder.width, 2636);

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2802,9 +2802,20 @@ void main() {
 
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rRect = result1.captured[0] as RRect;
-      final paint = result1.captured[1] as Paint;
+            ..called(3);
+      final rRectShadow = result1.captured[0] as RRect;
+      final paintShadow = result1.captured[1] as Paint;
+      expect(
+        rRectShadow,
+        RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
+      );
+      expect(paintShadow.color, isSameColorAs(const Color(0x00000000)));
+      expect(
+        paintShadow.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+      final rRect = result1.captured[2] as RRect;
+      final paint = result1.captured[3] as Paint;
       expect(
         rRect,
         RRect.fromLTRBAndCorners(
@@ -2817,8 +2828,8 @@ void main() {
         ),
       );
       expect(paint.color, isSameColorAs(const Color(0x11111111)));
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBAndCorners(
@@ -2871,6 +2882,7 @@ void main() {
               .toList();
         },
         tooltipBorder: const BorderSide(color: Color(0x11111111), width: 2),
+        shadow: const Shadow(),
       );
       final data = LineChartData(
         minY: 0,
@@ -2927,16 +2939,27 @@ void main() {
 
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rRect = result1.captured[0] as RRect;
-      final paint = result1.captured[1] as Paint;
+            ..called(3);
+      final rRectShadow = result1.captured[0] as RRect;
+      final paintShadow = result1.captured[1] as Paint;
+      expect(
+        rRectShadow,
+        RRect.fromLTRBR(-28, 40, 10, 78, const Radius.circular(12)),
+      );
+      expect(paintShadow.color, isSameColorAs(const Color(0xFF000000)));
+      expect(
+        paintShadow.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+      final rRect = result1.captured[2] as RRect;
+      final paint = result1.captured[3] as Paint;
       expect(
         rRect,
         RRect.fromLTRBR(-28, 40, 10, 78, const Radius.circular(12)),
       );
       expect(paint.color, isSameColorAs(const Color(0x11111111)));
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(-28, 40, 10, 78, const Radius.circular(12)),
@@ -2982,6 +3005,10 @@ void main() {
               .toList();
         },
         tooltipBorder: const BorderSide(color: Color(0x11111111), width: 2),
+        shadow: Shadow(
+          color: Colors.black.withValues(alpha: 0.25),
+          offset: const Offset(0, 3),
+        ),
       );
       final data = LineChartData(
         minY: 0,
@@ -3038,16 +3065,27 @@ void main() {
 
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rRect = result1.captured[0] as RRect;
-      final paint = result1.captured[1] as Paint;
+            ..called(3);
+      final rRectShadow = result1.captured[0] as RRect;
+      final paintShadow = result1.captured[1] as Paint;
+      expect(
+        rRectShadow,
+        RRect.fromLTRBR(10, 40 + 3, 48, 78 + 3, const Radius.circular(12)),
+      );
+      expect(paintShadow.color, isSameColorAs(const Color(0x40000000)));
+      expect(
+        paintShadow.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+      final rRect = result1.captured[2] as RRect;
+      final paint = result1.captured[3] as Paint;
       expect(
         rRect,
         RRect.fromLTRBR(10, 40, 48, 78, const Radius.circular(12)),
       );
       expect(paint.color, isSameColorAs(const Color(0x11111111)));
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(10, 40, 48, 78, const Radius.circular(12)),
@@ -3165,16 +3203,27 @@ void main() {
 
       final result1 =
           verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-            ..called(2);
-      final rRect = result1.captured[0] as RRect;
-      final paint = result1.captured[1] as Paint;
+            ..called(3);
+      final rRectShadow = result1.captured[0] as RRect;
+      final paintShadow = result1.captured[1] as Paint;
+      expect(
+        rRectShadow,
+        RRect.fromLTRBR(10, 0, 48, 56, const Radius.circular(12)),
+      );
+      expect(paintShadow.color, isSameColorAs(const Color(0x00000000)));
+      expect(
+        paintShadow.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+      final rRect = result1.captured[2] as RRect;
+      final paint = result1.captured[3] as Paint;
       expect(
         rRect,
         RRect.fromLTRBR(10, 0, 48, 56, const Radius.circular(12)),
       );
       expect(paint.color, isSameColorAs(const Color(0x11111111)));
-      final rRectBorder = result1.captured[2] as RRect;
-      final paintBorder = result1.captured[3] as Paint;
+      final rRectBorder = result1.captured[4] as RRect;
+      final paintBorder = result1.captured[5] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(10, 0, 48, 56, const Radius.circular(12)),

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -2807,7 +2807,14 @@ void main() {
       final paintShadow = result1.captured[1] as Paint;
       expect(
         rRectShadow,
-        RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
+        RRect.fromLTRBAndCorners(
+          0,
+          40,
+          38,
+          78,
+          topLeft: const Radius.circular(10),
+          topRight: const Radius.circular(8),
+        ),
       );
       expect(paintShadow.color, isSameColorAs(const Color(0x00000000)));
       expect(

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -6,6 +6,7 @@ import 'package:fl_chart/src/chart/scatter_chart/scatter_chart_painter.dart';
 import 'package:fl_chart/src/utils/canvas_wrapper.dart';
 import 'package:fl_chart/src/utils/utils.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -456,14 +457,29 @@ void main() {
 
       verificationResult.called(1);
 
-      final captured2 = verifyInOrder([
-        mockCanvasWrapper.drawRRect(captureAny, captureAny),
-        mockCanvasWrapper.drawText(captureAny, any),
-      ]).captured;
+      final result1 =
+          verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
+            ..called(3);
 
-      final rRect = captured2[0][0] as RRect;
-      final bgPaint = captured2[0][1] as Paint;
-      final textPainter = captured2[1][0] as TextPainter;
+      final result2 = verify(mockCanvasWrapper.drawText(captureAny, any))
+        ..called(1);
+
+      final rRectShadow = result1.captured[0] as RRect;
+      final shadowPaint = result1.captured[1] as Paint;
+      expect(rRectShadow.blRadiusX, 0);
+      expect(rRectShadow.blRadiusY, 0);
+      expect(rRectShadow.tlRadiusY, 85);
+      expect(rRectShadow.trRadiusX, 8);
+      expect(shadowPaint.color, isSameColorAs(const Color(0x00000000)));
+      expect(shadowPaint.style, PaintingStyle.fill);
+      expect(
+        shadowPaint.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+
+      final rRect = result1.captured[2] as RRect;
+      final bgPaint = result1.captured[3] as Paint;
+      final textPainter = result2.captured[0] as TextPainter;
 
       expect(rRect.blRadiusX, 0);
       expect(rRect.blRadiusY, 0);
@@ -522,6 +538,7 @@ void main() {
                 ],
               );
             },
+            shadow: const Shadow(),
           ),
         ),
       );
@@ -563,14 +580,28 @@ void main() {
 
       verificationResult.called(1);
 
-      final captured2 = verifyInOrder([
-        mockCanvasWrapper.drawRRect(captureAny, captureAny),
-        mockCanvasWrapper.drawText(captureAny, any),
-      ]).captured;
+      final result1 =
+          verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
+            ..called(3);
 
-      final rRect = captured2[0][0] as RRect;
-      final bgPaint = captured2[0][1] as Paint;
-      final textPainter = captured2[1][0] as TextPainter;
+      final result2 = verify(mockCanvasWrapper.drawText(captureAny, any))
+        ..called(1);
+
+      final rRectShadow = result1.captured[0] as RRect;
+      final shadowPaint = result1.captured[1] as Paint;
+      expect(rRectShadow.blRadiusX, 22);
+      expect(rRectShadow.tlRadiusY, 22);
+      expect(rRectShadow.left, -134);
+      expect(shadowPaint.color, isSameColorAs(const Color(0xFF000000)));
+      expect(shadowPaint.style, PaintingStyle.fill);
+      expect(
+        shadowPaint.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+
+      final rRect = result1.captured[2] as RRect;
+      final bgPaint = result1.captured[3] as Paint;
+      final textPainter = result2.captured[0] as TextPainter;
 
       expect(rRect.blRadiusX, 22);
       expect(rRect.tlRadiusY, 22);
@@ -629,6 +660,10 @@ void main() {
                 ],
               );
             },
+            shadow: Shadow(
+              color: Colors.black.withValues(alpha: 0.25),
+              offset: const Offset(3, 0),
+            ),
           ),
         ),
       );
@@ -670,14 +705,28 @@ void main() {
 
       verificationResult.called(1);
 
-      final captured2 = verifyInOrder([
-        mockCanvasWrapper.drawRRect(captureAny, captureAny),
-        mockCanvasWrapper.drawText(captureAny, any),
-      ]).captured;
+      final result1 =
+          verify(mockCanvasWrapper.drawRRect(captureAny, captureAny))
+            ..called(3);
 
-      final rRect = captured2[0][0] as RRect;
-      final bgPaint = captured2[0][1] as Paint;
-      final textPainter = captured2[1][0] as TextPainter;
+      final result2 = verify(mockCanvasWrapper.drawText(captureAny, any))
+        ..called(1);
+
+      final rRectShadow = result1.captured[0] as RRect;
+      final shadowPaint = result1.captured[1] as Paint;
+      expect(rRectShadow.blRadiusX, 22);
+      expect(rRectShadow.tlRadiusY, 22);
+      expect(rRectShadow.left, 10 + 3);
+      expect(shadowPaint.color, isSameColorAs(const Color(0x40000000)));
+      expect(shadowPaint.style, PaintingStyle.fill);
+      expect(
+        shadowPaint.maskFilter,
+        const MaskFilter.blur(BlurStyle.normal, 0),
+      );
+
+      final rRect = result1.captured[2] as RRect;
+      final bgPaint = result1.captured[3] as Paint;
+      final textPainter = result2.captured[0] as TextPainter;
 
       expect(rRect.blRadiusX, 22);
       expect(rRect.tlRadiusY, 22);


### PR DESCRIPTION
hi:)

this PR resolves https://github.com/imaNNeo/fl_chart/issues/1767

i've added 3 params to `LineTouchTooltipData` for tooltip shadow:
* `shadowColor` - color of the shadow
* `shadowBlur` - sigma value of mask filter blur (how much will shadow be blurred)
* `shadowOffset` - offset of the shadow (related to tooltip)

please check the image below to see example of changes:)

<img width="454" alt="image" src="https://github.com/user-attachments/assets/0b32f274-619a-439a-9acd-0e189e38cfc3">

and the code code of `LineTouchTooltipData` from example image:
```
LineTouchData get lineTouchData => LineTouchData(
        touchTooltipData: LineTouchTooltipData(
          getTooltipColor: (touchedSpot) => Colors.black,
          shadowColor: Colors.white.withOpacity(0.25),
          shadowBlur: 4,
          shadowOffset: const Offset(0, 4),
        ),
      );
```