### PR TITLE
fix: Call correct make target to run tests in verification workflow

### DIFF
--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -21,4 +21,4 @@ jobs:
       - name: Analyze the source code
         run: make analyze
       - name: Run tests
-        run: make test
+        run: make runTests


### PR DESCRIPTION
This PR replaces the `test` make target that does not exist with `runTests` to ensure tests are run in the workflow. 

Fixes issue #1791