### PR TITLE
feat: Allow locking scale/translation state

### DIFF
--- a/example/lib/presentation/samples/line/line_chart_sample12.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample12.dart
@@ -17,6 +17,8 @@ class LineChartSample12 extends StatefulWidget {
 class _LineChartSample12State extends State<LineChartSample12> {
   List<(DateTime, double)>? _bitcoinPriceHistory;
   late TransformationController _transformationController;
+  bool _isPanEnabled = true;
+  bool _isScaleEnabled = true;
 
   @override
   void initState() {
@@ -43,6 +45,7 @@ class _LineChartSample12State extends State<LineChartSample12> {
   Widget build(BuildContext context) {
     const leftReservedSize = 52.0;
     return Column(
+      spacing: 16,
       children: [
         LayoutBuilder(
           builder: (context, constraints) {
@@ -71,6 +74,33 @@ class _LineChartSample12State extends State<LineChartSample12> {
                   );
           },
         ),
+        Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 16.0),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            spacing: 16,
+            children: [
+              const Text('Pan'),
+              Switch(
+                value: _isPanEnabled,
+                onChanged: (value) {
+                  setState(() {
+                    _isPanEnabled = value;
+                  });
+                },
+              ),
+              const Text('Scale'),
+              Switch(
+                value: _isScaleEnabled,
+                onChanged: (value) {
+                  setState(() {
+                    _isScaleEnabled = value;
+                  });
+                },
+              ),
+            ],
+          ),
+        ),
         AspectRatio(
           aspectRatio: 1.4,
           child: Padding(
@@ -83,6 +113,8 @@ class _LineChartSample12State extends State<LineChartSample12> {
                 scaleAxis: FlScaleAxis.horizontal,
                 minScale: 1.0,
                 maxScale: 25.0,
+                panEnabled: _isPanEnabled,
+                scaleEnabled: _isScaleEnabled,
                 transformationController: _transformationController,
               ),
               LineChartData(

--- a/lib/src/chart/base/axis_chart/axis_chart_scaffold_widget.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_scaffold_widget.dart
@@ -234,6 +234,8 @@ class _AxisChartScaffoldWidgetState extends State<AxisChartScaffoldWidget> {
               _transformationConfig.trackpadScrollCausesScale,
           maxScale: _transformationConfig.maxScale,
           minScale: _transformationConfig.minScale,
+          panEnabled: _transformationConfig.panEnabled,
+          scaleEnabled: _transformationConfig.scaleEnabled,
           child: SizedBox(
             width: constraints.maxWidth,
             height: constraints.maxHeight,

--- a/lib/src/chart/base/axis_chart/transformation_config.dart
+++ b/lib/src/chart/base/axis_chart/transformation_config.dart
@@ -7,6 +7,8 @@ class FlTransformationConfig {
     this.scaleAxis = FlScaleAxis.none,
     this.minScale = 1,
     this.maxScale = 2.5,
+    this.panEnabled = true,
+    this.scaleEnabled = true,
     this.trackpadScrollCausesScale = false,
     this.transformationController,
   })  : assert(minScale >= 1, 'minScale must be greater than or equal to 1'),
@@ -27,6 +29,16 @@ class FlTransformationConfig {
   ///
   /// Ignored when [scaleAxis] is [FlScaleAxis.none].
   final double maxScale;
+
+  /// If false, the user will be prevented from panning.
+  ///
+  /// Ignored when [scaleAxis] is [FlScaleAxis.none].
+  final bool panEnabled;
+
+  /// If false, the user will be prevented from scaling.
+  ///
+  /// Ignored when [scaleAxis] is [FlScaleAxis.none].
+  final bool scaleEnabled;
 
   /// Whether trackpad scroll causes scale.
   ///

--- a/repo_files/documentations/handle_transformations.md
+++ b/repo_files/documentations/handle_transformations.md
@@ -115,5 +115,6 @@ See [Matrix4](https://pub.dev/documentation/vector_math/latest/vector_math_64/Ma
 3. Consider your chart's alignment when choosing a `scaleAxis`
 4. Provide visual feedback for transformation limits
 5. Consider adding reset functionality for better user experience
+6. If you have touch indicators, consider allowing users to disable panning when zoomed in. This way the touch indicators will be shown when users hold and drag to explore the chart's data, instead of panning the chart.
 
 Remember that transformations are purely visual and don't affect the underlying data. They're particularly useful for exploring detailed data sets or allowing users to focus on specific regions of interest in your charts.

--- a/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
@@ -469,6 +469,8 @@ void main() {
       expect(interactiveViewer1.maxScale, 2.5);
       expect(interactiveViewer1.minScale, 1);
       expect(interactiveViewer1.clipBehavior, Clip.none);
+      expect(interactiveViewer1.panEnabled, true);
+      expect(interactiveViewer1.scaleEnabled, true);
       expect(
         interactiveViewer1.transformationController,
         isA<TransformationController>().having(
@@ -487,6 +489,8 @@ void main() {
             trackpadScrollCausesScale: true,
             maxScale: 10,
             minScale: 1.5,
+            panEnabled: false,
+            scaleEnabled: false,
             transformationController: transformationController,
           ),
           chartBuilder: (context, chartVirtualRect) => dummyChart,
@@ -500,6 +504,8 @@ void main() {
       expect(interactiveViewer2.maxScale, 10);
       expect(interactiveViewer2.minScale, 1.5);
       expect(interactiveViewer2.clipBehavior, Clip.none);
+      expect(interactiveViewer2.panEnabled, false);
+      expect(interactiveViewer2.scaleEnabled, false);
       expect(
         interactiveViewer2.transformationController,
         transformationController,


### PR DESCRIPTION
Allows to disable panning and scaling.

When disabled users cannot scale/pan the chart. Transforming the chart via a `TransformationController` is still possible in this case.

Solves #1818

# Demo

https://github.com/user-attachments/assets/e1acde03-1c65-4437-b955-d0abb39bc955

