### PR TITLE
fix!: PieChartSectionData equatable

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -134,7 +134,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
 }
 
 /// Holds data related to drawing each [PieChart] section.
-class PieChartSectionData {
+class PieChartSectionData with EquatableMixin {
   /// [PieChart] draws section from right side of the circle (0 degrees),
   /// each section have a [value] that determines how much it should occupy,
   /// this is depends on sum of all sections, each section should
@@ -282,6 +282,22 @@ class PieChartSectionData {
           t,
         ),
       );
+
+  /// Used for equality check, see [EquatableMixin].
+  @override
+  List<Object?> get props => [
+        value,
+        color,
+        gradient,
+        radius,
+        showTitle,
+        titleStyle,
+        title,
+        borderSide,
+        badgeWidget,
+        titlePositionPercentageOffset,
+        badgePositionPercentageOffset,
+      ];
 }
 
 /// Holds data to handle touch events, and touch responses in the [PieChart].

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -308,6 +308,9 @@ class MockData {
   static final scatterTouchedSpot = ScatterTouchedSpot(scatterSpot1, 0);
 
   static final pieChartSectionData1 = PieChartSectionData(value: 12);
+
+  static final pieChartSectionData2 = PieChartSectionData(value: 22);
+
   static final pieTouchedSection1 = PieTouchedSection(
     pieChartSectionData1,
     0,

--- a/test/chart/pie_chart/pie_chart_data_test.dart
+++ b/test/chart/pie_chart/pie_chart_data_test.dart
@@ -73,7 +73,7 @@ void main() {
                 PieChartSectionData(value: 22, color: Colors.green),
               ],
             ),
-        false,
+        true,
       );
 
       expect(

--- a/test/utils/lerp_test.dart
+++ b/test/utils/lerp_test.dart
@@ -388,4 +388,137 @@ void main() {
     expect(lerpGradient(colors, [], 0.8), const Color(0x25252525));
     expect(lerpGradient(colors, [], 1), const Color(0x33333333));
   });
+
+  test('lerpLineChartBarDataList uses `LineChartBarData.lerp`', () {
+    final list1 = [
+      MockData.lineChartBarData1,
+      MockData.lineChartBarData1,
+      MockData.lineChartBarData1,
+    ];
+    final list2 = [
+      MockData.lineChartBarData2,
+      MockData.lineChartBarData2,
+      MockData.lineChartBarData2,
+      MockData.lineChartBarData2,
+    ];
+
+    expect(
+      lerpLineChartBarDataList(list1, list2, 1),
+      lerpList(list1, list2, 1, lerp: LineChartBarData.lerp),
+    );
+  });
+
+  test('lerpBetweenBarsDataList uses `BetweenBarsData.lerp`', () {
+    final list1 = [
+      betweenBarsData1,
+      betweenBarsData1,
+      betweenBarsData1,
+    ];
+    final list2 = [
+      betweenBarsData2,
+      betweenBarsData2,
+      betweenBarsData2,
+      betweenBarsData2,
+    ];
+
+    expect(
+      lerpBetweenBarsDataList(list1, list2, 1),
+      lerpList(list1, list2, 1, lerp: BetweenBarsData.lerp),
+    );
+  });
+
+  test('lerpBarChartGroupDataList uses `BarChartGroupData.lerp`', () {
+    final list1 = [
+      barChartGroupData1,
+      barChartGroupData1,
+      barChartGroupData1,
+    ];
+    final list2 = [
+      barChartGroupData2,
+      barChartGroupData2,
+      barChartGroupData2,
+      barChartGroupData2,
+    ];
+
+    expect(
+      lerpBarChartGroupDataList(list1, list2, 1),
+      lerpList(list1, list2, 1, lerp: BarChartGroupData.lerp),
+    );
+  });
+
+  test('lerpBarChartRodDataList uses `BarChartRodData.lerp`', () {
+    final list1 = [
+      barChartRodData1,
+      barChartRodData1,
+      barChartRodData1,
+    ];
+    final list2 = [
+      barChartRodData2,
+      barChartRodData2,
+      barChartRodData2,
+      barChartRodData2,
+    ];
+
+    expect(
+      lerpBarChartRodDataList(list1, list2, 1),
+      lerpList(list1, list2, 1, lerp: BarChartRodData.lerp),
+    );
+  });
+
+  test('lerpPieChartSectionDataList uses `PieChartSectionData.lerp`', () {
+    final list1 = [
+      MockData.pieChartSectionData1,
+      MockData.pieChartSectionData1,
+      MockData.pieChartSectionData1,
+    ];
+    final list2 = [
+      MockData.pieChartSectionData2,
+      MockData.pieChartSectionData2,
+      MockData.pieChartSectionData2,
+      MockData.pieChartSectionData2,
+    ];
+
+    expect(
+      lerpPieChartSectionDataList(list1, list2, 1),
+      lerpList(list1, list2, 1, lerp: PieChartSectionData.lerp),
+    );
+  });
+
+  test('lerpBarChartRodStackList uses `BarChartRodStackItem.lerp`', () {
+    final list1 = [
+      barChartRodStackItem1,
+      barChartRodStackItem1,
+      barChartRodStackItem1,
+    ];
+    final list2 = [
+      barChartRodStackItem2,
+      barChartRodStackItem2,
+      barChartRodStackItem2,
+      barChartRodStackItem2,
+    ];
+
+    expect(
+      lerpBarChartRodStackList(list1, list2, 1),
+      lerpList(list1, list2, 1, lerp: BarChartRodStackItem.lerp),
+    );
+  });
+
+  test('lerpRadarDataSetList uses `RadarDataSet.lerp`', () {
+    final list1 = [
+      MockData.radarDataSet1,
+      MockData.radarDataSet1,
+      MockData.radarDataSet1,
+    ];
+    final list2 = [
+      MockData.radarDataSet2,
+      MockData.radarDataSet2,
+      MockData.radarDataSet2,
+      MockData.radarDataSet2,
+    ];
+
+    expect(
+      lerpRadarDataSetList(list1, list2, 1),
+      lerpList(list1, list2, 1, lerp: RadarDataSet.lerp),
+    );
+  });
 }


### PR DESCRIPTION
This PR adds tests for lerp utilities and increases the test coverage from 87.52% to 100%. 

In the process I added `EquatableMixin`, because `PieChartSectionData` with the same `sections` were not considered equal.

As far as tests go, this is a breaking change, because one test case assumed pie chart data to be unequal when their `sections` don't reference the same object, even though the `sections` have the same list elements. 

Please let me know, what you think is the best approach for this for fl_chart.