### PR TITLE
ref: Improve readability of GradientExtension.getSafeColorStops

### DIFF
--- a/lib/src/extensions/gradient_extension.dart
+++ b/lib/src/extensions/gradient_extension.dart
@@ -2,25 +2,24 @@ import 'package:flutter/painting.dart';
 
 /// Extensions on [Gradient]
 extension GradientExtension on Gradient {
-  /// Returns colorStops
+  /// Returns color stops.
   ///
-  /// if [stops] provided, returns it directly,
-  /// Otherwise we calculate it using colors list
+  /// If [stops] has the same length as [colors], returns it directly.
+  /// Otherwise, calculates stops linearly between 0.0 and 1.0.
+  ///
+  /// Throws [ArgumentError] if [colors] has less than 2 colors.
   List<double> getSafeColorStops() {
-    var resultStops = <double>[];
-    if (stops == null || stops!.length != colors.length) {
-      if (colors.length > 1) {
-        /// provided colorStops is invalid and we calculate it here
-        colors.asMap().forEach((index, color) {
-          final percent = 1.0 / (colors.length - 1);
-          resultStops.add(percent * index);
-        });
-      } else {
-        throw ArgumentError('"colors" must have length > 1.');
-      }
-    } else {
-      resultStops = stops!;
+    if (stops?.length == colors.length) {
+      return stops!;
     }
-    return resultStops;
+
+    if (colors.length <= 1) {
+      throw ArgumentError('"colors" must have length > 1.');
+    }
+
+    final stopsStep = 1.0 / (colors.length - 1);
+    return [
+      for (var index = 0; index < colors.length; index++) index * stopsStep,
+    ];
   }
 }


### PR DESCRIPTION
This PR refactors `GradientExtension.getSafeColorStops` to improve readability.

It makes sense to merge the tests for this method introduced with  #1787 first, to ensure it's still working as expected.

All of the tests introduced in #1787 are still passing with the refactored code.