### PR TITLE
Adds support for mirrored label text direction

### DIFF
--- a/lib/src/chart/base/axis_chart/axis_chart_painter.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_painter.dart
@@ -322,6 +322,7 @@ abstract class AxisChartPainter<D extends AxisChartData>
 
           switch (label.direction) {
             case LabelDirection.horizontal:
+            case LabelDirection.horizontalMirrored:
               canvasWrapper.drawText(
                 tp,
                 label.alignment.withinRect(
@@ -332,6 +333,9 @@ abstract class AxisChartPainter<D extends AxisChartData>
                     to.dy + padding.top,
                   ),
                 ),
+                label.direction == LabelDirection.horizontalMirrored
+                    ? -180
+                    : null,
               );
             case LabelDirection.vertical:
               canvasWrapper.drawVerticalText(
@@ -344,6 +348,20 @@ abstract class AxisChartPainter<D extends AxisChartData>
                     to.dy + padding.top,
                   ),
                 ),
+              );
+            case LabelDirection.verticalMirrored:
+              debugPrint('$from $to ${tp.height} ${tp.width} $padding');
+              canvasWrapper.drawVerticalText(
+                tp,
+                label.alignment.withinRect(
+                  Rect.fromLTRB(
+                    from.dx + padding.left,
+                    from.dy - padding.bottom,
+                    to.dx - padding.right - tp.height,
+                    to.dy + padding.top + tp.width,
+                  ),
+                ),
+                -90,
               );
           }
         }
@@ -428,6 +446,7 @@ abstract class AxisChartPainter<D extends AxisChartData>
 
           switch (label.direction) {
             case LabelDirection.horizontal:
+            case LabelDirection.horizontalMirrored:
               canvasWrapper.drawText(
                 tp,
                 label.alignment.withinRect(
@@ -438,6 +457,9 @@ abstract class AxisChartPainter<D extends AxisChartData>
                     to.dy - padding.bottom - tp.height,
                   ),
                 ),
+                label.direction == LabelDirection.horizontalMirrored
+                    ? -180
+                    : null,
               );
             case LabelDirection.vertical:
               canvasWrapper.drawVerticalText(
@@ -450,6 +472,19 @@ abstract class AxisChartPainter<D extends AxisChartData>
                     to.dy - padding.bottom - tp.width,
                   ),
                 ),
+              );
+            case LabelDirection.verticalMirrored:
+              canvasWrapper.drawVerticalText(
+                tp,
+                label.alignment.withinRect(
+                  Rect.fromLTRB(
+                    from.dx - padding.right + tp.height,
+                    from.dy + padding.top - tp.width,
+                    to.dx + padding.left,
+                    to.dy - padding.bottom,
+                  ),
+                ),
+                -90,
               );
           }
         }

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -811,7 +811,12 @@ typedef CheckToShowDot = bool Function(FlSpot spot, LineChartBarData barData);
 /// Shows all dots on spots.
 bool showAllDots(FlSpot spot, LineChartBarData barData) => true;
 
-enum LabelDirection { horizontal, vertical }
+enum LabelDirection {
+  horizontal,
+  vertical,
+  horizontalMirrored,
+  verticalMirrored
+}
 
 /// Shows a text label
 abstract class FlLineLabel with EquatableMixin {

--- a/lib/src/utils/canvas_wrapper.dart
+++ b/lib/src/utils/canvas_wrapper.dart
@@ -102,10 +102,14 @@ class CanvasWrapper {
   /// Paints a vertical text on the [Canvas]
   ///
   /// Gets a [TextPainter] and call its [TextPainter.paint] using our canvas
-  void drawVerticalText(TextPainter tp, Offset offset) {
+  void drawVerticalText(
+    TextPainter tp,
+    Offset offset, [
+    double rotateAngle = 90,
+  ]) {
     save();
     translate(offset.dx, offset.dy);
-    rotate(Utils().radians(90));
+    rotate(Utils().radians(rotateAngle));
     translate(-offset.dx, -offset.dy);
     tp.paint(canvas, offset);
     restore();


### PR DESCRIPTION
Currently the `HorizontalLineLabel` and `VerticalLineLabel` support `.horizontal` and `.vertical` direction but there is no way (afaik) how to flip the text upside down along this direction. This is a problem mainly for vertical direction where the text is upside down (in relation to axis names).

This PR adds additional label direction options: `.horizontalMirrored` and `.verticalMirrored` which would flip the text upside down. This is not a breaking change.