### PR TITLE
Update bar_chart_sample1.dart

### DIFF
--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -72,7 +72,7 @@ class BarChartSample1State extends State<BarChartSample1> {
                     padding: const EdgeInsets.symmetric(horizontal: 8),
                     child: BarChart(
                       isPlaying ? randomData() : mainBarData(),
-                      duration: animDuration,
+                      swapAnimationDuration : animDuration,
                     ),
                   ),
                 ),


### PR DESCRIPTION
The parameter `duration` for `BarChart` isn't defined, so  `duration` has been changed to `swapAnimationDuration`.