### PR TITLE
Deprecate `swapAnimationDuration` and `swapAnimationCurve` properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## newVersion
+* **IMPROVEMENT** (by @moshe5745) Update the docs related to line chart's `duration` and `curve` properties, #1618
+* **IMPROVEMENT** (by @imaNNeo) Deprecate `swapAnimationDuration` and `swapAnimationCurve` properties to use `curve` and `duration` instead to keep the consistency over the project, #1618
+
 ## 0.69.0
 * **BUGFIX** (by @imaNNeo) Fix a memory leak issue in the axis-based charts, there was a logic to calculate and cache the minX, maxX, minY and maxY properties to reduce the computation cost. But it caused some memory issues, as we don't have a quick solution for this, we disabled the caching logic for now, later we can move the calculation logic to the render objects to keep and update them only when the data is changed, #1106, #1693
 * **BUGFIX**  (by @imaNNeo) Fix showing grid lines even when there is no line to show in the LineChart, #1691

--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -72,7 +72,7 @@ class BarChartSample1State extends State<BarChartSample1> {
                     padding: const EdgeInsets.symmetric(horizontal: 8),
                     child: BarChart(
                       isPlaying ? randomData() : mainBarData(),
-                      swapAnimationDuration: animDuration,
+                      duration: animDuration,
                     ),
                   ),
                 ),

--- a/example/lib/presentation/samples/radar/radar_chart_sample1.dart
+++ b/example/lib/presentation/samples/radar/radar_chart_sample1.dart
@@ -187,7 +187,7 @@ class _RadarChartSample1State extends State<RadarChartSample1> {
                 tickBorderData: const BorderSide(color: Colors.transparent),
                 gridBorderData: BorderSide(color: widget.gridColor, width: 2),
               ),
-              swapAnimationDuration: const Duration(milliseconds: 400),
+              duration: const Duration(milliseconds: 400),
             ),
           ),
         ],

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample1.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample1.dart
@@ -51,8 +51,8 @@ class ScatterChartSample1State extends State<ScatterChartSample1> {
               enabled: false,
             ),
           ),
-          swapAnimationDuration: const Duration(milliseconds: 600),
-          swapAnimationCurve: Curves.fastOutSlowIn,
+          duration: const Duration(milliseconds: 600),
+          curve: Curves.fastOutSlowIn,
         ),
       ),
     );

--- a/lib/src/chart/bar_chart/bar_chart.dart
+++ b/lib/src/chart/bar_chart/bar_chart.dart
@@ -8,18 +8,21 @@ import 'package:flutter/cupertino.dart';
 class BarChart extends ImplicitlyAnimatedWidget {
   /// [data] determines how the [BarChart] should be look like,
   /// when you make any change in the [BarChartData], it updates
-  /// new values with animation, and duration is [swapAnimationDuration].
-  /// also you can change the [swapAnimationCurve]
+  /// new values with animation, and duration is [duration].
+  /// also you can change the [curve]
   /// which default is [Curves.linear].
   const BarChart(
     this.data, {
     this.chartRendererKey,
     super.key,
-    Duration swapAnimationDuration = const Duration(milliseconds: 150),
-    Curve swapAnimationCurve = Curves.linear,
+    @Deprecated('Please use [duration] instead')
+    Duration? swapAnimationDuration,
+    Duration duration = const Duration(milliseconds: 150),
+    @Deprecated('Please use [curve] instead') Curve? swapAnimationCurve,
+    Curve curve = Curves.linear,
   }) : super(
-          duration: swapAnimationDuration,
-          curve: swapAnimationCurve,
+          duration: swapAnimationDuration ?? duration,
+          curve: swapAnimationCurve ?? curve,
         );
 
   /// Determines how the [BarChart] should be look like.

--- a/lib/src/chart/line_chart/line_chart.dart
+++ b/lib/src/chart/line_chart/line_chart.dart
@@ -9,8 +9,8 @@ import 'package:flutter/material.dart';
 class LineChart extends ImplicitlyAnimatedWidget {
   /// [data] determines how the [LineChart] should be look like,
   /// when you make any change in the [LineChartData], it updates
-  /// new values with animation, and duration is [swapAnimationDuration].
-  /// also you can change the [swapAnimationCurve]
+  /// new values with animation, and duration is [duration].
+  /// also you can change the [curve]
   /// which default is [Curves.linear].
   const LineChart(
     this.data, {

--- a/lib/src/chart/pie_chart/pie_chart.dart
+++ b/lib/src/chart/pie_chart/pie_chart.dart
@@ -6,17 +6,20 @@ import 'package:flutter/material.dart';
 class PieChart extends ImplicitlyAnimatedWidget {
   /// [data] determines how the [PieChart] should be look like,
   /// when you make any change in the [PieChartData], it updates
-  /// new values with animation, and duration is [swapAnimationDuration].
-  /// also you can change the [swapAnimationCurve]
+  /// new values with animation, and duration is [duration].
+  /// also you can change the [curve]
   /// which default is [Curves.linear].
   const PieChart(
     this.data, {
     super.key,
-    Duration swapAnimationDuration = defaultDuration,
-    Curve swapAnimationCurve = Curves.linear,
+    @Deprecated('Please use [duration] instead')
+    Duration? swapAnimationDuration,
+    Duration duration = const Duration(milliseconds: 150),
+    @Deprecated('Please use [curve] instead') Curve? swapAnimationCurve,
+    Curve curve = Curves.linear,
   }) : super(
-          duration: swapAnimationDuration,
-          curve: swapAnimationCurve,
+          duration: swapAnimationDuration ?? duration,
+          curve: swapAnimationCurve ?? curve,
         );
 
   /// Default duration to reuse externally.
@@ -86,6 +89,7 @@ class BadgeWidgetsDelegate extends MultiChildLayoutDelegate {
     required this.badgeWidgetsCount,
     required this.badgeWidgetsOffsets,
   });
+
   final int badgeWidgetsCount;
   final Map<int, Offset> badgeWidgetsOffsets;
 

--- a/lib/src/chart/radar_chart/radar_chart.dart
+++ b/lib/src/chart/radar_chart/radar_chart.dart
@@ -6,17 +6,20 @@ import 'package:flutter/material.dart';
 class RadarChart extends ImplicitlyAnimatedWidget {
   /// [data] determines how the [RadarChart] should be look like,
   /// when you make any change in the [RadarChart], it updates
-  /// new values with animation, and duration is [swapAnimationDuration].
-  /// also you can change the [swapAnimationCurve]
+  /// new values with animation, and duration is [duration].
+  /// also you can change the [curve]
   /// which default is [Curves.linear].
   const RadarChart(
     this.data, {
     super.key,
-    Duration swapAnimationDuration = const Duration(milliseconds: 150),
-    Curve swapAnimationCurve = Curves.linear,
+    @Deprecated('Please use [duration] instead')
+    Duration? swapAnimationDuration,
+    Duration duration = const Duration(milliseconds: 150),
+    @Deprecated('Please use [curve] instead') Curve? swapAnimationCurve,
+    Curve curve = Curves.linear,
   }) : super(
-          duration: swapAnimationDuration,
-          curve: swapAnimationCurve,
+          duration: swapAnimationDuration ?? duration,
+          curve: swapAnimationCurve ?? curve,
         );
 
   /// Determines how the [RadarChart] should be look like.

--- a/lib/src/chart/scatter_chart/scatter_chart.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart.dart
@@ -7,18 +7,21 @@ import 'package:flutter/cupertino.dart';
 class ScatterChart extends ImplicitlyAnimatedWidget {
   /// [data] determines how the [ScatterChart] should be look like,
   /// when you make any change in the [ScatterChartData], it updates
-  /// new values with animation, and duration is [swapAnimationDuration].
-  /// also you can change the [swapAnimationCurve]
+  /// new values with animation, and duration is [duration].
+  /// also you can change the [curve]
   /// which default is [Curves.linear].
   const ScatterChart(
     this.data, {
     this.chartRendererKey,
     super.key,
-    Duration swapAnimationDuration = const Duration(milliseconds: 150),
-    Curve swapAnimationCurve = Curves.linear,
+    @Deprecated('Please use [duration] instead')
+    Duration? swapAnimationDuration,
+    Duration duration = const Duration(milliseconds: 150),
+    @Deprecated('Please use [curve] instead') Curve? swapAnimationCurve,
+    Curve curve = Curves.linear,
   }) : super(
-          duration: swapAnimationDuration,
-          curve: swapAnimationCurve,
+          duration: swapAnimationDuration ?? duration,
+          curve: swapAnimationCurve ?? curve,
         );
 
   /// Determines how the [ScatterChart] should be look like.

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -6,13 +6,13 @@ BarChart(
   BarChartData(
     // read about it in the BarChartData section
   ),
-  swapAnimationDuration: Duration(milliseconds: 150), // Optional
-  swapAnimationCurve: Curves.linear, // Optional
+  duration: Duration(milliseconds: 150), // Optional
+  curve: Curves.linear, // Optional
 );
 ```
 
 ### Implicit Animations
-When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `swapAnimationDuration` and `swapAnimationCurve` properties, respectively.
+When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `duration` and `curve` properties, respectively.
 
 ### BarChartData
 |PropName		|Description	|default value|

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -6,8 +6,8 @@ PieChart(
   PieChartData(
     // read about it in the PieChartData section
   ),
-  swapAnimationDuration: Duration(milliseconds: 150), // Optional
-  swapAnimationCurve: Curves.linear, // Optional
+  duration: Duration(milliseconds: 150), // Optional
+  curve: Curves.linear, // Optional
 );
 ```
 
@@ -15,7 +15,7 @@ PieChart(
 
 
 ### Implicit Animations
-When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `swapAnimationDuration` and `swapAnimationCurve` properties, respectively.
+When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `duration` and `curve` properties, respectively.
 
 ### PieChartData
 |PropName		|Description	|default value|

--- a/repo_files/documentations/scatter_chart.md
+++ b/repo_files/documentations/scatter_chart.md
@@ -8,13 +8,13 @@ ScatterChart(
   ScatterChartData(
     // read about it in the ScatterChartData section
   ),
-  swapAnimationDuration: Duration(milliseconds: 150), // Optional
-  swapAnimationCurve: Curves.linear, // Optional
+  duration: Duration(milliseconds: 150), // Optional
+  curve: Curves.linear, // Optional
 );
 ```
 
 ### Implicit Animations
-When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `swapAnimationDuration` and `swapAnimationCurve` properties, respectively.
+When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `duration` and `curve` properties, respectively.
 
 ### ScatterChartData
 |PropName		|Description	|default value|


### PR DESCRIPTION
Deprecate `swapAnimationDuration` and `swapAnimationCurve` properties to use `curve` and `duration` instead to keep the consistency over the project, #1618