### PR TITLE
Add capStyle for Pie Charts

### DIFF
--- a/example/lib/presentation/samples/pie/pie_chart_sample2.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample2.dart
@@ -12,7 +12,6 @@ class PieChartSample2 extends StatefulWidget {
 
 class PieChart2State extends State {
   int touchedIndex = -1;
-  CapStyle capStyle = CapStyle.none;
 
   @override
   Widget build(BuildContext context) {
@@ -39,7 +38,7 @@ class PieChart2State extends State {
                       });
                     },
                   ),
-                  capStyle: capStyle,
+                  capStyle: CapStyle.none,
                   borderData: FlBorderData(
                     show: false,
                   ),

--- a/example/lib/presentation/samples/pie/pie_chart_sample2.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample2.dart
@@ -12,6 +12,7 @@ class PieChartSample2 extends StatefulWidget {
 
 class PieChart2State extends State {
   int touchedIndex = -1;
+  CapStyle capStyle = CapStyle.none;
 
   @override
   Widget build(BuildContext context) {
@@ -19,9 +20,6 @@ class PieChart2State extends State {
       aspectRatio: 1.3,
       child: Row(
         children: <Widget>[
-          const SizedBox(
-            height: 18,
-          ),
           Expanded(
             child: AspectRatio(
               aspectRatio: 1,
@@ -41,6 +39,7 @@ class PieChart2State extends State {
                       });
                     },
                   ),
+                  capStyle: capStyle,
                   borderData: FlBorderData(
                     show: false,
                   ),

--- a/example/lib/presentation/samples/pie/pie_chart_sample2.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample2.dart
@@ -38,7 +38,7 @@ class PieChart2State extends State {
                       });
                     },
                   ),
-                  capStyle: CapStyle.none,
+                  pieCapStyle: PieCapStyle.none,
                   borderData: FlBorderData(
                     show: false,
                   ),

--- a/example/macos/Podfile.lock
+++ b/example/macos/Podfile.lock
@@ -26,10 +26,10 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
-  package_info_plus: fa739dd842b393193c5ca93c26798dff6e3d0e0c
+  package_info_plus: 12f1c5c2cfe8727ca46cbd0b26677728972d9a5b
   path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
-  url_launcher_macos: 5f437abeda8c85500ceb03f5c1938a8c5a705399
+  url_launcher_macos: c82c93949963e55b228a30115bd219499a6fe404
 
 PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
-COCOAPODS: 1.16.2
+COCOAPODS: 1.15.2

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -36,11 +36,6 @@ class PieChartData extends BaseChartData with EquatableMixin {
           capStyle == null || centerSpaceRadius != null,
           'centerSpaceRadius must not be null if capStyle is provided',
         ),
-        // assert(
-        //   capStyle == null ||
-        //       (sections?.map((e) => e.radius).toSet().length ?? 0) <= 1,
-        //   'All sections must have the same radius if capStyle is provided',
-        // ),
         sections = sections ?? const [],
         centerSpaceRadius = centerSpaceRadius ?? double.infinity,
         centerSpaceColor = centerSpaceColor ?? Colors.transparent,

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -31,10 +31,10 @@ class PieChartData extends BaseChartData with EquatableMixin {
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
     bool? titleSunbeamLayout,
-    CapStyle? capStyle,
+    PieCapStyle? pieCapStyle,
   })  : assert(
-          capStyle == null || centerSpaceRadius != null,
-          'centerSpaceRadius must not be null if capStyle is provided',
+          pieCapStyle == null || centerSpaceRadius != null,
+          'centerSpaceRadius must not be null if pieCapStyle is provided',
         ),
         sections = sections ?? const [],
         centerSpaceRadius = centerSpaceRadius ?? double.infinity,
@@ -43,7 +43,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
         startDegreeOffset = startDegreeOffset ?? 0,
         pieTouchData = pieTouchData ?? PieTouchData(),
         titleSunbeamLayout = titleSunbeamLayout ?? false,
-        capStyle = capStyle ?? CapStyle.none,
+        pieCapStyle = pieCapStyle ?? PieCapStyle.none,
         super(
           borderData: borderData ?? FlBorderData(show: false),
           touchData: pieTouchData ?? PieTouchData(),
@@ -74,7 +74,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
   final bool titleSunbeamLayout;
 
   /// Cap style of pie charts
-  final CapStyle capStyle;
+  final PieCapStyle pieCapStyle;
 
   /// We hold this value to determine weight of each [PieChartSectionData.value].
   double get sumValue => sections
@@ -92,7 +92,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
     bool? titleSunbeamLayout,
-    CapStyle? capStyle,
+    PieCapStyle? capStyle,
   }) =>
       PieChartData(
         sections: sections ?? this.sections,
@@ -103,7 +103,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
         pieTouchData: pieTouchData ?? this.pieTouchData,
         borderData: borderData ?? this.borderData,
         titleSunbeamLayout: titleSunbeamLayout ?? this.titleSunbeamLayout,
-        capStyle: capStyle ?? this.capStyle,
+        pieCapStyle: capStyle ?? pieCapStyle,
       );
 
   /// Lerps a [BaseChartData] based on [t] value, check [Tween.lerp].
@@ -118,7 +118,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
           b.centerSpaceRadius,
           t,
         ),
-        capStyle: capStyle,
+        pieCapStyle: pieCapStyle,
         pieTouchData: b.pieTouchData,
         sectionsSpace: lerpDouble(a.sectionsSpace, b.sectionsSpace, t),
         startDegreeOffset:
@@ -142,7 +142,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
         startDegreeOffset,
         borderData,
         titleSunbeamLayout,
-        capStyle,
+        pieCapStyle,
       ];
 }
 
@@ -415,7 +415,7 @@ class PieChartDataTween extends Tween<PieChartData> {
   PieChartData lerp(double t) => begin!.lerp(begin!, end!, t);
 }
 
-enum CapStyle {
+enum PieCapStyle {
   none,
   startCapped,
   endCapped,

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -31,13 +31,24 @@ class PieChartData extends BaseChartData with EquatableMixin {
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
     bool? titleSunbeamLayout,
-  })  : sections = sections ?? const [],
+    CapStyle? capStyle,
+  })  : assert(
+          capStyle == null || centerSpaceRadius != null,
+          'centerSpaceRadius must not be null if capStyle is provided',
+        ),
+        // assert(
+        //   capStyle == null ||
+        //       (sections?.map((e) => e.radius).toSet().length ?? 0) <= 1,
+        //   'All sections must have the same radius if capStyle is provided',
+        // ),
+        sections = sections ?? const [],
         centerSpaceRadius = centerSpaceRadius ?? double.infinity,
         centerSpaceColor = centerSpaceColor ?? Colors.transparent,
         sectionsSpace = sectionsSpace ?? 2,
         startDegreeOffset = startDegreeOffset ?? 0,
         pieTouchData = pieTouchData ?? PieTouchData(),
         titleSunbeamLayout = titleSunbeamLayout ?? false,
+        capStyle = capStyle ?? CapStyle.none,
         super(
           borderData: borderData ?? FlBorderData(show: false),
           touchData: pieTouchData ?? PieTouchData(),
@@ -67,6 +78,9 @@ class PieChartData extends BaseChartData with EquatableMixin {
   /// Whether to rotate the titles on each section of the chart
   final bool titleSunbeamLayout;
 
+  /// Cap style of pie charts
+  final CapStyle capStyle;
+
   /// We hold this value to determine weight of each [PieChartSectionData.value].
   double get sumValue => sections
       .map((data) => data.value)
@@ -83,6 +97,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
     PieTouchData? pieTouchData,
     FlBorderData? borderData,
     bool? titleSunbeamLayout,
+    CapStyle? capStyle,
   }) =>
       PieChartData(
         sections: sections ?? this.sections,
@@ -93,6 +108,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
         pieTouchData: pieTouchData ?? this.pieTouchData,
         borderData: borderData ?? this.borderData,
         titleSunbeamLayout: titleSunbeamLayout ?? this.titleSunbeamLayout,
+        capStyle: capStyle ?? this.capStyle,
       );
 
   /// Lerps a [BaseChartData] based on [t] value, check [Tween.lerp].
@@ -107,6 +123,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
           b.centerSpaceRadius,
           t,
         ),
+        capStyle: capStyle,
         pieTouchData: b.pieTouchData,
         sectionsSpace: lerpDouble(a.sectionsSpace, b.sectionsSpace, t),
         startDegreeOffset:
@@ -130,6 +147,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
         startDegreeOffset,
         borderData,
         titleSunbeamLayout,
+        capStyle,
       ];
 }
 
@@ -400,4 +418,10 @@ class PieChartDataTween extends Tween<PieChartData> {
   /// Lerps a [PieChartData] based on [t] value, check [Tween.lerp].
   @override
   PieChartData lerp(double t) => begin!.lerp(begin!, end!, t);
+}
+
+enum CapStyle {
+  none,
+  startCapped,
+  endCapped,
 }

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -172,6 +172,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         sectionDegree,
         center,
         centerRadius,
+        data.capStyle,
       );
 
       drawSection(section, sectionPath, canvasWrapper);
@@ -189,6 +190,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     double sectionDegree,
     Offset center,
     double centerRadius,
+    CapStyle capStyle,
   ) {
     final sectionRadiusRect = Rect.fromCircle(
       center: center,
@@ -204,32 +206,74 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     final sweepRadians = Utils().radians(sectionDegree);
     final endRadians = startRadians + sweepRadians;
 
-    final startLineDirection =
-        Offset(math.cos(startRadians), math.sin(startRadians));
+    final startLineDirection = Offset(
+      math.cos(startRadians),
+      math.sin(startRadians),
+    );
 
     final startLineFrom = center + startLineDirection * centerRadius;
     final startLineTo = startLineFrom + startLineDirection * section.radius;
+    // sectionRadiusRect.shortestSide; //extra center is added here
     final startLine = Line(startLineFrom, startLineTo);
 
-    final endLineDirection = Offset(math.cos(endRadians), math.sin(endRadians));
+    final endLineDirection = Offset(
+      math.cos(endRadians),
+      math.sin(endRadians),
+    );
 
     final endLineFrom = center + endLineDirection * centerRadius;
-    final endLineTo = endLineFrom + endLineDirection * section.radius;
+    final endLineTo =
+        endLineFrom + endLineDirection * section.radius; // extra center
     final endLine = Line(endLineFrom, endLineTo);
 
-    var sectionPath = Path()
-      ..moveTo(startLine.from.dx, startLine.from.dy)
-      ..lineTo(startLine.to.dx, startLine.to.dy)
-      ..arcTo(sectionRadiusRect, startRadians, sweepRadians, false)
-      ..lineTo(endLine.from.dx, endLine.from.dy)
-      ..arcTo(centerRadiusRect, endRadians, -sweepRadians, false)
-      ..moveTo(startLine.from.dx, startLine.from.dy)
-      ..close();
+    var sectionPath = Path();
+    switch (capStyle) {
+      case CapStyle.startCapped:
+        sectionPath
+          ..moveTo(startLine.from.dx, startLine.from.dy)
+          ..arcToPoint(
+            startLine.to,
+            radius: Radius.circular(section.radius / 2),
+          )
+          ..arcTo(sectionRadiusRect, startRadians, sweepRadians, false)
+          ..arcToPoint(
+            endLine.from,
+            radius: Radius.circular(section.radius / 2),
+            clockwise: false,
+          )
+          ..arcTo(centerRadiusRect, endRadians, -sweepRadians, false)
+          ..moveTo(startLine.from.dx, startLine.from.dy)
+          ..close();
+      case CapStyle.endCapped:
+        sectionPath
+          ..moveTo(startLine.from.dx, startLine.from.dy)
+          ..arcToPoint(
+            startLine.to,
+            radius: Radius.circular(section.radius / 2),
+            clockwise: false,
+          )
+          ..arcTo(sectionRadiusRect, startRadians, sweepRadians, false)
+          ..arcToPoint(
+            endLine.from,
+            radius: Radius.circular(section.radius / 2),
+          )
+          ..arcTo(centerRadiusRect, endRadians, -sweepRadians, false)
+          ..moveTo(startLine.from.dx, startLine.from.dy)
+          ..close();
+      case CapStyle.none:
+        sectionPath
+          ..moveTo(startLine.from.dx, startLine.from.dy)
+          ..lineTo(startLine.to.dx, startLine.to.dy)
+          ..arcTo(sectionRadiusRect, startRadians, sweepRadians, false)
+          ..lineTo(endLine.from.dx, endLine.from.dy)
+          ..arcTo(centerRadiusRect, endRadians, -sweepRadians, false)
+          ..moveTo(startLine.from.dx, startLine.from.dy)
+          ..close();
+    }
 
-    /// Subtract section space from the sectionPath
     if (sectionSpace != 0) {
       final startLineSeparatorPath = createRectPathAroundLine(
-        Line(startLineFrom, startLineTo),
+        startLine,
         sectionSpace,
       );
       try {
@@ -238,25 +282,24 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           sectionPath,
           startLineSeparatorPath,
         );
-      } catch (_) {
-        /// It's a flutter engine issue with [Path.combine] in web-html renderer
-        /// https://github.com/imaNNeo/fl_chart/issues/955
-      }
-
-      final endLineSeparatorPath =
-          createRectPathAroundLine(Line(endLineFrom, endLineTo), sectionSpace);
-      try {
-        sectionPath = Path.combine(
-          PathOperation.difference,
-          sectionPath,
-          endLineSeparatorPath,
-        );
-      } catch (_) {
+      } catch (e) {
         /// It's a flutter engine issue with [Path.combine] in web-html renderer
         /// https://github.com/imaNNeo/fl_chart/issues/955
       }
     }
 
+    final endLineSeparatorPath =
+        createRectPathAroundLine(endLine, sectionSpace);
+    try {
+      sectionPath = Path.combine(
+        PathOperation.difference,
+        sectionPath,
+        endLineSeparatorPath,
+      );
+    } catch (e) {
+      /// It's a flutter engine issue with [Path.combine] in web-html renderer
+      /// https://github.com/imaNNeo/fl_chart/issues/955
+    }
     return sectionPath;
   }
 
@@ -486,6 +529,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         sectionAngle,
         center,
         centerRadius,
+        data.capStyle,
       );
 
       if (sectionPath.contains(localPosition)) {

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -172,7 +172,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         sectionDegree,
         center,
         centerRadius,
-        data.capStyle,
+        data.pieCapStyle,
       );
 
       drawSection(section, sectionPath, canvasWrapper);
@@ -190,7 +190,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     double sectionDegree,
     Offset center,
     double centerRadius,
-    CapStyle capStyle,
+    PieCapStyle pieCapStyle,
   ) {
     final sectionRadiusRect = Rect.fromCircle(
       center: center,
@@ -227,8 +227,8 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     final endLine = Line(endLineFrom, endLineTo);
 
     var sectionPath = Path();
-    switch (capStyle) {
-      case CapStyle.startCapped:
+    switch (pieCapStyle) {
+      case PieCapStyle.startCapped:
         sectionPath
           ..moveTo(startLine.from.dx, startLine.from.dy)
           ..arcToPoint(
@@ -244,7 +244,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           ..arcTo(centerRadiusRect, endRadians, -sweepRadians, false)
           ..moveTo(startLine.from.dx, startLine.from.dy)
           ..close();
-      case CapStyle.endCapped:
+      case PieCapStyle.endCapped:
         sectionPath
           ..moveTo(startLine.from.dx, startLine.from.dy)
           ..arcToPoint(
@@ -260,7 +260,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           ..arcTo(centerRadiusRect, endRadians, -sweepRadians, false)
           ..moveTo(startLine.from.dx, startLine.from.dy)
           ..close();
-      case CapStyle.none:
+      case PieCapStyle.none:
         sectionPath
           ..moveTo(startLine.from.dx, startLine.from.dy)
           ..lineTo(startLine.to.dx, startLine.to.dy)
@@ -529,7 +529,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         sectionAngle,
         center,
         centerRadius,
-        data.capStyle,
+        data.pieCapStyle,
       );
 
       if (sectionPath.contains(localPosition)) {

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -28,7 +28,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |pieTouchData| [PieTouchData](#pietouchdata-read-about-touch-handling) holds the touch interactivity details| PieTouchData()|
 |borderData| shows a border around the chart, check the [FlBorderData](base_chart.md#FlBorderData)|FlBorderData()|
 |titleSunbeamLayout| whether to rotate the titles on each section of the chart|false|
-|capStyle| whether add cap at the end of pie charts. Only available on pie charts with non-null & non-zero centerSpaceRadius|CapStyle.none|
+|pieCapStyle| whether add cap at the end of pie charts. Only available on pie charts with non-null & non-zero centerSpaceRadius|PieCapStyle.none|
 
 
 ### PieChartSectionData

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -28,6 +28,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |pieTouchData| [PieTouchData](#pietouchdata-read-about-touch-handling) holds the touch interactivity details| PieTouchData()|
 |borderData| shows a border around the chart, check the [FlBorderData](base_chart.md#FlBorderData)|FlBorderData()|
 |titleSunbeamLayout| whether to rotate the titles on each section of the chart|false|
+|capStyle| whether add cap at the end of pie charts. Only available on pie charts with non-null & non-zero centerSpaceRadius|CapStyle.none|
 
 
 ### PieChartSectionData


### PR DESCRIPTION
Enhances Pie Charts that have non-null & non-zero `centerSpaceRadius`. Fixes this issue: https://github.com/imaNNeo/fl_chart/issues/1699
Based on this PR https://github.com/imaNNeo/fl_chart/pull/1698