### PR TITLE
Feature/indicator horizontal line

### DIFF
--- a/example/lib/presentation/samples/line/line_chart_sample12.dart
+++ b/example/lib/presentation/samples/line/line_chart_sample12.dart
@@ -175,6 +175,7 @@ class _LineChartSample12State extends State<LineChartSample12> {
                             );
                           },
                         ),
+                        showHorizontalLine: true,
                       );
                     }).toList();
                   },

--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -1264,6 +1264,9 @@ class LineTooltipItem with EquatableMixin {
 /// details of showing indicator when touch happened on [LineChart]
 /// [indicatorBelowLine] we draw a vertical line below of the touched spot
 /// [touchedSpotDotData] we draw a larger dot on the touched spot to bold it
+/// [showHorizontalLine] if true, a horizontal line is drawn at the Y-position of the touched spot.
+/// [indicatorHorizontalLine] defines the style of the horizontal line at the touched spot.
+///   If null, [indicatorBelowLine] is used as the fallback.
 class TouchedSpotIndicatorData with EquatableMixin {
   /// if [LineTouchData.handleBuiltInTouches] is true,
   /// [LineChart] shows a thicker line and larger spot as indicator automatically when touch happens,
@@ -1272,8 +1275,10 @@ class TouchedSpotIndicatorData with EquatableMixin {
   /// [touchedSpotDotData] determines dot's style.
   const TouchedSpotIndicatorData(
     this.indicatorBelowLine,
-    this.touchedSpotDotData,
-  );
+    this.touchedSpotDotData, {
+    this.showHorizontalLine = false,
+    FlLine? indicatorHorizontalLine,
+  }) : indicatorHorizontalLine = indicatorHorizontalLine ?? indicatorBelowLine;
 
   /// Determines line's style.
   final FlLine indicatorBelowLine;
@@ -1281,11 +1286,19 @@ class TouchedSpotIndicatorData with EquatableMixin {
   /// Determines dot's style.
   final FlDotData touchedSpotDotData;
 
+  /// Whether the horizontal line should be drawn or not.
+  final bool showHorizontalLine;
+
+  /// Horizontal line shown at the Y-position of the touched spot.
+  final FlLine indicatorHorizontalLine;
+
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
         indicatorBelowLine,
         touchedSpotDotData,
+        showHorizontalLine,
+        indicatorHorizontalLine,
       ];
 }
 

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -518,6 +518,35 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
         indicatorLine.dashArray,
       );
 
+      // Optionally draw horizontal line
+      if (indicatorData.showHorizontalLine) {
+        // Draw horizontal line from the left edge of the chart to right edge
+        // at the y position of the touched spot
+        final horizontalLine = indicatorData.indicatorHorizontalLine;
+        const left = 0.0;
+        final right = viewSize.width;
+
+        final horizontalStart = Offset(left, touchedSpot.dy);
+        final horizontalEnd = Offset(right, touchedSpot.dy);
+
+        _touchLinePaint
+          ..setColorOrGradientForLine(
+            horizontalLine.color,
+            horizontalLine.gradient,
+            from: horizontalStart,
+            to: horizontalEnd,
+          )
+          ..strokeWidth = horizontalLine.strokeWidth
+          ..transparentIfWidthIsZero();
+
+        canvasWrapper.drawDashedLine(
+          horizontalStart,
+          horizontalEnd,
+          _touchLinePaint,
+          horizontalLine.dashArray,
+        );
+      }
+
       /// Draw the indicator dot
       if (showingDots) {
         canvasWrapper.drawDot(dotPainter, spot, touchedSpot);

--- a/repo_files/documentations/line_chart.md
+++ b/repo_files/documentations/line_chart.md
@@ -11,7 +11,7 @@ LineChart(
 );
 ```
 
-### Implicit Animations 
+### Implicit Animations
 When you change the chart's state, it animates to the new state internally (using [implicit animations](https://flutter.dev/docs/development/ui/animations/implicit-animations)). You can control the animation [duration](https://api.flutter.dev/flutter/dart-core/Duration-class.html) and [curve](https://api.flutter.dev/flutter/animation/Curves-class.html) using optional `swapAnimationDuration` and `swapAnimationCurve` properties, respectively.
 
 ### LineChartData
@@ -131,7 +131,7 @@ When you change the chart's state, it animates to the new state internally (usin
  |fitInsideHorizontally| forces tooltip to horizontally shift inside the chart's bounding box| false|
  |fitInsideVertically| forces tooltip to vertically shift inside the chart's bounding box| false|
  |showOnTopOfTheChartBoxArea| forces the tooltip container to top of the line| false|
- |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)| 
+ |getTooltipColor|a callback that retrieves the Color for each touched spots separately from the given [LineBarSpot](#LineBarSpot) to set the background color of the tooltip bubble|Colors.blueGrey.darken(15)|
 
 ### LineTooltipItem
 |PropName|Description|default value|
@@ -147,6 +147,8 @@ When you change the chart's state, it animates to the new state internally (usin
 |:-------|:----------|:------------|
 |indicatorBelowLine|a [FlLine](base_chart.md#FlLine) to show the below line indicator on the touched spot|null|
 |touchedSpotDotData|a [FlDotData](#FlDotData) to show a dot indicator on the touched spot|null|
+| showHorizontalLine     | Whether to draw a horizontal line at the Y position of the touched spot     | false                               |
+| indicatorHorizontalLine| A [FlLine](base_chart.md#FlLine) to style the horizontal line (defaults to `indicatorBelowLine` if null) | null                                |
 
 
 ### LineBarSpot


### PR DESCRIPTION
## Summary

This PR adds support for an optional horizontal indicator line in `LineChart`.

## What's included

- `TouchedSpotIndicatorData`:
  - `showHorizontalLine`: enables horizontal indicator line rendering
  - `indicatorHorizontalLine`: defines the horizontal line's appearance
  - Fallback: if `indicatorHorizontalLine` is null, `indicatorBelowLine` is used
- Drawing logic in `LineChartPainter.drawTouchedSpotsIndicator`
- Unit test for horizontal line rendering
- Sample updated in `line_chart_sample12.dart`
- Documentation updated in `line_chart.md`

## Screenshot
Line Chart Sample 12 with horizontal indicator line

<img width="260" alt="showHorizontalLine" src="https://github.com/user-attachments/assets/cb876af3-89e9-41f7-8b08-a2f9edc3c787" />

---

Let me know if anything should be adjusted.
