### PR TITLE
feat!: Upgrade to Flutter 3.27.0

### DIFF
--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -1,9 +1,9 @@
 import 'dart:async';
 import 'dart:math';
 
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart_app/util/extensions/color_extensions.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class BarChartSample1 extends StatefulWidget {
@@ -19,7 +19,7 @@ class BarChartSample1 extends StatefulWidget {
       ];
 
   final Color barBackgroundColor =
-      AppColors.contentColorWhite.darken().withOpacity(0.3);
+      AppColors.contentColorWhite.darken().withValues(alpha: 0.3);
   final Color barColor = AppColors.contentColorWhite;
   final Color touchedBarColor = AppColors.contentColorGreen;
 

--- a/example/lib/presentation/samples/bar/bar_chart_sample2.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample2.dart
@@ -1,6 +1,6 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart_app/util/extensions/color_extensions.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class BarChartSample2 extends StatefulWidget {
@@ -243,7 +243,7 @@ class BarChartSample2State extends State<BarChartSample2> {
         Container(
           width: width,
           height: 10,
-          color: Colors.white.withOpacity(0.4),
+          color: Colors.white.withValues(alpha: 0.4),
         ),
         const SizedBox(
           width: space,
@@ -251,7 +251,7 @@ class BarChartSample2State extends State<BarChartSample2> {
         Container(
           width: width,
           height: 28,
-          color: Colors.white.withOpacity(0.8),
+          color: Colors.white.withValues(alpha: 0.8),
         ),
         const SizedBox(
           width: space,
@@ -259,7 +259,7 @@ class BarChartSample2State extends State<BarChartSample2> {
         Container(
           width: width,
           height: 42,
-          color: Colors.white.withOpacity(1),
+          color: Colors.white.withValues(alpha: 1),
         ),
         const SizedBox(
           width: space,
@@ -267,7 +267,7 @@ class BarChartSample2State extends State<BarChartSample2> {
         Container(
           width: width,
           height: 28,
-          color: Colors.white.withOpacity(0.8),
+          color: Colors.white.withValues(alpha: 0.8),
         ),
         const SizedBox(
           width: space,
@@ -275,7 +275,7 @@ class BarChartSample2State extends State<BarChartSample2> {
         Container(
           width: width,
           height: 10,
-          color: Colors.white.withOpacity(0.4),
+          color: Colors.white.withValues(alpha: 0.4),
         ),
       ],
     );

--- a/example/lib/presentation/samples/bar/bar_chart_sample4.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample4.dart
@@ -1,6 +1,6 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart_app/util/extensions/color_extensions.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class BarChartSample4 extends StatefulWidget {
@@ -103,7 +103,7 @@ class BarChartSample4State extends State<BarChartSample4> {
                   show: true,
                   checkToShowHorizontalLine: (value) => value % 10 == 0,
                   getDrawingHorizontalLine: (value) => FlLine(
-                    color: AppColors.borderColor.withOpacity(0.1),
+                    color: AppColors.borderColor.withValues(alpha: 0.1),
                     strokeWidth: 1,
                   ),
                   drawVerticalLine: false,

--- a/example/lib/presentation/samples/bar/bar_chart_sample5.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample5.dart
@@ -1,6 +1,6 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart_app/util/app_utils.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class BarChartSample5 extends StatefulWidget {
@@ -221,29 +221,29 @@ class BarChartSample5State extends State<BarChartSample5> {
             BarChartRodStackItem(
               0,
               -value1,
-              AppColors.contentColorGreen
-                  .withOpacity(isTouched ? shadowOpacity * 2 : shadowOpacity),
+              AppColors.contentColorGreen.withValues(
+                  alpha: isTouched ? shadowOpacity * 2 : shadowOpacity),
               const BorderSide(color: Colors.transparent),
             ),
             BarChartRodStackItem(
               -value1,
               -(value1 + value2),
-              AppColors.contentColorYellow
-                  .withOpacity(isTouched ? shadowOpacity * 2 : shadowOpacity),
+              AppColors.contentColorYellow.withValues(
+                  alpha: isTouched ? shadowOpacity * 2 : shadowOpacity),
               const BorderSide(color: Colors.transparent),
             ),
             BarChartRodStackItem(
               -(value1 + value2),
               -(value1 + value2 + value3),
-              AppColors.contentColorPink
-                  .withOpacity(isTouched ? shadowOpacity * 2 : shadowOpacity),
+              AppColors.contentColorPink.withValues(
+                  alpha: isTouched ? shadowOpacity * 2 : shadowOpacity),
               const BorderSide(color: Colors.transparent),
             ),
             BarChartRodStackItem(
               -(value1 + value2 + value3),
               -(value1 + value2 + value3 + value4),
-              AppColors.contentColorBlue
-                  .withOpacity(isTouched ? shadowOpacity * 2 : shadowOpacity),
+              AppColors.contentColorBlue.withValues(
+                  alpha: isTouched ? shadowOpacity * 2 : shadowOpacity),
               const BorderSide(color: Colors.transparent),
             ),
           ],
@@ -328,12 +328,12 @@ class BarChartSample5State extends State<BarChartSample5> {
               getDrawingHorizontalLine: (value) {
                 if (value == 0) {
                   return FlLine(
-                    color: AppColors.borderColor.withOpacity(0.1),
+                    color: AppColors.borderColor.withValues(alpha: 0.1),
                     strokeWidth: 3,
                   );
                 }
                 return FlLine(
-                  color: AppColors.borderColor.withOpacity(0.05),
+                  color: AppColors.borderColor.withValues(alpha: 0.05),
                   strokeWidth: 0.8,
                 );
               },

--- a/example/lib/presentation/samples/bar/bar_chart_sample7.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample7.dart
@@ -1,7 +1,7 @@
 import 'dart:math' as math;
 
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 class BarChartSample7 extends StatefulWidget {
@@ -61,7 +61,7 @@ class _BarChartSample7State extends State<BarChartSample7> {
               show: true,
               border: Border.symmetric(
                 horizontal: BorderSide(
-                  color: AppColors.borderColor.withOpacity(0.2),
+                  color: AppColors.borderColor.withValues(alpha: 0.2),
                 ),
               ),
             ),
@@ -103,7 +103,7 @@ class _BarChartSample7State extends State<BarChartSample7> {
               show: true,
               drawVerticalLine: false,
               getDrawingHorizontalLine: (value) => FlLine(
-                color: AppColors.borderColor.withOpacity(0.2),
+                color: AppColors.borderColor.withValues(alpha: 0.2),
                 strokeWidth: 1,
               ),
             ),

--- a/example/lib/presentation/samples/bar/bar_chart_sample8.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample8.dart
@@ -1,15 +1,15 @@
 import 'dart:math';
 
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart_app/util/extensions/color_extensions.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class BarChartSample8 extends StatefulWidget {
   BarChartSample8({super.key});
 
   final Color barBackgroundColor =
-      AppColors.contentColorWhite.darken().withOpacity(0.3);
+      AppColors.contentColorWhite.darken().withValues(alpha: 0.3);
   final Color barColor = AppColors.contentColorWhite;
 
   @override

--- a/example/lib/presentation/samples/line/line_chart_sample1.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample1.dart
@@ -1,5 +1,5 @@
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 class _LineChart extends StatelessWidget {
@@ -42,7 +42,8 @@ class _LineChart extends StatelessWidget {
   LineTouchData get lineTouchData1 => LineTouchData(
         handleBuiltInTouches: true,
         touchTooltipData: LineTouchTooltipData(
-          getTooltipColor: (touchedSpot) => Colors.blueGrey.withOpacity(0.8),
+          getTooltipColor: (touchedSpot) =>
+              Colors.blueGrey.withValues(alpha: 0.8),
         ),
       );
 
@@ -168,8 +169,8 @@ class _LineChart extends StatelessWidget {
   FlBorderData get borderData => FlBorderData(
         show: true,
         border: Border(
-          bottom:
-              BorderSide(color: AppColors.primary.withOpacity(0.2), width: 4),
+          bottom: BorderSide(
+              color: AppColors.primary.withValues(alpha: 0.2), width: 4),
           left: const BorderSide(color: Colors.transparent),
           right: const BorderSide(color: Colors.transparent),
           top: const BorderSide(color: Colors.transparent),
@@ -202,7 +203,7 @@ class _LineChart extends StatelessWidget {
         dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(
           show: false,
-          color: AppColors.contentColorPink.withOpacity(0),
+          color: AppColors.contentColorPink.withValues(alpha: 0),
         ),
         spots: const [
           FlSpot(1, 1),
@@ -233,7 +234,7 @@ class _LineChart extends StatelessWidget {
   LineChartBarData get lineChartBarData2_1 => LineChartBarData(
         isCurved: true,
         curveSmoothness: 0,
-        color: AppColors.contentColorGreen.withOpacity(0.5),
+        color: AppColors.contentColorGreen.withValues(alpha: 0.5),
         barWidth: 4,
         isStrokeCapRound: true,
         dotData: const FlDotData(show: false),
@@ -251,13 +252,13 @@ class _LineChart extends StatelessWidget {
 
   LineChartBarData get lineChartBarData2_2 => LineChartBarData(
         isCurved: true,
-        color: AppColors.contentColorPink.withOpacity(0.5),
+        color: AppColors.contentColorPink.withValues(alpha: 0.5),
         barWidth: 4,
         isStrokeCapRound: true,
         dotData: const FlDotData(show: false),
         belowBarData: BarAreaData(
           show: true,
-          color: AppColors.contentColorPink.withOpacity(0.2),
+          color: AppColors.contentColorPink.withValues(alpha: 0.2),
         ),
         spots: const [
           FlSpot(1, 1),
@@ -272,7 +273,7 @@ class _LineChart extends StatelessWidget {
   LineChartBarData get lineChartBarData2_3 => LineChartBarData(
         isCurved: true,
         curveSmoothness: 0,
-        color: AppColors.contentColorCyan.withOpacity(0.5),
+        color: AppColors.contentColorCyan.withValues(alpha: 0.5),
         barWidth: 2,
         isStrokeCapRound: true,
         dotData: const FlDotData(show: true),
@@ -342,7 +343,8 @@ class LineChartSample1State extends State<LineChartSample1> {
           IconButton(
             icon: Icon(
               Icons.refresh,
-              color: Colors.white.withOpacity(isShowingMainData ? 1.0 : 0.5),
+              color:
+                  Colors.white.withValues(alpha: isShowingMainData ? 1.0 : 0.5),
             ),
             onPressed: () {
               setState(() {

--- a/example/lib/presentation/samples/line/line_chart_sample10.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample10.dart
@@ -115,7 +115,7 @@ class _LineChartSample10State extends State<LineChartSample10> {
         show: false,
       ),
       gradient: LinearGradient(
-        colors: [widget.sinColor.withOpacity(0), widget.sinColor],
+        colors: [widget.sinColor.withValues(alpha: 0), widget.sinColor],
         stops: const [0.1, 1.0],
       ),
       barWidth: 4,
@@ -130,7 +130,7 @@ class _LineChartSample10State extends State<LineChartSample10> {
         show: false,
       ),
       gradient: LinearGradient(
-        colors: [widget.cosColor.withOpacity(0), widget.cosColor],
+        colors: [widget.cosColor.withValues(alpha: 0), widget.cosColor],
         stops: const [0.1, 1.0],
       ),
       barWidth: 4,

--- a/example/lib/presentation/samples/line/line_chart_sample2.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample2.dart
@@ -1,5 +1,5 @@
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 class LineChartSample2 extends StatefulWidget {
@@ -48,7 +48,9 @@ class _LineChartSample2State extends State<LineChartSample2> {
               'avg',
               style: TextStyle(
                 fontSize: 12,
-                color: showAvg ? Colors.white.withOpacity(0.5) : Colors.white,
+                color: showAvg
+                    ? Colors.white.withValues(alpha: 0.5)
+                    : Colors.white,
               ),
             ),
           ),
@@ -184,7 +186,7 @@ class _LineChartSample2State extends State<LineChartSample2> {
             show: true,
             gradient: LinearGradient(
               colors: gradientColors
-                  .map((color) => color.withOpacity(0.3))
+                  .map((color) => color.withValues(alpha: 0.3))
                   .toList(),
             ),
           ),
@@ -278,10 +280,10 @@ class _LineChartSample2State extends State<LineChartSample2> {
               colors: [
                 ColorTween(begin: gradientColors[0], end: gradientColors[1])
                     .lerp(0.2)!
-                    .withOpacity(0.1),
+                    .withValues(alpha: 0.1),
                 ColorTween(begin: gradientColors[0], end: gradientColors[1])
                     .lerp(0.2)!
-                    .withOpacity(0.1),
+                    .withValues(alpha: 0.1),
               ],
             ),
           ),

--- a/example/lib/presentation/samples/line/line_chart_sample3.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample3.dart
@@ -1,5 +1,5 @@
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 class LineChartSample3 extends StatefulWidget {
@@ -16,20 +16,20 @@ class LineChartSample3 extends StatefulWidget {
     Color? tooltipBgColor,
     Color? tooltipTextColor,
   })  : lineColor = lineColor ?? AppColors.contentColorRed,
-        indicatorLineColor =
-            indicatorLineColor ?? AppColors.contentColorYellow.withOpacity(0.2),
+        indicatorLineColor = indicatorLineColor ??
+            AppColors.contentColorYellow.withValues(alpha: 0.2),
         indicatorTouchedLineColor =
             indicatorTouchedLineColor ?? AppColors.contentColorYellow,
         indicatorSpotStrokeColor = indicatorSpotStrokeColor ??
-            AppColors.contentColorYellow.withOpacity(0.5),
+            AppColors.contentColorYellow.withValues(alpha: 0.5),
         indicatorTouchedSpotStrokeColor =
             indicatorTouchedSpotStrokeColor ?? AppColors.contentColorYellow,
-        bottomTextColor =
-            bottomTextColor ?? AppColors.contentColorYellow.withOpacity(0.2),
+        bottomTextColor = bottomTextColor ??
+            AppColors.contentColorYellow.withValues(alpha: 0.2),
         bottomTouchedTextColor =
             bottomTouchedTextColor ?? AppColors.contentColorYellow,
-        averageLineColor =
-            averageLineColor ?? AppColors.contentColorGreen.withOpacity(0.8),
+        averageLineColor = averageLineColor ??
+            AppColors.contentColorGreen.withValues(alpha: 0.8),
         tooltipBgColor = tooltipBgColor ?? AppColors.contentColorGreen,
         tooltipTextColor = tooltipTextColor ?? Colors.black;
 
@@ -70,7 +70,7 @@ class _LineChartSample3State extends State<LineChartSample3> {
       return Container();
     }
     final style = TextStyle(
-      color: AppColors.mainTextColor1.withOpacity(0.5),
+      color: AppColors.mainTextColor1.withValues(alpha: 0.5),
       fontSize: 10,
     );
     String text;
@@ -136,7 +136,7 @@ class _LineChartSample3State extends State<LineChartSample3> {
             Text(
               'Average Line',
               style: TextStyle(
-                color: widget.averageLineColor.withOpacity(1),
+                color: widget.averageLineColor.withValues(alpha: 1),
                 fontWeight: FontWeight.bold,
                 fontSize: 16,
               ),
@@ -152,7 +152,7 @@ class _LineChartSample3State extends State<LineChartSample3> {
             Text(
               'Indicators',
               style: TextStyle(
-                color: widget.indicatorLineColor.withOpacity(1),
+                color: widget.indicatorLineColor.withValues(alpha: 1),
                 fontWeight: FontWeight.bold,
                 fontSize: 16,
               ),
@@ -306,8 +306,8 @@ class _LineChartSample3State extends State<LineChartSample3> {
                       show: true,
                       gradient: LinearGradient(
                         colors: [
-                          widget.lineColor.withOpacity(0.5),
-                          widget.lineColor.withOpacity(0),
+                          widget.lineColor.withValues(alpha: 0.5),
+                          widget.lineColor.withValues(alpha: 0),
                         ],
                         stops: const [0.5, 1.0],
                         begin: Alignment.topCenter,

--- a/example/lib/presentation/samples/line/line_chart_sample4.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample4.dart
@@ -1,5 +1,5 @@
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 class LineChartSample4 extends StatelessWidget {
@@ -9,11 +9,11 @@ class LineChartSample4 extends StatelessWidget {
     Color? belowLineColor,
     Color? aboveLineColor,
   })  : mainLineColor =
-            mainLineColor ?? AppColors.contentColorYellow.withOpacity(1),
+            mainLineColor ?? AppColors.contentColorYellow.withValues(alpha: 1),
         belowLineColor =
-            belowLineColor ?? AppColors.contentColorPink.withOpacity(1),
-        aboveLineColor =
-            aboveLineColor ?? AppColors.contentColorPurple.withOpacity(0.7);
+            belowLineColor ?? AppColors.contentColorPink.withValues(alpha: 1),
+        aboveLineColor = aboveLineColor ??
+            AppColors.contentColorPurple.withValues(alpha: 0.7);
 
   final Color mainLineColor;
   final Color belowLineColor;

--- a/example/lib/presentation/samples/line/line_chart_sample5.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample5.dart
@@ -1,5 +1,5 @@
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 class LineChartSample5 extends StatefulWidget {
@@ -91,9 +91,9 @@ class _LineChartSample5State extends State<LineChartSample5> {
           show: true,
           gradient: LinearGradient(
             colors: [
-              widget.gradientColor1.withOpacity(0.4),
-              widget.gradientColor2.withOpacity(0.4),
-              widget.gradientColor3.withOpacity(0.4),
+              widget.gradientColor1.withValues(alpha: 0.4),
+              widget.gradientColor2.withValues(alpha: 0.4),
+              widget.gradientColor3.withValues(alpha: 0.4),
             ],
           ),
         ),

--- a/example/lib/presentation/samples/line/line_chart_sample7.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample7.dart
@@ -1,5 +1,5 @@
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 class LineChartSample7 extends StatelessWidget {
@@ -11,7 +11,7 @@ class LineChartSample7 extends StatelessWidget {
   })  : line1Color = line1Color ?? AppColors.contentColorGreen,
         line2Color = line2Color ?? AppColors.contentColorRed,
         betweenColor =
-            betweenColor ?? AppColors.contentColorRed.withOpacity(0.5);
+            betweenColor ?? AppColors.contentColorRed.withValues(alpha: 0.5);
 
   final Color line1Color;
   final Color line2Color;

--- a/example/lib/presentation/samples/line/line_chart_sample8.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample8.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:ui' as ui;
 
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_svg/flutter_svg.dart';
@@ -122,19 +122,19 @@ class _LineChartSample8State extends State<LineChartSample8> {
           VerticalRangeAnnotation(
             x1: 2,
             x2: 5,
-            color: AppColors.contentColorBlue.withOpacity(0.2),
+            color: AppColors.contentColorBlue.withValues(alpha: 0.2),
           ),
           VerticalRangeAnnotation(
             x1: 8,
             x2: 9,
-            color: AppColors.contentColorBlue.withOpacity(0.2),
+            color: AppColors.contentColorBlue.withValues(alpha: 0.2),
           ),
         ],
         horizontalRangeAnnotations: [
           HorizontalRangeAnnotation(
             y1: 2,
             y2: 3,
-            color: AppColors.contentColorGreen.withOpacity(0.3),
+            color: AppColors.contentColorGreen.withValues(alpha: 0.3),
           ),
         ],
       ),

--- a/example/lib/presentation/samples/line/line_chart_sample9.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample9.dart
@@ -1,7 +1,7 @@
 import 'dart:math';
 
-import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:flutter/material.dart';
 
 // ignore: must_be_immutable
@@ -130,12 +130,12 @@ class LineChartSample9 extends StatelessWidget {
                     return value.toInt() == 0;
                   },
                   getDrawingHorizontalLine: (_) => FlLine(
-                    color: AppColors.contentColorBlue.withOpacity(1),
+                    color: AppColors.contentColorBlue.withValues(alpha: 1),
                     dashArray: [8, 2],
                     strokeWidth: 0.8,
                   ),
                   getDrawingVerticalLine: (_) => FlLine(
-                    color: AppColors.contentColorYellow.withOpacity(1),
+                    color: AppColors.contentColorYellow.withValues(alpha: 1),
                     dashArray: [8, 2],
                     strokeWidth: 0.8,
                   ),

--- a/example/lib/presentation/samples/pie/pie_chart_sample1.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample1.dart
@@ -1,6 +1,6 @@
+import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart_app/presentation/resources/app_resources.dart';
 import 'package:fl_chart_app/presentation/widgets/indicator.dart';
-import 'package:fl_chart/fl_chart.dart';
 import 'package:flutter/material.dart';
 
 class PieChartSample1 extends StatefulWidget {
@@ -123,7 +123,7 @@ class PieChartSample1State extends State {
                   ? const BorderSide(
                       color: AppColors.contentColorWhite, width: 6)
                   : BorderSide(
-                      color: AppColors.contentColorWhite.withOpacity(0)),
+                      color: AppColors.contentColorWhite.withValues(alpha: 0)),
             );
           case 1:
             return PieChartSectionData(
@@ -136,7 +136,7 @@ class PieChartSample1State extends State {
                   ? const BorderSide(
                       color: AppColors.contentColorWhite, width: 6)
                   : BorderSide(
-                      color: AppColors.contentColorWhite.withOpacity(0)),
+                      color: AppColors.contentColorWhite.withValues(alpha: 0)),
             );
           case 2:
             return PieChartSectionData(
@@ -149,7 +149,7 @@ class PieChartSample1State extends State {
                   ? const BorderSide(
                       color: AppColors.contentColorWhite, width: 6)
                   : BorderSide(
-                      color: AppColors.contentColorWhite.withOpacity(0)),
+                      color: AppColors.contentColorWhite.withValues(alpha: 0)),
             );
           case 3:
             return PieChartSectionData(
@@ -162,7 +162,7 @@ class PieChartSample1State extends State {
                   ? const BorderSide(
                       color: AppColors.contentColorWhite, width: 6)
                   : BorderSide(
-                      color: AppColors.contentColorWhite.withOpacity(0)),
+                      color: AppColors.contentColorWhite.withValues(alpha: 0)),
             );
           default:
             throw Error();

--- a/example/lib/presentation/samples/pie/pie_chart_sample3.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample3.dart
@@ -164,7 +164,7 @@ class _Badge extends StatelessWidget {
         ),
         boxShadow: <BoxShadow>[
           BoxShadow(
-            color: Colors.black.withOpacity(.5),
+            color: Colors.black.withValues(alpha: .5),
             offset: const Offset(3, 3),
             blurRadius: 3,
           ),

--- a/example/lib/presentation/samples/radar/radar_chart_sample1.dart
+++ b/example/lib/presentation/samples/radar/radar_chart_sample1.dart
@@ -208,10 +208,11 @@ class _RadarChartSample1State extends State<RadarChartSample1> {
 
       return RadarDataSet(
         fillColor: isSelected
-            ? rawDataSet.color.withOpacity(0.2)
-            : rawDataSet.color.withOpacity(0.05),
-        borderColor:
-            isSelected ? rawDataSet.color : rawDataSet.color.withOpacity(0.25),
+            ? rawDataSet.color.withValues(alpha: 0.2)
+            : rawDataSet.color.withValues(alpha: 0.05),
+        borderColor: isSelected
+            ? rawDataSet.color
+            : rawDataSet.color.withValues(alpha: 0.25),
         entryRadius: isSelected ? 3 : 2,
         dataEntries:
             rawDataSet.values.map((e) => RadarEntry(value: e)).toList(),

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample1.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample1.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 class ScatterChartSample1 extends StatefulWidget {
   ScatterChartSample1({super.key});
 
-  final blue1 = AppColors.contentColorBlue.withOpacity(0.5);
+  final blue1 = AppColors.contentColorBlue.withValues(alpha: 0.5);
   final blue2 = AppColors.contentColorBlue;
 
   @override

--- a/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
+++ b/example/lib/presentation/samples/scatter/scatter_chart_sample2.dart
@@ -88,7 +88,7 @@ class _ScatterChartSample2State extends State {
                     size,
                     selectedSpots.contains(index)
                         ? _availableColors[index % _availableColors.length]
-                        : AppColors.contentColorWhite.withOpacity(0.5),
+                        : AppColors.contentColorWhite.withValues(alpha: 0.5),
                   ),
                 );
               }).toList(),

--- a/example/lib/util/extensions/color_extensions.dart
+++ b/example/lib/util/extensions/color_extensions.dart
@@ -6,10 +6,10 @@ extension ColorExtension on Color {
     assert(1 <= percent && percent <= 100);
     final value = 1 - percent / 100;
     return Color.fromARGB(
-      alpha,
-      (red * value).round(),
-      (green * value).round(),
-      (blue * value).round(),
+      _floatToInt8(a),
+      (_floatToInt8(r) * value).round(),
+      (_floatToInt8(g) * value).round(),
+      (_floatToInt8(b) * value).round(),
     );
   }
 
@@ -17,18 +17,27 @@ extension ColorExtension on Color {
     assert(1 <= percent && percent <= 100);
     final value = percent / 100;
     return Color.fromARGB(
-      alpha,
-      (red + ((255 - red) * value)).round(),
-      (green + ((255 - green) * value)).round(),
-      (blue + ((255 - blue) * value)).round(),
+      _floatToInt8(a),
+      (_floatToInt8(r) + ((255 - _floatToInt8(r)) * value)).round(),
+      (_floatToInt8(g) + ((255 - _floatToInt8(g)) * value)).round(),
+      (_floatToInt8(b) + ((255 - _floatToInt8(b)) * value)).round(),
     );
   }
 
   Color avg(Color other) {
-    final red = (this.red + other.red) ~/ 2;
-    final green = (this.green + other.green) ~/ 2;
-    final blue = (this.blue + other.blue) ~/ 2;
-    final alpha = (this.alpha + other.alpha) ~/ 2;
+    final red = (_floatToInt8(r) + _floatToInt8(other.r)) ~/ 2;
+    final green = (_floatToInt8(g) + _floatToInt8(other.g)) ~/ 2;
+    final blue = (_floatToInt8(b) + _floatToInt8(other.b)) ~/ 2;
+    final alpha = (_floatToInt8(a) + _floatToInt8(other.a)) ~/ 2;
     return Color.fromARGB(alpha, red, green, blue);
+  }
+
+  // Int color components were deprecated in Flutter 3.27.0.
+  // This method is used to convert the new double color components to the
+  // old int color components.
+  //
+  // Taken from the Color class.
+  int _floatToInt8(double x) {
+    return (x * 255.0).round() & 0xff;
   }
 }

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -311,7 +311,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
           }
 
           // draw border stroke
-          if (borderSide.width > 0 && borderSide.color.opacity > 0) {
+          if (borderSide.width > 0 && borderSide.color.a > 0) {
             _barStrokePaint
               ..color = borderSide.color
               ..strokeWidth = borderSide.width;
@@ -526,8 +526,9 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
     Size drawSize,
     PaintHolder<BarChartData> holder,
   ) {
-    if (stackItem.borderSide.width == 0 ||
-        stackItem.borderSide.color.opacity == 0) return;
+    if (stackItem.borderSide.width == 0 || stackItem.borderSide.color.a == 0) {
+      return;
+    }
     RRect strokeBarRect;
     if (index == 0) {
       strokeBarRect = RRect.fromLTRBAndCorners(

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -1377,7 +1377,7 @@ class FlDotCirclePainter extends FlDotPainter {
   /// Implementation of the parent class to draw the circle
   @override
   void draw(Canvas canvas, FlSpot spot, Offset offsetInCanvas) {
-    if (strokeWidth != 0.0 && strokeColor.opacity != 0.0) {
+    if (strokeWidth != 0.0 && strokeColor.a != 0.0) {
       canvas.drawCircle(
         offsetInCanvas,
         radius + (strokeWidth / 2),
@@ -1474,7 +1474,7 @@ class FlDotSquarePainter extends FlDotPainter {
   /// Implementation of the parent class to draw the square
   @override
   void draw(Canvas canvas, FlSpot spot, Offset offsetInCanvas) {
-    if (strokeWidth != 0.0 && strokeColor.opacity != 0.0) {
+    if (strokeWidth != 0.0 && strokeColor.a != 0.0) {
       canvas.drawRect(
         Rect.fromCircle(
           center: offsetInCanvas,

--- a/lib/src/chart/base/axis_chart/axis_chart_painter.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_painter.dart
@@ -153,7 +153,7 @@ abstract class AxisChartPainter<D extends AxisChartData>
   @visibleForTesting
   void drawBackground(CanvasWrapper canvasWrapper, PaintHolder<D> holder) {
     final data = holder.data;
-    if (data.backgroundColor.opacity == 0.0) {
+    if (data.backgroundColor.a == 0.0) {
       return;
     }
 

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -527,7 +527,7 @@ class BarAreaData with EquatableMixin {
     this.applyCutOffY = false,
   }) : color = color ??
             ((color == null && gradient == null)
-                ? Colors.blueGrey.withOpacity(0.5)
+                ? Colors.blueGrey.withValues(alpha: 0.5)
                 : null);
 
   final bool show;
@@ -584,7 +584,7 @@ class BetweenBarsData with EquatableMixin {
     this.gradient,
   }) : color = color ??
             ((color == null && gradient == null)
-                ? Colors.blueGrey.withOpacity(0.5)
+                ? Colors.blueGrey.withValues(alpha: 0.5)
                 : null);
 
   /// The index of the lineBarsData from where the area has to be rendered

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -908,7 +908,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     Path barPath,
     LineChartBarData barData,
   ) {
-    if (!barData.show || barData.shadow.color.opacity == 0.0) {
+    if (!barData.show || barData.shadow.color.a == 0.0) {
       return;
     }
     if (barPath.computeMetrics().isEmpty) {

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -140,7 +140,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           ..restore();
         _sectionPaint.blendMode = BlendMode.srcOver;
         if (section.borderSide.width != 0.0 &&
-            section.borderSide.color.opacity != 0.0) {
+            section.borderSide.color.a != 0.0) {
           _sectionStrokePaint
             ..strokeWidth = section.borderSide.width
             ..color = section.borderSide.color;
@@ -326,8 +326,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     CanvasWrapper canvasWrapper,
     Size viewSize,
   ) {
-    if (section.borderSide.width != 0.0 &&
-        section.borderSide.color.opacity != 0.0) {
+    if (section.borderSide.width != 0.0 && section.borderSide.color.a != 0.0) {
       canvasWrapper
         ..saveLayer(
           Rect.fromLTWH(0, 0, viewSize.width, viewSize.height),

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -289,7 +289,7 @@ class RadarDataSet with EquatableMixin {
           'Radar needs at least 3 RadarEntry',
         ),
         dataEntries = dataEntries ?? const [],
-        fillColor = fillColor ?? Colors.cyan.withOpacity(0.2),
+        fillColor = fillColor ?? Colors.cyan.withValues(alpha: 0.2),
         borderColor = borderColor ?? Colors.cyan,
         borderWidth = borderWidth ?? 2.0,
         entryRadius = entryRadius ?? 5.0;

--- a/lib/src/extensions/border_extension.dart
+++ b/lib/src/extensions/border_extension.dart
@@ -9,10 +9,10 @@ extension BorderExtension on Border {
       return false;
     }
 
-    if (left.color.opacity == 0.0 &&
-        top.color.opacity == 0.0 &&
-        right.color.opacity == 0.0 &&
-        bottom.color.opacity == 0.0) {
+    if (left.color.a == 0.0 &&
+        top.color.a == 0.0 &&
+        right.color.a == 0.0 &&
+        bottom.color.a == 0.0) {
       return false;
     }
     return true;

--- a/lib/src/extensions/color_extension.dart
+++ b/lib/src/extensions/color_extension.dart
@@ -6,10 +6,19 @@ extension ColorExtension on Color {
     assert(1 <= percent && percent <= 100);
     final value = 1 - percent / 100;
     return Color.fromARGB(
-      alpha,
-      (red * value).round(),
-      (green * value).round(),
-      (blue * value).round(),
+      _floatToInt8(a),
+      (_floatToInt8(r) * value).round(),
+      (_floatToInt8(g) * value).round(),
+      (_floatToInt8(b) * value).round(),
     );
+  }
+
+  // Int color components were deprecated in Flutter 3.27.0.
+  // This method is used to convert the new double color components to the
+  // old int color components.
+  //
+  // Taken from the Color class.
+  int _floatToInt8(double x) {
+    return (x * 255.0).round() & 0xff;
   }
 }

--- a/lib/src/extensions/paint_extension.dart
+++ b/lib/src/extensions/paint_extension.dart
@@ -5,7 +5,7 @@ extension PaintExtension on Paint {
   void transparentIfWidthIsZero() {
     if (strokeWidth == 0) {
       shader = null;
-      color = color.withOpacity(0);
+      color = color.withValues(alpha: 0);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ documentation: https://github.com/imaNNeo/fl_chart
 
 environment:
   sdk: ^3.2.0
-  flutter: '>=3.16.0'
+  flutter: ">=3.27.0"
 
 funding:
   - https://github.com/sponsors/imaNNeo
@@ -28,21 +28,21 @@ dev_dependencies:
   very_good_analysis: ^6.0.0
 
 screenshots:
-  - description: 'FL Chart Logo'
+  - description: "FL Chart Logo"
     path: pub_screenshots/logo_1024.png
-  - description: 'LineChartSample1 and LineChartSample2'
+  - description: "LineChartSample1 and LineChartSample2"
     path: pub_screenshots/line_chart.jpg
-  - description: 'LineChartSample10'
+  - description: "LineChartSample10"
     path: pub_screenshots/line_chart_sample_10.gif
-  - description: 'BarChartSample1 and BarChartSample2'
+  - description: "BarChartSample1 and BarChartSample2"
     path: pub_screenshots/bar_chart.jpg
-  - description: 'BarChartSample7'
+  - description: "BarChartSample7"
     path: pub_screenshots/bar_chart_sample_7.gif
-  - description: 'PieChartSample1, PieChartSample2 and PieChartSample3'
+  - description: "PieChartSample1, PieChartSample2 and PieChartSample3"
     path: pub_screenshots/pie_chart.jpg
-  - description: 'ScatterChartSample2'
+  - description: "ScatterChartSample2"
     path: pub_screenshots/scatter_chart_sample_2.gif
-  - description: 'RadarChartSample1'
+  - description: "RadarChartSample1"
     path: pub_screenshots/radar_chart_sample_1.jpg
 
 topics:
@@ -51,4 +51,3 @@ topics:
   - visualization
   - graph
   - diagram
-

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -409,7 +409,10 @@ void main() {
         ),
         true,
       );
-      expect(results[0]['paint_color'] as Color, const Color(0x00000000));
+      expect(
+        results[0]['paint_color'] as Color,
+        isSameColorAs(const Color(0x00000000)),
+      );
 
       expect(
         HelperMethods.equalsRRects(
@@ -424,7 +427,10 @@ void main() {
         ),
         true,
       );
-      expect(results[1]['paint_color'] as Color, const Color(0x11111111));
+      expect(
+        results[1]['paint_color'] as Color,
+        isSameColorAs(const Color(0x11111111)),
+      );
 
       expect(
         HelperMethods.equalsRRects(
@@ -439,7 +445,10 @@ void main() {
         ),
         true,
       );
-      expect(results[2]['paint_color'] as Color, const Color(0x22222222));
+      expect(
+        results[2]['paint_color'] as Color,
+        isSameColorAs(const Color(0x22222222)),
+      );
 
       expect(
         HelperMethods.equalsRRects(
@@ -674,7 +683,10 @@ void main() {
         ),
         true,
       );
-      expect(results[0]['paint_color'] as Color, const Color(0x00000000));
+      expect(
+        results[0]['paint_color'] as Color,
+        isSameColorAs(const Color(0x00000000)),
+      );
 
       expect(
         HelperMethods.equalsRRects(
@@ -689,7 +701,10 @@ void main() {
         ),
         true,
       );
-      expect(results[1]['paint_color'] as Color, const Color(0x11111111));
+      expect(
+        results[1]['paint_color'] as Color,
+        isSameColorAs(const Color(0x11111111)),
+      );
 
       expect(
         HelperMethods.equalsRRects(
@@ -704,7 +719,10 @@ void main() {
         ),
         true,
       );
-      expect(results[2]['paint_color'] as Color, const Color(0x22222222));
+      expect(
+        results[2]['paint_color'] as Color,
+        isSameColorAs(const Color(0x22222222)),
+      );
 
       expect(
         HelperMethods.equalsRRects(
@@ -798,10 +816,22 @@ void main() {
 
       barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
       expect(results.length, 5);
-      expect(results[1]['paint_color'], const Color(0x11111111));
-      expect(results[2]['paint_color'], const Color(0x22222222));
-      expect(results[3]['paint_color'], const Color(0x33333333));
-      expect(results[4]['paint_color'], const Color(0x44444444));
+      expect(
+        results[1]['paint_color'],
+        isSameColorAs(const Color(0x11111111)),
+      );
+      expect(
+        results[2]['paint_color'],
+        isSameColorAs(const Color(0x22222222)),
+      );
+      expect(
+        results[3]['paint_color'],
+        isSameColorAs(const Color(0x33333333)),
+      );
+      expect(
+        results[4]['paint_color'],
+        isSameColorAs(const Color(0x44444444)),
+      );
     });
 
     test('test 4', () {
@@ -1176,7 +1206,7 @@ void main() {
       expect(rrect.top, -106);
 
       final bgTooltipPaint = result1.captured[1] as Paint;
-      expect(bgTooltipPaint.color, const Color(0xf33f33f3));
+      expect(bgTooltipPaint.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(bgTooltipPaint.style, PaintingStyle.fill);
 
       final rRectBorder = result1.captured[2] as RRect;
@@ -1187,7 +1217,7 @@ void main() {
       expect(rRectBorder.height, 90);
       expect(rRectBorder.left, -22.5);
       expect(rRectBorder.top, -106);
-      expect(paintBorder.color, const Color(0xf33f33f3));
+      expect(paintBorder.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(paintBorder.strokeWidth, 2);
       expect(paintBorder.style, PaintingStyle.stroke);
 
@@ -1376,7 +1406,7 @@ void main() {
       expect(rrect.top, 116);
 
       final bgTooltipPaint = result1.captured[1] as Paint;
-      expect(bgTooltipPaint.color, const Color(0xf33f33f3));
+      expect(bgTooltipPaint.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(bgTooltipPaint.style, PaintingStyle.fill);
 
       final rRectBorder = result1.captured[2] as RRect;
@@ -1387,7 +1417,7 @@ void main() {
       expect(rRectBorder.height, 90);
       expect(rRectBorder.left, -80);
       expect(rRectBorder.top, 116);
-      expect(paintBorder.color, const Color(0xf33f33f3));
+      expect(paintBorder.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(paintBorder.strokeWidth, 2);
       expect(paintBorder.style, PaintingStyle.stroke);
 
@@ -1551,7 +1581,7 @@ void main() {
       expect(rrect.top, -6934.0);
 
       final bgTooltipPaint = result1.captured[1] as Paint;
-      expect(bgTooltipPaint.color, const Color(0xf33f33f3));
+      expect(bgTooltipPaint.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(bgTooltipPaint.style, PaintingStyle.fill);
 
       final rRectBorder = result1.captured[2] as RRect;
@@ -1562,7 +1592,7 @@ void main() {
       expect(rRectBorder.height, 7034.0);
       expect(rRectBorder.left, -2436);
       expect(rRectBorder.top, -6934.0);
-      expect(paintBorder.color, const Color(0xf33f33f3));
+      expect(paintBorder.color, isSameColorAs(const Color(0xf33f33f3)));
       expect(paintBorder.strokeWidth, 2);
       expect(paintBorder.style, PaintingStyle.stroke);
 
@@ -1710,7 +1740,10 @@ void main() {
           bottomRight: const Radius.circular(12),
         ),
       );
-      expect(results[0]['paint.color'], const Color(0x11111111));
+      expect(
+        results[0]['paint.color'],
+        isSameColorAs(const Color(0x11111111)),
+      );
       expect(results[0]['paint.strokeWidth'], 1.0);
 
       expect(
@@ -1722,7 +1755,10 @@ void main() {
           70,
         ),
       );
-      expect(results[1]['paint.color'], const Color(0x22222221));
+      expect(
+        results[1]['paint.color'],
+        isSameColorAs(const Color(0x22222221)),
+      );
       expect(results[1]['paint.strokeWidth'], 2.0);
 
       expect(
@@ -1734,7 +1770,10 @@ void main() {
           20,
         ),
       );
-      expect(results[2]['paint.color'], const Color(0x33333331));
+      expect(
+        results[2]['paint.color'],
+        isSameColorAs(const Color(0x33333331)),
+      );
       expect(results[2]['paint.strokeWidth'], 3.0);
     });
   });
@@ -2203,9 +2242,9 @@ void main() {
           any,
           argThat(
             const TypeMatcher<Paint>().having(
-              (p0) => p0.color.value,
+              (p0) => p0.color,
               'colors match',
-              equals(Colors.red),
+              isSameColorAs(Colors.red),
             ),
           ),
           holder.data.extraLinesData.verticalLines[0].dashArray,
@@ -2300,9 +2339,9 @@ void main() {
           any,
           argThat(
             const TypeMatcher<Paint>().having(
-              (p0) => p0.color.value,
+              (p0) => p0.color,
               'colors match',
-              equals(Colors.red.value),
+              isSameColorAs(Colors.red),
             ),
           ),
           holder.data.extraLinesData.horizontalLines[0].dashArray,
@@ -2396,9 +2435,9 @@ void main() {
           any,
           captureThat(
             const TypeMatcher<Paint>().having(
-              (p0) => p0.color.value,
+              (p0) => p0.color,
               'colors match',
-              equals(Colors.cyanAccent.value),
+              isSameColorAs(Colors.cyanAccent),
             ),
           ),
           [100, 20],
@@ -2407,7 +2446,7 @@ void main() {
         results.add({
           'from': inv.positionalArguments[0] as Offset,
           'to': inv.positionalArguments[1] as Offset,
-          'paint_color': (inv.positionalArguments[2] as Paint).color.value,
+          'paint_color': (inv.positionalArguments[2] as Paint).color,
           'paint_stroke_width':
               (inv.positionalArguments[2] as Paint).strokeWidth,
         });
@@ -2421,7 +2460,7 @@ void main() {
 
       expect(results.length, 1);
 
-      expect(results[0]['paint_color'], Colors.cyanAccent.value);
+      expect(results[0]['paint_color'], isSameColorAs(Colors.cyanAccent));
       expect(results[0]['paint_stroke_width'], 90);
 
       Utils.changeInstance(utilsMainInstance);
@@ -2480,9 +2519,9 @@ void main() {
           any,
           argThat(
             const TypeMatcher<Paint>().having(
-              (p0) => p0.color.value,
+              (p0) => p0.color,
               'colors match',
-              equals(Colors.cyanAccent.value),
+              isSameColorAs(Colors.cyanAccent),
             ),
           ),
           holder.data.extraLinesData.horizontalLines[0].dashArray,

--- a/test/chart/base/axis_chart/axis_chart_data_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_data_test.dart
@@ -242,7 +242,7 @@ void main() {
       expect(
         horizontalRangeAnnotation1 ==
             HorizontalRangeAnnotation(
-              color: Colors.green.withOpacity(0.5),
+              color: Colors.green.withValues(alpha: 0.5),
               y2: 12,
               y1: 12.1,
             ),
@@ -274,7 +274,7 @@ void main() {
       expect(
         verticalRangeAnnotation1 ==
             VerticalRangeAnnotation(
-              color: Colors.green.withOpacity(0.5),
+              color: Colors.green.withValues(alpha: 0.5),
               x2: 12,
               x1: 12.1,
             ),

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -639,7 +639,7 @@ final FlBorderData borderData1Clone = FlBorderData(
 );
 final FlBorderData borderData2 = FlBorderData(
   show: true,
-  border: Border.all(color: Colors.green.withOpacity(0.5)),
+  border: Border.all(color: Colors.green.withValues(alpha: 0.5)),
 );
 
 bool checkToShowSpotLine(FlSpot spot) => true;
@@ -798,7 +798,7 @@ const Shadow shadow3 = Shadow(
   blurRadius: 14,
 );
 final Shadow shadow4 = Shadow(
-  color: Colors.red.withOpacity(0.5),
+  color: Colors.red.withValues(alpha: 0.5),
   blurRadius: 12,
 );
 
@@ -974,7 +974,7 @@ final LineChartBarData lineChartBarData6 = LineChartBarData(
 final LineChartBarData lineChartBarData7 = LineChartBarData(
   dashArray: [0, 1],
   gradient: LinearGradient(
-    colors: [Colors.red, Colors.green.withOpacity(0.4)],
+    colors: [Colors.red, Colors.green.withValues(alpha: 0.4)],
     stops: const [0, 1],
     begin: Alignment.center,
     end: Alignment.bottomRight,
@@ -2007,7 +2007,7 @@ final LineChartData lineChartData9 = LineChartData(
     showingTooltipIndicator1,
     showingTooltipIndicator2,
   ],
-  backgroundColor: Colors.red.withOpacity(0.2),
+  backgroundColor: Colors.red.withValues(alpha: 0.2),
   maxY: 23,
   rangeAnnotations: rangeAnnotations1,
   gridData: flGridData1,

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -1,6 +1,6 @@
 import 'dart:math' as math;
-import 'dart:ui';
 import 'dart:ui' as ui show Gradient;
+import 'dart:ui';
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
@@ -448,8 +448,8 @@ void main() {
       final paint = verificationResult.captured.single as Paint;
       verificationResult.called(1);
       expect(
-        paint.color.value,
-        barData.gradient?.colors.first.value ?? barData.color?.value,
+        paint.color,
+        isSameColorAs(barData.gradient?.colors.first ?? barData.color!),
       );
     });
   });
@@ -1448,7 +1448,7 @@ void main() {
       expect(results.length, 2);
 
       for (final item in results) {
-        expect((item['paint_color'] as Color).alpha, 0);
+        expect((item['paint_color'] as Color).a, 0);
         expect(item['paint_stroke_width'], 18);
       }
     });
@@ -1630,7 +1630,7 @@ void main() {
       expect(results.length, 2);
 
       for (final item in results) {
-        expect((item['paint_color'] as Color).alpha, 0);
+        expect((item['paint_color'] as Color).a, 0);
         expect(item['paint_stroke_width'], 18);
       }
     });
@@ -1785,7 +1785,7 @@ void main() {
       expect(path.getBounds(), barPath.shift(const Offset(10, 15)).getBounds());
 
       final paint = result.captured[1] as Paint;
-      expect(paint.color, const Color(0x0100FF00));
+      expect(paint.color, isSameColorAs(const Color(0x0100FF00)));
       expect(paint.shader, null);
       expect(paint.strokeWidth, 80);
       expect(
@@ -1903,7 +1903,7 @@ void main() {
       expect(drewPath, barPath);
 
       final paint = result.captured[1] as Paint;
-      expect(paint.color, const Color(0xF0F0F0F0));
+      expect(paint.color, isSameColorAs(const Color(0xF0F0F0F0)));
       expect(paint.shader, null);
       expect(paint.maskFilter, null);
       expect(paint.strokeWidth, 80);
@@ -2093,22 +2093,34 @@ void main() {
 
       expect(results.length, 4);
 
-      expect(results[0]['paint_color'], const Color(0x11111111));
+      expect(
+        results[0]['paint_color'],
+        isSameColorAs(const Color(0x11111111)),
+      );
       expect(results[0]['paint_stroke_width'], 11);
       expect(results[0]['from'], const Offset(0, 90));
       expect(results[0]['to'], const Offset(100, 90));
 
-      expect(results[1]['paint_color'], const Color(0x22222222));
+      expect(
+        results[1]['paint_color'],
+        isSameColorAs(const Color(0x22222222)),
+      );
       expect(results[1]['paint_stroke_width'], 22);
       expect(results[1]['from'], const Offset(0, 80));
       expect(results[1]['to'], const Offset(100, 80));
 
-      expect(results[2]['paint_color'], const Color(0x33333333));
+      expect(
+        results[2]['paint_color'],
+        isSameColorAs(const Color(0x33333333)),
+      );
       expect(results[2]['paint_stroke_width'], 33);
       expect(results[2]['from'], const Offset(40, 0));
       expect(results[2]['to'], const Offset(40, 100));
 
-      expect(results[3]['paint_color'], const Color(0x44444444));
+      expect(
+        results[3]['paint_color'],
+        isSameColorAs(const Color(0x44444444)),
+      );
       expect(results[3]['paint_stroke_width'], 44);
       expect(results[3]['from'], const Offset(50, 0));
       expect(results[3]['to'], const Offset(50, 100));
@@ -2160,9 +2172,9 @@ void main() {
           any,
           argThat(
             const TypeMatcher<Paint>().having(
-              (p0) => p0.color.value,
+              (p0) => p0.color,
               'colors match',
-              equals(Colors.cyanAccent.value),
+              isSameColorAs(Colors.cyanAccent),
             ),
           ),
           holder.data.extraLinesData.horizontalLines[0].dashArray,
@@ -2215,9 +2227,9 @@ void main() {
           any,
           argThat(
             const TypeMatcher<Paint>().having(
-              (p0) => p0.color.value,
+              (p0) => p0.color,
               'colors match',
-              equals(Colors.cyanAccent.value),
+              isSameColorAs(Colors.cyanAccent),
             ),
           ),
           holder.data.extraLinesData.verticalLines[0].dashArray,
@@ -2282,9 +2294,9 @@ void main() {
           any,
           argThat(
             const TypeMatcher<Paint>().having(
-              (p0) => p0.color.value,
+              (p0) => p0.color,
               'colors match',
-              equals(Colors.cyanAccent.value),
+              isSameColorAs(Colors.cyanAccent),
             ),
           ),
           holder.data.extraLinesData.verticalLines[0].dashArray,
@@ -2471,14 +2483,14 @@ void main() {
         rRect,
         RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
       );
-      expect(paint.color, const Color(0x11111111));
+      expect(paint.color, isSameColorAs(const Color(0x11111111)));
       final rRectBorder = result1.captured[2] as RRect;
       final paintBorder = result1.captured[3] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(0, 40, 38, 78, const Radius.circular(12)),
       );
-      expect(paintBorder.color, const Color(0x11111111));
+      expect(paintBorder.color, isSameColorAs(const Color(0x11111111)));
       expect(paintBorder.strokeWidth, 2);
 
       final result2 = verify(mockCanvasWrapper.drawText(captureAny, captureAny))
@@ -2582,14 +2594,14 @@ void main() {
         rRect,
         RRect.fromLTRBR(-28, 40, 10, 78, const Radius.circular(12)),
       );
-      expect(paint.color, const Color(0x11111111));
+      expect(paint.color, isSameColorAs(const Color(0x11111111)));
       final rRectBorder = result1.captured[2] as RRect;
       final paintBorder = result1.captured[3] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(-28, 40, 10, 78, const Radius.circular(12)),
       );
-      expect(paintBorder.color, const Color(0x11111111));
+      expect(paintBorder.color, isSameColorAs(const Color(0x11111111)));
       expect(paintBorder.strokeWidth, 2);
 
       final result2 = verify(mockCanvasWrapper.drawText(captureAny, captureAny))
@@ -2693,14 +2705,14 @@ void main() {
         rRect,
         RRect.fromLTRBR(10, 40, 48, 78, const Radius.circular(12)),
       );
-      expect(paint.color, const Color(0x11111111));
+      expect(paint.color, isSameColorAs(const Color(0x11111111)));
       final rRectBorder = result1.captured[2] as RRect;
       final paintBorder = result1.captured[3] as Paint;
       expect(
         rRectBorder,
         RRect.fromLTRBR(10, 40, 48, 78, const Radius.circular(12)),
       );
-      expect(paintBorder.color, const Color(0x11111111));
+      expect(paintBorder.color, isSameColorAs(const Color(0x11111111)));
       expect(paintBorder.strokeWidth, 2);
 
       final result2 = verify(mockCanvasWrapper.drawText(captureAny, captureAny))
@@ -3351,13 +3363,13 @@ void main() {
 
       expect(results[0]['from'], const Offset(0, 60));
       expect(results[0]['to'], const Offset(20, 60));
-      expect(results[0]['paint_color'], MockData.color1);
+      expect(results[0]['paint_color'], isSameColorAs(MockData.color1));
       expect(results[0]['paint_stroke_width'], 11);
       expect(results[0]['dash_array'], [1, 1]);
 
       expect(results[1]['from'], const Offset(0, 40));
       expect(results[1]['to'], const Offset(20, 40));
-      expect(results[1]['paint_color'], MockData.color2);
+      expect(results[1]['paint_color'], isSameColorAs(MockData.color2));
       expect(results[1]['paint_stroke_width'], 22);
       expect(results[1]['dash_array'], [2, 2]);
     });
@@ -3431,13 +3443,13 @@ void main() {
 
       expect(results[0]['from'], const Offset(40, 0));
       expect(results[0]['to'], const Offset(40, 20));
-      expect(results[0]['paint_color'], MockData.color1);
+      expect(results[0]['paint_color'], isSameColorAs(MockData.color1));
       expect(results[0]['paint_stroke_width'], 11);
       expect(results[0]['dash_array'], [1, 1]);
 
       expect(results[1]['from'], const Offset(60, 0));
       expect(results[1]['to'], const Offset(60, 20));
-      expect(results[1]['paint_color'], MockData.color2);
+      expect(results[1]['paint_color'], isSameColorAs(MockData.color2));
       expect(results[1]['paint_stroke_width'], 22);
       expect(results[1]['dash_array'], [2, 2]);
     });
@@ -3481,7 +3493,7 @@ void main() {
         minX: 0,
         maxX: 10,
         titlesData: const FlTitlesData(show: false),
-        backgroundColor: MockData.color1.withOpacity(0),
+        backgroundColor: MockData.color1.withValues(alpha: 0),
       );
 
       final lineChartPainter = LineChartPainter();
@@ -3522,7 +3534,10 @@ void main() {
         ),
       );
       expect(result.callCount, 1);
-      expect((result.captured.single as Paint).color, MockData.color1);
+      expect(
+        (result.captured.single as Paint).color,
+        isSameColorAs(MockData.color1),
+      );
     });
   });
 
@@ -3586,10 +3601,10 @@ void main() {
       expect(results.length, 2);
 
       expect(results[0]['rect'], const Rect.fromLTRB(0, 0, 20, 60));
-      expect(results[0]['paint_color'], MockData.color1);
+      expect(results[0]['paint_color'], isSameColorAs(MockData.color1));
 
       expect(results[1]['rect'], const Rect.fromLTRB(0, -40, 20, -20));
-      expect(results[1]['paint_color'], MockData.color2);
+      expect(results[1]['paint_color'], isSameColorAs(MockData.color2));
     });
 
     test('test 3 - vertical', () {
@@ -3629,10 +3644,10 @@ void main() {
       expect(results.length, 2);
 
       expect(results[0]['rect'], const Rect.fromLTRB(2, 0, 4, 100));
-      expect(results[0]['paint_color'], MockData.color1);
+      expect(results[0]['paint_color'], isSameColorAs(MockData.color1));
 
       expect(results[1]['rect'], const Rect.fromLTRB(8, 0, 10, 100));
-      expect(results[1]['paint_color'], MockData.color2);
+      expect(results[1]['paint_color'], isSameColorAs(MockData.color2));
     });
 
     test('test 4 - both', () {

--- a/test/chart/pie_chart/pie_chart_data_test.dart
+++ b/test/chart/pie_chart/pie_chart_data_test.dart
@@ -83,7 +83,7 @@ void main() {
                 PieChartSectionData(value: 12, color: Colors.red),
                 PieChartSectionData(
                   value: 22,
-                  color: Colors.green.withOpacity(0.99),
+                  color: Colors.green.withValues(alpha: 0.99),
                 ),
               ],
             ),

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -109,7 +109,10 @@ void main() {
         mockCanvasWrapper.drawCircle(const Offset(100, 100), 10, captureAny),
       );
       expect(result.callCount, 1);
-      expect((result.captured.first as Paint).color, MockData.color1);
+      expect(
+        (result.captured.first as Paint).color,
+        isSameColorAs(MockData.color1),
+      );
     });
   });
 
@@ -220,7 +223,10 @@ void main() {
       ]);
       final result = results[1];
       expect(result.callCount, 1);
-      expect((result.captured.single as Paint).color, MockData.color2);
+      expect(
+        (result.captured.single as Paint).color,
+        isSameColorAs(MockData.color2),
+      );
       expect((result.captured.single as Paint).style, PaintingStyle.fill);
 
       final result2 = verify(
@@ -231,7 +237,10 @@ void main() {
         ),
       );
       expect(result2.callCount, 1);
-      expect((result2.captured.single as Paint).color, MockData.color3);
+      expect(
+        (result2.captured.single as Paint).color,
+        isSameColorAs(MockData.color3),
+      );
       expect((result2.captured.single as Paint).strokeWidth, 3);
       expect((result2.captured.single as Paint).style, PaintingStyle.stroke);
     });
@@ -290,7 +299,10 @@ void main() {
         HelperMethods.equalsPaths(results[0]['path'] as Path, path0),
         true,
       );
-      expect(results[0]['paint_color'] as Color, MockData.color1);
+      expect(
+        results[0]['paint_color'] as Color,
+        isSameColorAs(MockData.color1),
+      );
       expect(results[0]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
       final path1 = barChartPainter.generateSectionPath(
@@ -305,7 +317,10 @@ void main() {
         HelperMethods.equalsPaths(results[1]['path'] as Path, path1),
         true,
       );
-      expect(results[1]['paint_color'] as Color, MockData.color2);
+      expect(
+        results[1]['paint_color'] as Color,
+        isSameColorAs(MockData.color2),
+      );
       expect(results[1]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
       final path2 = barChartPainter.generateSectionPath(
@@ -320,7 +335,10 @@ void main() {
         HelperMethods.equalsPaths(results[2]['path'] as Path, path2),
         true,
       );
-      expect(results[2]['paint_color'] as Color, MockData.color3);
+      expect(
+        results[2]['paint_color'] as Color,
+        isSameColorAs(MockData.color3),
+      );
       expect(results[2]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
       final path3 = barChartPainter.generateSectionPath(
@@ -335,7 +353,10 @@ void main() {
         HelperMethods.equalsPaths(results[3]['path'] as Path, path3),
         true,
       );
-      expect(results[3]['paint_color'] as Color, MockData.color4);
+      expect(
+        results[3]['paint_color'] as Color,
+        isSameColorAs(MockData.color4),
+      );
       expect(results[3]['paint_style'] as PaintingStyle, PaintingStyle.fill);
     });
   });
@@ -646,19 +667,31 @@ void main() {
       expect(results.length, 4);
 
       expect(results[0]['path'] as Path, MockData.path1);
-      expect(results[0]['paint_color'] as Color, MockData.color1);
+      expect(
+        results[0]['paint_color'] as Color,
+        isSameColorAs(MockData.color1),
+      );
       expect(results[0]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
       expect(results[1]['path'] as Path, MockData.path2);
-      expect(results[1]['paint_color'] as Color, MockData.color2);
+      expect(
+        results[1]['paint_color'] as Color,
+        isSameColorAs(MockData.color2),
+      );
       expect(results[1]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
       expect(results[2]['path'] as Path, MockData.path3);
-      expect(results[2]['paint_color'] as Color, MockData.color3);
+      expect(
+        results[2]['paint_color'] as Color,
+        isSameColorAs(MockData.color3),
+      );
       expect(results[2]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
       expect(results[3]['path'] as Path, MockData.path4);
-      expect(results[3]['paint_color'] as Color, MockData.color4);
+      expect(
+        results[3]['paint_color'] as Color,
+        isSameColorAs(MockData.color4),
+      );
       expect(results[3]['paint_style'] as PaintingStyle, PaintingStyle.fill);
     });
   });
@@ -819,7 +852,10 @@ void main() {
       expect(drawPathResults.length, 4);
 
       expect(drawPathResults[0]['path'], MockData.path1);
-      expect(drawPathResults[0]['paint_color'], MockData.color1);
+      expect(
+        drawPathResults[0]['paint_color'],
+        isSameColorAs(MockData.color1),
+      );
       expect(drawPathResults[0]['paint_style'], PaintingStyle.stroke);
       expect(
         drawPathResults[0]['paint_stroke_width'],
@@ -827,7 +863,10 @@ void main() {
       );
 
       expect(drawPathResults[1]['path'], MockData.path2);
-      expect(drawPathResults[1]['paint_color'], MockData.color2);
+      expect(
+        drawPathResults[1]['paint_color'],
+        isSameColorAs(MockData.color2),
+      );
       expect(drawPathResults[1]['paint_style'], PaintingStyle.stroke);
       expect(
         drawPathResults[1]['paint_stroke_width'],
@@ -835,7 +874,10 @@ void main() {
       );
 
       expect(drawPathResults[2]['path'], MockData.path3);
-      expect(drawPathResults[2]['paint_color'], MockData.color3);
+      expect(
+        drawPathResults[2]['paint_color'],
+        isSameColorAs(MockData.color3),
+      );
       expect(drawPathResults[2]['paint_style'], PaintingStyle.stroke);
       expect(
         drawPathResults[2]['paint_stroke_width'],
@@ -843,7 +885,10 @@ void main() {
       );
 
       expect(drawPathResults[3]['path'], MockData.path4);
-      expect(drawPathResults[3]['paint_color'], MockData.color4);
+      expect(
+        drawPathResults[3]['paint_color'],
+        isSameColorAs(MockData.color4),
+      );
       expect(drawPathResults[3]['paint_style'], PaintingStyle.stroke);
       expect(
         drawPathResults[3]['paint_stroke_width'],

--- a/test/chart/radar_chart/radar_chart_painter_test.dart
+++ b/test/chart/radar_chart/radar_chart_painter_test.dart
@@ -151,20 +151,29 @@ void main() {
       // Background circle
       expect(drawCircleResults[0]['offset'], const Offset(200, 150));
       expect(drawCircleResults[0]['radius'], 120);
-      expect(drawCircleResults[0]['paint_color'], MockData.color2);
+      expect(
+        drawCircleResults[0]['paint_color'],
+        isSameColorAs(MockData.color2),
+      );
       expect(drawCircleResults[0]['paint_style'], PaintingStyle.fill);
 
       // Border circle
       expect(drawCircleResults[1]['offset'], const Offset(200, 150));
       expect(drawCircleResults[1]['radius'], 120);
-      expect(drawCircleResults[1]['paint_color'], MockData.color6);
+      expect(
+        drawCircleResults[1]['paint_color'],
+        isSameColorAs(MockData.color6),
+      );
       expect(drawCircleResults[1]['paint_stroke'], 33);
       expect(drawCircleResults[1]['paint_style'], PaintingStyle.stroke);
 
       // First Tick
       expect(drawCircleResults[2]['offset'], const Offset(200, 150));
       expect(drawCircleResults[2]['radius'], 60);
-      expect(drawCircleResults[2]['paint_color'], MockData.color5);
+      expect(
+        drawCircleResults[2]['paint_color'],
+        isSameColorAs(MockData.color5),
+      );
       expect(drawCircleResults[2]['paint_stroke'], 55);
       expect(drawCircleResults[2]['paint_style'], PaintingStyle.stroke);
 
@@ -240,17 +249,26 @@ void main() {
       expect(drawPathResult.length, 3);
 
       // Background circle
-      expect(drawPathResult[0]['paint_color'], MockData.color2);
+      expect(
+        drawPathResult[0]['paint_color'],
+        isSameColorAs(MockData.color2),
+      );
       expect(drawPathResult[0]['paint_stroke'], 0);
       expect(drawPathResult[0]['paint_style'], PaintingStyle.fill);
 
       // Border circle
-      expect(drawPathResult[1]['paint_color'], MockData.color6);
+      expect(
+        drawPathResult[1]['paint_color'],
+        isSameColorAs(MockData.color6),
+      );
       expect(drawPathResult[1]['paint_stroke'], 33);
       expect(drawPathResult[1]['paint_style'], PaintingStyle.stroke);
 
       // First Tick
-      expect(drawPathResult[2]['paint_color'], MockData.color5);
+      expect(
+        drawPathResult[2]['paint_color'],
+        isSameColorAs(MockData.color5),
+      );
       expect(drawPathResult[2]['paint_stroke'], 55);
       expect(drawPathResult[2]['paint_style'], PaintingStyle.stroke);
 
@@ -327,7 +345,10 @@ void main() {
 
       expect(drawLineResults[0]['offset_from'], const Offset(200, 150));
       expect(drawLineResults[0]['offset_to'], const Offset(200, 30));
-      expect(drawLineResults[0]['paint_color'], MockData.color3);
+      expect(
+        drawLineResults[0]['paint_color'],
+        isSameColorAs(MockData.color3),
+      );
       expect(drawLineResults[0]['paint_style'], PaintingStyle.stroke);
       expect(drawLineResults[0]['paint_stroke'], 3);
 
@@ -336,7 +357,10 @@ void main() {
         drawLineResults[1]['offset_to'],
         const Offset(303.92304845413264, 209.99999999999997),
       );
-      expect(drawLineResults[1]['paint_color'], MockData.color3);
+      expect(
+        drawLineResults[1]['paint_color'],
+        isSameColorAs(MockData.color3),
+      );
       expect(drawLineResults[1]['paint_style'], PaintingStyle.stroke);
       expect(drawLineResults[1]['paint_stroke'], 3);
 
@@ -345,7 +369,10 @@ void main() {
         drawLineResults[2]['offset_to'],
         const Offset(96.07695154586739, 210.00000000000006),
       );
-      expect(drawLineResults[2]['paint_color'], MockData.color3);
+      expect(
+        drawLineResults[2]['paint_color'],
+        isSameColorAs(MockData.color3),
+      );
       expect(drawLineResults[2]['paint_style'], PaintingStyle.stroke);
       expect(drawLineResults[2]['paint_stroke'], 3);
     });
@@ -643,24 +670,42 @@ void main() {
 
       expect(drawPathResults.length, 6);
 
-      expect(drawPathResults[0]['paint_color'], MockData.color1);
+      expect(
+        drawPathResults[0]['paint_color'],
+        isSameColorAs(MockData.color1),
+      );
       expect(drawPathResults[0]['paint_style'], PaintingStyle.fill);
 
-      expect(drawPathResults[1]['paint_color'], MockData.color3);
+      expect(
+        drawPathResults[1]['paint_color'],
+        isSameColorAs(MockData.color3),
+      );
       expect(drawPathResults[1]['paint_stroke'], 3);
       expect(drawPathResults[1]['paint_style'], PaintingStyle.stroke);
 
-      expect(drawPathResults[2]['paint_color'], MockData.color2);
+      expect(
+        drawPathResults[2]['paint_color'],
+        isSameColorAs(MockData.color2),
+      );
       expect(drawPathResults[2]['paint_style'], PaintingStyle.fill);
 
-      expect(drawPathResults[3]['paint_color'], MockData.color2);
+      expect(
+        drawPathResults[3]['paint_color'],
+        isSameColorAs(MockData.color2),
+      );
       expect(drawPathResults[3]['paint_stroke'], 2);
       expect(drawPathResults[3]['paint_style'], PaintingStyle.stroke);
 
-      expect(drawPathResults[4]['paint_color'], MockData.color3);
+      expect(
+        drawPathResults[4]['paint_color'],
+        isSameColorAs(MockData.color3),
+      );
       expect(drawPathResults[4]['paint_style'], PaintingStyle.fill);
 
-      expect(drawPathResults[5]['paint_color'], MockData.color1);
+      expect(
+        drawPathResults[5]['paint_color'],
+        isSameColorAs(MockData.color1),
+      );
       expect(drawPathResults[5]['paint_stroke'], 1);
       expect(drawPathResults[5]['paint_style'], PaintingStyle.stroke);
     });

--- a/test/extensions/border_extension_test.dart
+++ b/test/extensions/border_extension_test.dart
@@ -7,7 +7,7 @@ void main() {
     test('test 1', () {
       final border = Border(
         left: BorderSide(
-          color: Colors.red.withOpacity(0.00001),
+          color: Colors.red.withValues(alpha: 0.00001),
           width: 10,
         ),
       );
@@ -21,7 +21,7 @@ void main() {
 
     test('test 3', () {
       final border = Border.all(
-        color: Colors.red.withOpacity(0),
+        color: Colors.red.withValues(alpha: 0),
         width: 10,
       );
       expect(border.isVisible(), false);

--- a/test/extensions/color_extensions_test.dart
+++ b/test/extensions/color_extensions_test.dart
@@ -7,12 +7,12 @@ void main() {
   test('test darken', () {
     expect(
       const Color(0x11111111).darken(),
-      const Color(0x110a0a0a),
+      isSameColorAs(const Color(0x110a0a0a)),
     );
 
     expect(
       const Color(0x11111111).darken(100),
-      const Color(0x11000000),
+      isSameColorAs(const Color(0x11000000)),
     );
   });
 }

--- a/test/extensions/fl_border_data_extension_test.dart
+++ b/test/extensions/fl_border_data_extension_test.dart
@@ -25,7 +25,7 @@ void main() {
           ),
           top: BorderSide(
             width: 10,
-            color: Colors.red.withOpacity(0.5),
+            color: Colors.red.withValues(alpha: 0.5),
           ),
           bottom: const BorderSide(
             width: 4,

--- a/test/extensions/gradient_extension_test.dart
+++ b/test/extensions/gradient_extension_test.dart
@@ -105,4 +105,7 @@ class _TestGradient extends Gradient {
 
   @override
   Gradient scale(double t) => throw UnimplementedError();
+
+  @override
+  Gradient withOpacity(double opacity) => throw UnimplementedError();
 }

--- a/test/extensions/paint_extension_test.dart
+++ b/test/extensions/paint_extension_test.dart
@@ -23,7 +23,7 @@ void main() {
       ..strokeWidth = 0.0
       ..transparentIfWidthIsZero();
     expect(paint.strokeWidth, 0.0);
-    expect(MockData.color0.withOpacity(0), paint.color);
+    expect(MockData.color0.withValues(alpha: 0), paint.color);
   });
 
   test('test setColorOrGradient', () {

--- a/test/matchers.dart
+++ b/test/matchers.dart
@@ -1,0 +1,97 @@
+import 'package:fl_chart/src/chart/base/axis_chart/axis_chart_data.dart';
+import 'package:fl_chart/src/chart/scatter_chart/scatter_chart_data.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+Matcher matchesScatterSpotWithCirclePainter(ScatterSpot spot) {
+  return isA<ScatterSpot>()
+      .having(
+        (spot) => spot.x,
+        'x',
+        spot.x,
+      )
+      .having(
+        (spot) => spot.y,
+        'y',
+        spot.y,
+      )
+      .having(
+        (spot) => spot.show,
+        'show',
+        spot.show,
+      )
+      .having(
+        (spot) => spot.dotPainter,
+        'dotPainter',
+        isA<FlDotCirclePainter>().having(
+          (painter) => painter.color,
+          'color',
+          isSameColorAs((spot.dotPainter as FlDotCirclePainter).color),
+        ),
+      );
+}
+
+Matcher matchesVerticalRangeAnnotation(VerticalRangeAnnotation annotation) {
+  return isA<VerticalRangeAnnotation>()
+      .having(
+        (annotation) => annotation.x1,
+        'x1',
+        annotation.x1,
+      )
+      .having(
+        (annotation) => annotation.x2,
+        'x2',
+        annotation.x2,
+      )
+      .having(
+        (annotation) => annotation.color,
+        'color',
+        isSameColorAs(annotation.color!),
+      );
+}
+
+Matcher matchesHorizontalRangeAnnotation(HorizontalRangeAnnotation annotation) {
+  return isA<HorizontalRangeAnnotation>()
+      .having(
+        (annotation) => annotation.y1,
+        'y1',
+        annotation.y1,
+      )
+      .having(
+        (annotation) => annotation.y2,
+        'y2',
+        annotation.y2,
+      )
+      .having(
+        (annotation) => annotation.color,
+        'color',
+        isSameColorAs(annotation.color!),
+      );
+}
+
+Matcher matchesVerticalLine(VerticalLine line) {
+  return isA<VerticalLine>()
+      .having(
+        (line) => line.x,
+        'x',
+        line.x,
+      )
+      .having(
+        (line) => line.color,
+        'color',
+        isSameColorAs(line.color!),
+      );
+}
+
+Matcher matchesHorizontalLine(HorizontalLine line) {
+  return isA<HorizontalLine>()
+      .having(
+        (line) => line.y,
+        'y',
+        line.y,
+      )
+      .having(
+        (line) => line.color,
+        'color',
+        isSameColorAs(line.color!),
+      );
+}

--- a/test/utils/lerp_test.dart
+++ b/test/utils/lerp_test.dart
@@ -5,6 +5,7 @@ import 'package:fl_chart/src/utils/lerp.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import '../chart/data_pool.dart';
+import '../matchers.dart';
 
 void main() {
   const tolerance = 0.001;
@@ -29,32 +30,47 @@ void main() {
       MockData.color3,
       MockData.color5,
     ];
-    expect(lerpColorList(list1, list2, 0), const [
-      MockData.color1,
-      MockData.color1,
-      MockData.color2,
-      MockData.color5,
+    expect(lerpColorList(list1, list2, 0), [
+      isSameColorAs(MockData.color1),
+      isSameColorAs(MockData.color1),
+      isSameColorAs(MockData.color2),
+      isSameColorAs(MockData.color5),
     ]);
     expect(lerpColorList(list1, list2, 1), list2);
-    expect(lerpColorList(list1, list2, 0.5), const [
-      MockData.color1,
-      Color(0x19191919),
-      Color(0x2a2a2a2a),
-      MockData.color5,
+    expect(lerpColorList(list1, list2, 0.5), [
+      isSameColorAs(MockData.color1),
+      isSameColorAs(const Color(0x19191919)),
+      isSameColorAs(const Color(0x2a2a2a2a)),
+      isSameColorAs(MockData.color5),
     ]);
   });
 
   test('test lerpColor', () {
-    expect(lerpColor(MockData.color1, MockData.color1, 0.5), MockData.color1);
-    expect(lerpColor(MockData.color1, MockData.color1, 0), MockData.color1);
-    expect(lerpColor(MockData.color1, MockData.color1, 1), MockData.color1);
+    expect(
+      lerpColor(MockData.color1, MockData.color1, 0.5),
+      isSameColorAs(MockData.color1),
+    );
+    expect(
+      lerpColor(MockData.color1, MockData.color1, 0),
+      isSameColorAs(MockData.color1),
+    );
+    expect(
+      lerpColor(MockData.color1, MockData.color1, 1),
+      isSameColorAs(MockData.color1),
+    );
 
-    expect(lerpColor(MockData.color1, MockData.color2, 0), MockData.color1);
+    expect(
+      lerpColor(MockData.color1, MockData.color2, 0),
+      isSameColorAs(MockData.color1),
+    );
     expect(
       lerpColor(MockData.color1, MockData.color2, 0.3),
-      const Color(0x16161616),
+      isSameColorAs(const Color(0x16161616)),
     );
-    expect(lerpColor(MockData.color1, MockData.color2, 1), MockData.color2);
+    expect(
+      lerpColor(MockData.color1, MockData.color2, 1),
+      isSameColorAs(MockData.color2),
+    );
   });
 
   test('test lerpDoubleAllowInfinity', () {
@@ -188,10 +204,14 @@ void main() {
       MockData.horizontalLine4,
     ]);
     expect(lerpHorizontalLineList(list1, list2, 0.5), [
-      HorizontalLine(y: 0.5, color: const Color(0x08080808)),
-      MockData.horizontalLine1,
-      HorizontalLine(y: 1.5, color: const Color(0x19191919)),
-      MockData.horizontalLine4,
+      matchesHorizontalLine(
+        HorizontalLine(y: 0.5, color: const Color(0x08080808)),
+      ),
+      matchesHorizontalLine(MockData.horizontalLine1),
+      matchesHorizontalLine(
+        HorizontalLine(y: 1.5, color: const Color(0x19191919)),
+      ),
+      matchesHorizontalLine(MockData.horizontalLine4),
     ]);
     expect(lerpHorizontalLineList(list1, list2, 1), list2);
   });
@@ -215,10 +235,14 @@ void main() {
       MockData.verticalLine4,
     ]);
     expect(lerpVerticalLineList(list1, list2, 0.5), [
-      VerticalLine(x: 0.5, color: const Color(0x08080808)),
-      MockData.verticalLine1,
-      VerticalLine(x: 1.5, color: const Color(0x19191919)),
-      MockData.verticalLine4,
+      matchesVerticalLine(
+        VerticalLine(x: 0.5, color: const Color(0x08080808)),
+      ),
+      matchesVerticalLine(MockData.verticalLine1),
+      matchesVerticalLine(
+        VerticalLine(x: 1.5, color: const Color(0x19191919)),
+      ),
+      matchesVerticalLine(MockData.verticalLine4),
     ]);
     expect(lerpVerticalLineList(list1, list2, 1), list2);
   });
@@ -242,18 +266,22 @@ void main() {
       MockData.horizontalRangeAnnotation4,
     ]);
     expect(lerpHorizontalRangeAnnotationList(list1, list2, 0.5), [
-      HorizontalRangeAnnotation(
-        y1: 0.5,
-        y2: 1.5,
-        color: const Color(0x08080808),
+      matchesHorizontalRangeAnnotation(
+        HorizontalRangeAnnotation(
+          y1: 0.5,
+          y2: 1.5,
+          color: const Color(0x08080808),
+        ),
       ),
-      MockData.horizontalRangeAnnotation1,
-      HorizontalRangeAnnotation(
-        y1: 1.5,
-        y2: 2.5,
-        color: const Color(0x19191919),
+      matchesHorizontalRangeAnnotation(MockData.horizontalRangeAnnotation1),
+      matchesHorizontalRangeAnnotation(
+        HorizontalRangeAnnotation(
+          y1: 1.5,
+          y2: 2.5,
+          color: const Color(0x19191919),
+        ),
       ),
-      MockData.horizontalRangeAnnotation4,
+      matchesHorizontalRangeAnnotation(MockData.horizontalRangeAnnotation4),
     ]);
     expect(lerpHorizontalRangeAnnotationList(list1, list2, 1), list2);
   });
@@ -277,10 +305,22 @@ void main() {
       MockData.verticalRangeAnnotation4,
     ]);
     expect(lerpVerticalRangeAnnotationList(list1, list2, 0.5), [
-      VerticalRangeAnnotation(x1: 0.5, x2: 1.5, color: const Color(0x08080808)),
-      MockData.verticalRangeAnnotation1,
-      VerticalRangeAnnotation(x1: 1.5, x2: 2.5, color: const Color(0x19191919)),
-      MockData.verticalRangeAnnotation4,
+      matchesVerticalRangeAnnotation(
+        VerticalRangeAnnotation(
+          x1: 0.5,
+          x2: 1.5,
+          color: const Color(0x08080808),
+        ),
+      ),
+      matchesVerticalRangeAnnotation(MockData.verticalRangeAnnotation1),
+      matchesVerticalRangeAnnotation(
+        VerticalRangeAnnotation(
+          x1: 1.5,
+          x2: 2.5,
+          color: const Color(0x19191919),
+        ),
+      ),
+      matchesVerticalRangeAnnotation(MockData.verticalRangeAnnotation4),
     ]);
     expect(lerpVerticalRangeAnnotationList(list1, list2, 1), list2);
   });
@@ -304,10 +344,22 @@ void main() {
       MockData.verticalRangeAnnotation4,
     ]);
     expect(lerpVerticalRangeAnnotationList(list1, list2, 0.5), [
-      VerticalRangeAnnotation(x1: 0.5, x2: 1.5, color: const Color(0x08080808)),
-      MockData.verticalRangeAnnotation1,
-      VerticalRangeAnnotation(x1: 1.5, x2: 2.5, color: const Color(0x19191919)),
-      MockData.verticalRangeAnnotation4,
+      matchesVerticalRangeAnnotation(
+        VerticalRangeAnnotation(
+          x1: 0.5,
+          x2: 1.5,
+          color: const Color(0x08080808),
+        ),
+      ),
+      matchesVerticalRangeAnnotation(MockData.verticalRangeAnnotation1),
+      matchesVerticalRangeAnnotation(
+        VerticalRangeAnnotation(
+          x1: 1.5,
+          x2: 2.5,
+          color: const Color(0x19191919),
+        ),
+      ),
+      matchesVerticalRangeAnnotation(MockData.verticalRangeAnnotation4),
     ]);
     expect(lerpVerticalRangeAnnotationList(list1, list2, 1), list2);
   });
@@ -358,18 +410,22 @@ void main() {
       MockData.scatterSpot4,
     ]);
     expect(lerpScatterSpotList(list1, list2, 0.5), [
-      ScatterSpot(
-        0.5,
-        0.5,
-        dotPainter: FlDotCirclePainter(color: const Color(0x08080808)),
+      matchesScatterSpotWithCirclePainter(
+        ScatterSpot(
+          0.5,
+          0.5,
+          dotPainter: FlDotCirclePainter(color: const Color(0x08080808)),
+        ),
       ),
-      MockData.scatterSpot1,
-      ScatterSpot(
-        1.5,
-        1.5,
-        dotPainter: FlDotCirclePainter(color: const Color(0x19191919)),
+      matchesScatterSpotWithCirclePainter(MockData.scatterSpot1),
+      matchesScatterSpotWithCirclePainter(
+        ScatterSpot(
+          1.5,
+          1.5,
+          dotPainter: FlDotCirclePainter(color: const Color(0x19191919)),
+        ),
       ),
-      MockData.scatterSpot4,
+      matchesScatterSpotWithCirclePainter(MockData.scatterSpot4),
     ]);
     expect(lerpScatterSpotList(list1, list2, 1), list2);
   });
@@ -381,12 +437,30 @@ void main() {
       MockData.color2,
       MockData.color3,
     ];
-    expect(lerpGradient(colors, [], 0), const Color(0x00000000));
-    expect(lerpGradient(colors, [], 0.2), const Color(0x00000000));
-    expect(lerpGradient(colors, [], 0.4), const Color(0x0a0a0a0a));
-    expect(lerpGradient(colors, [], 0.6), const Color(0x17171717));
-    expect(lerpGradient(colors, [], 0.8), const Color(0x25252525));
-    expect(lerpGradient(colors, [], 1), const Color(0x33333333));
+    expect(
+      lerpGradient(colors, [], 0),
+      isSameColorAs(const Color(0x00000000)),
+    );
+    expect(
+      lerpGradient(colors, [], 0.2),
+      isSameColorAs(const Color(0x00000000)),
+    );
+    expect(
+      lerpGradient(colors, [], 0.4),
+      isSameColorAs(const Color(0x0a0a0a0a)),
+    );
+    expect(
+      lerpGradient(colors, [], 0.6),
+      isSameColorAs(const Color(0x17171717)),
+    );
+    expect(
+      lerpGradient(colors, [], 0.8),
+      isSameColorAs(const Color(0x25252525)),
+    );
+    expect(
+      lerpGradient(colors, [], 1),
+      isSameColorAs(const Color(0x33333333)),
+    );
   });
 
   test('lerpLineChartBarDataList uses `LineChartBarData.lerp`', () {


### PR DESCRIPTION
This PR updates the codebase to work with the changes in Flutter 3.27.0. 

This is a BREAKING CHANGE, because `Color.withValues` was newly introduced in 3.27.0.

See [Migration Guide](https://docs.flutter.dev/release/breaking-changes/wide-gamut-framework) for additional info.

I updated the constraint for the flutter sdk in the `pubspec.yaml` accordingly.

Closes #1804.