### PR TITLE
fix: Typo in bar chart data docstring

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -21,7 +21,7 @@ class BarChartData extends AxisChartData with EquatableMixin {
   /// It draws some titles on left, top, right, bottom sides per each axis number,
   /// you can modify [titlesData] to have your custom titles,
   /// also you can define the axis title (one text per axis) for each side
-  /// using [axisTitleData], you can restrict the y axis using [minX], and [maxY] values.
+  /// using [axisTitleData], you can restrict the y axis using [minY], and [maxY] values.
   ///
   /// It draws a color as a background behind everything you can set it using [backgroundColor],
   /// then a grid over it, you can customize it using [gridData],


### PR DESCRIPTION
This PR fixes a typo in the docstring of `BarChartData`