### PR TITLE
feat: make FlSpot extend Equatable

### DIFF
--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -450,7 +450,7 @@ class FlTitlesData with EquatableMixin {
 
 /// Represents a conceptual position in cartesian (axis based) space.
 @immutable
-class FlSpot {
+class FlSpot with EquatableMixin {
   /// [x] determines cartesian (axis based) horizontally position
   /// 0 means most left point of the chart
   ///
@@ -522,6 +522,9 @@ class FlSpot {
   /// Override hashCode
   @override
   int get hashCode => x.hashCode ^ y.hashCode;
+
+  @override
+  List<Object?> get props => [x, y];
 }
 
 /// Responsible to hold grid data,


### PR DESCRIPTION
Issue: 
The `FlSpot` class does not extend `Equatable`. There can be a use case where `FlSpot` object can be built from within a controller or a bloc. If it's returned as a field of state, it needs to be equatable.

example:
```
class SomeSuccessState extends Equatable {
  const SomeSuccessState(this.spotsList);

  final List<FlSpot> spotsList;

  @override
  List<Object?> get props => [spotsList];
}
```

This pr makes `FlSpot` object extend form `EquatableMixin` to address this issue. Let me know if you have any further concerns.