### PR TITLE
Feature/radar chart vertice label

### DIFF
--- a/example/lib/presentation/samples/chart_samples.dart
+++ b/example/lib/presentation/samples/chart_samples.dart
@@ -27,6 +27,7 @@ import 'pie/pie_chart_sample1.dart';
 import 'pie/pie_chart_sample2.dart';
 import 'pie/pie_chart_sample3.dart';
 import 'radar/radar_chart_sample1.dart';
+import 'radar/radar_chart_sample2.dart';
 import 'scatter/scatter_chart_sample1.dart';
 import 'scatter/scatter_chart_sample2.dart';
 
@@ -68,6 +69,7 @@ class ChartSamples {
     ],
     ChartType.radar: [
       RadarChartSample(1, (context) => RadarChartSample1()),
+      RadarChartSample(2, (context) => const RadarChartSample2()),
     ],
     ChartType.candlestick: [
       CandlestickChartSample(1, (context) => const CandlestickChartSample1()),

--- a/example/lib/presentation/samples/radar/radar_chart_sample2.dart
+++ b/example/lib/presentation/samples/radar/radar_chart_sample2.dart
@@ -56,9 +56,9 @@ class _RadarChartSample2State extends State<RadarChartSample2> {
             );
           },
           getVerticeLabel: (index) {
-            return RadarChartVerticeLabel(
+            return RadarChartVertexLabel(
               text: widget.scores[index].value.toInt().toString(),
-              positionPercentageOffset: 0,
+              offset: 0,
             );
           },
           titlePositionPercentageOffset: 0.5,

--- a/example/lib/presentation/samples/radar/radar_chart_sample2.dart
+++ b/example/lib/presentation/samples/radar/radar_chart_sample2.dart
@@ -1,0 +1,113 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_resources.dart';
+import 'package:flutter/material.dart';
+
+class RadarChartSample2 extends StatefulWidget {
+  const RadarChartSample2({super.key});
+
+  final List<SubjectScore> scores = const [
+    SubjectScore(subject: 'Social Studies', value: 80),
+    SubjectScore(subject: 'Math', value: 75),
+    SubjectScore(subject: 'English', value: 70),
+    SubjectScore(subject: 'Science', value: 65),
+    SubjectScore(subject: 'Art', value: 60),
+  ];
+
+  final double _maxPoint = 100;
+
+  @override
+  State<RadarChartSample2> createState() => _RadarChartSample2State();
+}
+
+class _RadarChartSample2State extends State<RadarChartSample2> {
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1,
+      child: RadarChart(
+        RadarChartDataExtended(
+          dataSets: [
+            RadarDataSet(
+              dataEntries: widget.scores
+                  .map((score) => RadarEntry(value: score.value))
+                  .toList(),
+            ),
+            RadarDataSet(
+              dataEntries: List.generate(
+                widget.scores.length,
+                (index) => RadarEntry(value: widget._maxPoint),
+              ),
+              fillColor: Colors.transparent,
+              borderColor: Colors.transparent,
+            ),
+          ],
+          radarBackgroundColor: Colors.transparent,
+          borderData: FlBorderData(
+            show: true,
+            border: Border.all(color: AppColors.borderColor),
+          ),
+          radarBorderData: const BorderSide(
+            color: AppColors.borderColor,
+          ),
+          getTitle: (index, angle) {
+            return RadarChartTitle(
+              text: widget.scores[index].subject,
+              positionPercentageOffset: 0.1,
+            );
+          },
+          getVerticeLabel: (index) {
+            return RadarChartVerticeLabel(
+              text: widget.scores[index].value.toInt().toString(),
+              positionPercentageOffset: 0,
+            );
+          },
+          titlePositionPercentageOffset: 0.5,
+          verticeLabelTextStyle: const TextStyle(
+            color: AppColors.primary,
+          ),
+          tickBorderData: const BorderSide(
+            color: AppColors.mainGridLineColor,
+          ),
+          gridBorderData: const BorderSide(
+            color: AppColors.mainGridLineColor,
+          ),
+          tickCount: 4,
+          ticksTextStyle: const TextStyle(
+            color: Colors.transparent,
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class RadarChartDataExtended extends RadarChartData {
+  RadarChartDataExtended({
+    required List<RadarDataSet> super.dataSets,
+    super.radarBackgroundColor,
+    super.borderData,
+    super.radarBorderData,
+    super.getTitle,
+    super.getVerticeLabel,
+    super.titleTextStyle,
+    super.titlePositionPercentageOffset,
+    super.verticeLabelTextStyle,
+    super.tickBorderData,
+    super.gridBorderData,
+    super.tickCount,
+    super.ticksTextStyle,
+  });
+
+  @override
+  RadarEntry get minEntry => super.maxEntry;
+}
+
+class SubjectScore {
+  const SubjectScore({
+    required this.subject,
+    required this.value,
+  });
+
+  final String subject;
+  final double value;
+}

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -91,7 +91,6 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     this.titleTextStyle,
     this.verticeLabelTextStyle,
     double? titlePositionPercentageOffset,
-    double? verticeLabelPositionPercentageOffset,
     int? tickCount,
     this.ticksTextStyle,
     BorderSide? tickBorderData,
@@ -110,20 +109,12 @@ class RadarChartData extends BaseChartData with EquatableMixin {
                   titlePositionPercentageOffset <= 1,
           'titlePositionPercentageOffset must be something between 0 and 1 ',
         ),
-        assert(
-          verticeLabelPositionPercentageOffset == null ||
-              verticeLabelPositionPercentageOffset >= 0 &&
-                  verticeLabelPositionPercentageOffset <= 1,
-          'verticeLabelPositionPercentageOffset must be something between 0 and 1 ',
-        ),
         dataSets = dataSets ?? const [],
         radarBackgroundColor = radarBackgroundColor ?? Colors.transparent,
         radarBorderData = radarBorderData ?? const BorderSide(width: 2),
         radarShape = radarShape ?? RadarShape.circle,
         radarTouchData = radarTouchData ?? RadarTouchData(),
         titlePositionPercentageOffset = titlePositionPercentageOffset ?? 0.2,
-        verticeLabelPositionPercentageOffset =
-            verticeLabelPositionPercentageOffset ?? 0.2,
         tickCount = tickCount ?? 1,
         tickBorderData = tickBorderData ?? const BorderSide(width: 2),
         gridBorderData = gridBorderData ?? const BorderSide(width: 2),
@@ -177,13 +168,6 @@ class RadarChartData extends BaseChartData with EquatableMixin {
   /// if it is 1 the title will be drawn near the outside of section,
   /// the default value is 0.2.
   final double titlePositionPercentageOffset;
-
-  /// the [verticeLabelPositionPercentageOffset] is the place of showing labels on the [RadarChart] vertices
-  /// The higher the value of this field, the more labels move away from the chart vertices.
-  /// this field should be between 0 and 1,
-  /// if it is 0 the label will be drawn near the chart vertices,
-  /// if it is 1 the label will be drawn near the outside of chart vertices,
-  final double verticeLabelPositionPercentageOffset;
 
   /// Defines the number of ticks that should be paint in [RadarChart]
   /// the default & minimum value of this field is 1.
@@ -245,7 +229,6 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     GetVerticeLabelByIndexFunction? getVerticeLabel,
     TextStyle? titleTextStyle,
     double? titlePositionPercentageOffset,
-    double? verticeLabelPositionPercentageOffset,
     int? tickCount,
     TextStyle? ticksTextStyle,
     BorderSide? tickBorderData,
@@ -264,9 +247,6 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         titleTextStyle: titleTextStyle ?? this.titleTextStyle,
         titlePositionPercentageOffset:
             titlePositionPercentageOffset ?? this.titlePositionPercentageOffset,
-        verticeLabelPositionPercentageOffset:
-            verticeLabelPositionPercentageOffset ??
-                this.verticeLabelPositionPercentageOffset,
         tickCount: tickCount ?? this.tickCount,
         ticksTextStyle: ticksTextStyle ?? this.ticksTextStyle,
         tickBorderData: tickBorderData ?? this.tickBorderData,
@@ -290,11 +270,6 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         titlePositionPercentageOffset: lerpDouble(
           a.titlePositionPercentageOffset,
           b.titlePositionPercentageOffset,
-          t,
-        ),
-        verticeLabelPositionPercentageOffset: lerpDouble(
-          a.verticeLabelPositionPercentageOffset,
-          b.verticeLabelPositionPercentageOffset,
           t,
         ),
         tickCount: lerpInt(a.tickCount, b.tickCount, t),
@@ -326,7 +301,6 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         titleTextStyle,
         verticeLabelTextStyle,
         titlePositionPercentageOffset,
-        verticeLabelPositionPercentageOffset,
         tickCount,
         ticksTextStyle,
         tickBorderData,

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -12,6 +12,10 @@ typedef GetTitleByIndexFunction = RadarChartTitle Function(
   double angle,
 );
 
+typedef GetVerticeLabelByIndexFunction = RadarChartVerticeLabel Function(
+  int index,
+);
+
 enum RadarShape {
   circle,
   polygon,
@@ -41,6 +45,22 @@ class RadarChartTitle {
   final double? positionPercentageOffset;
 }
 
+/// Defines a label for [RadarChart] vertices
+class RadarChartVerticeLabel {
+  const RadarChartVerticeLabel({
+    required this.text,
+    this.positionPercentageOffset,
+  });
+
+  /// [text] is used to draw labels on the vertices of [RadarChart]
+  final String text;
+
+  /// [positionPercentageOffset] is the place of showing label on the [RadarChart] vertices
+  /// The higher the value of this field, the more labels move away from the chart vertices.
+  /// This value should be between 0 and 1
+  final double? positionPercentageOffset;
+}
+
 /// [RadarChart] needs this class to render itself.
 ///
 /// It holds data needed to draw a radar chart,
@@ -67,8 +87,11 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? radarBorderData,
     RadarShape? radarShape,
     this.getTitle,
+    this.getVerticeLabel,
     this.titleTextStyle,
+    this.verticeLabelTextStyle,
     double? titlePositionPercentageOffset,
+    double? verticeLabelPositionPercentageOffset,
     int? tickCount,
     this.ticksTextStyle,
     BorderSide? tickBorderData,
@@ -87,12 +110,20 @@ class RadarChartData extends BaseChartData with EquatableMixin {
                   titlePositionPercentageOffset <= 1,
           'titlePositionPercentageOffset must be something between 0 and 1 ',
         ),
+        assert(
+          verticeLabelPositionPercentageOffset == null ||
+              verticeLabelPositionPercentageOffset >= 0 &&
+                  verticeLabelPositionPercentageOffset <= 1,
+          'verticeLabelPositionPercentageOffset must be something between 0 and 1 ',
+        ),
         dataSets = dataSets ?? const [],
         radarBackgroundColor = radarBackgroundColor ?? Colors.transparent,
         radarBorderData = radarBorderData ?? const BorderSide(width: 2),
         radarShape = radarShape ?? RadarShape.circle,
         radarTouchData = radarTouchData ?? RadarTouchData(),
         titlePositionPercentageOffset = titlePositionPercentageOffset ?? 0.2,
+        verticeLabelPositionPercentageOffset =
+            verticeLabelPositionPercentageOffset ?? 0.2,
         tickCount = tickCount ?? 1,
         tickBorderData = tickBorderData ?? const BorderSide(width: 2),
         gridBorderData = gridBorderData ?? const BorderSide(width: 2),
@@ -130,8 +161,14 @@ class RadarChartData extends BaseChartData with EquatableMixin {
   /// ```
   final GetTitleByIndexFunction? getTitle;
 
+  /// [getVerticeLabel] is used to draw labels on the vertices of the [RadarChart]
+  final GetVerticeLabelByIndexFunction? getVerticeLabel;
+
   /// Defines style of showing [RadarChart] titles.
   final TextStyle? titleTextStyle;
+
+  /// Defines style of showing [RadarChart] vertice labels.
+  final TextStyle? verticeLabelTextStyle;
 
   /// the [titlePositionPercentageOffset] is the place of showing title on the [RadarChart]
   /// The higher the value of this field, the more titles move away from the chart.
@@ -140,6 +177,13 @@ class RadarChartData extends BaseChartData with EquatableMixin {
   /// if it is 1 the title will be drawn near the outside of section,
   /// the default value is 0.2.
   final double titlePositionPercentageOffset;
+
+  /// the [verticeLabelPositionPercentageOffset] is the place of showing labels on the [RadarChart] vertices
+  /// The higher the value of this field, the more labels move away from the chart vertices.
+  /// this field should be between 0 and 1,
+  /// if it is 0 the label will be drawn near the chart vertices,
+  /// if it is 1 the label will be drawn near the outside of chart vertices,
+  final double verticeLabelPositionPercentageOffset;
 
   /// Defines the number of ticks that should be paint in [RadarChart]
   /// the default & minimum value of this field is 1.
@@ -198,8 +242,10 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? radarBorderData,
     RadarShape? radarShape,
     GetTitleByIndexFunction? getTitle,
+    GetVerticeLabelByIndexFunction? getVerticeLabel,
     TextStyle? titleTextStyle,
     double? titlePositionPercentageOffset,
+    double? verticeLabelPositionPercentageOffset,
     int? tickCount,
     TextStyle? ticksTextStyle,
     BorderSide? tickBorderData,
@@ -214,9 +260,13 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         radarBorderData: radarBorderData ?? this.radarBorderData,
         radarShape: radarShape ?? this.radarShape,
         getTitle: getTitle ?? this.getTitle,
+        getVerticeLabel: getVerticeLabel ?? this.getVerticeLabel,
         titleTextStyle: titleTextStyle ?? this.titleTextStyle,
         titlePositionPercentageOffset:
             titlePositionPercentageOffset ?? this.titlePositionPercentageOffset,
+        verticeLabelPositionPercentageOffset:
+            verticeLabelPositionPercentageOffset ??
+                this.verticeLabelPositionPercentageOffset,
         tickCount: tickCount ?? this.tickCount,
         ticksTextStyle: ticksTextStyle ?? this.ticksTextStyle,
         tickBorderData: tickBorderData ?? this.tickBorderData,
@@ -235,10 +285,16 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         radarBackgroundColor:
             Color.lerp(a.radarBackgroundColor, b.radarBackgroundColor, t),
         getTitle: b.getTitle,
+        getVerticeLabel: b.getVerticeLabel,
         titleTextStyle: TextStyle.lerp(a.titleTextStyle, b.titleTextStyle, t),
         titlePositionPercentageOffset: lerpDouble(
           a.titlePositionPercentageOffset,
           b.titlePositionPercentageOffset,
+          t,
+        ),
+        verticeLabelPositionPercentageOffset: lerpDouble(
+          a.verticeLabelPositionPercentageOffset,
+          b.verticeLabelPositionPercentageOffset,
           t,
         ),
         tickCount: lerpInt(a.tickCount, b.tickCount, t),
@@ -266,8 +322,11 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         radarBorderData,
         radarShape,
         getTitle,
+        getVerticeLabel,
         titleTextStyle,
+        verticeLabelTextStyle,
         titlePositionPercentageOffset,
+        verticeLabelPositionPercentageOffset,
         tickCount,
         ticksTextStyle,
         tickBorderData,

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -12,7 +12,7 @@ typedef GetTitleByIndexFunction = RadarChartTitle Function(
   double angle,
 );
 
-typedef GetVerticeLabelByIndexFunction = RadarChartVerticeLabel Function(
+typedef GetVerticeLabelByIndexFunction = RadarChartVertexLabel Function(
   int index,
 );
 
@@ -46,19 +46,19 @@ class RadarChartTitle {
 }
 
 /// Defines a label for [RadarChart] vertices
-class RadarChartVerticeLabel {
-  const RadarChartVerticeLabel({
+class RadarChartVertexLabel {
+  const RadarChartVertexLabel({
     required this.text,
-    this.positionPercentageOffset,
+    this.offset,
   });
 
   /// [text] is used to draw labels on the vertices of [RadarChart]
   final String text;
 
-  /// [positionPercentageOffset] is the place of showing label on the [RadarChart] vertices
+  /// [offset] is the place of showing label on the [RadarChart] vertices
   /// The higher the value of this field, the more labels move away from the chart vertices.
   /// This value should be between 0 and 1
-  final double? positionPercentageOffset;
+  final double? offset;
 }
 
 /// [RadarChart] needs this class to render itself.
@@ -228,6 +228,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     GetTitleByIndexFunction? getTitle,
     GetVerticeLabelByIndexFunction? getVerticeLabel,
     TextStyle? titleTextStyle,
+    TextStyle? verticeLabelTextStyle,
     double? titlePositionPercentageOffset,
     int? tickCount,
     TextStyle? ticksTextStyle,
@@ -245,6 +246,8 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         getTitle: getTitle ?? this.getTitle,
         getVerticeLabel: getVerticeLabel ?? this.getVerticeLabel,
         titleTextStyle: titleTextStyle ?? this.titleTextStyle,
+        verticeLabelTextStyle:
+            verticeLabelTextStyle ?? this.verticeLabelTextStyle,
         titlePositionPercentageOffset:
             titlePositionPercentageOffset ?? this.titlePositionPercentageOffset,
         tickCount: tickCount ?? this.tickCount,
@@ -267,6 +270,8 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         getTitle: b.getTitle,
         getVerticeLabel: b.getVerticeLabel,
         titleTextStyle: TextStyle.lerp(a.titleTextStyle, b.titleTextStyle, t),
+        verticeLabelTextStyle:
+            TextStyle.lerp(a.verticeLabelTextStyle, b.verticeLabelTextStyle, t),
         titlePositionPercentageOffset: lerpDouble(
           a.titlePositionPercentageOffset,
           b.titlePositionPercentageOffset,

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -1,4 +1,4 @@
-import 'dart:math' show cos, min, pi, sin;
+import 'dart:math' show cos, min, pi, sin, sqrt;
 
 import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
@@ -66,6 +66,7 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
     drawTicks(context, canvasWrapper, holder);
     drawTitles(context, canvasWrapper, holder);
     drawDataSets(canvasWrapper, holder);
+    drawVerticeLabels(context, canvasWrapper, holder);
   }
 
   @visibleForTesting
@@ -334,6 +335,77 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
             title.angle - baseTitleAngle,
           );
         },
+      );
+    }
+  }
+
+  @visibleForTesting
+  /// Draws labels at each vertex of the [RadarChart].
+  void drawVerticeLabels(
+    BuildContext context,
+    CanvasWrapper canvasWrapper,
+    PaintHolder<RadarChartData> holder,
+  ) {
+    final data = holder.data;
+    if (data.getVerticeLabel == null) return;
+
+    dataSetsPosition ??= calculateDataSetsPosition(canvasWrapper.size, holder);
+    if (dataSetsPosition!.isEmpty) return;
+
+    final size = canvasWrapper.size;
+    final centerX = radarCenterX(size);
+    final centerY = radarCenterY(size);
+    final vertexPositions = dataSetsPosition![0].entriesOffset;
+
+    final style = Utils().getThemeAwareTextStyle(
+      context,
+      data.verticeLabelTextStyle,
+    );
+
+    _titleTextPaint
+      ..textAlign = TextAlign.center
+      ..textDirection = TextDirection.ltr
+      ..textScaler = holder.textScaler;
+
+    for (var index = 0; index < vertexPositions.length; index++) {
+      final verticeLabel = data.getVerticeLabel!(index);
+      final threshold = 1.0 +
+          (verticeLabel.positionPercentageOffset ??
+              data.verticeLabelPositionPercentageOffset);
+      final span = TextSpan(
+        text: verticeLabel.text,
+        style: style,
+      );
+      _titleTextPaint
+        ..text = span
+        ..layout();
+
+      // Get the vertex position from dataSetsPosition
+      final vertexOffset = vertexPositions[index];
+
+      final vectorX = vertexOffset.dx - centerX;
+      final vectorY = vertexOffset.dy - centerY;
+
+      final vectorLength = sqrt(vectorX * vectorX + vectorY * vectorY);
+
+      final normalizedX = vectorX / vectorLength * threshold;
+      final normalizedY = vectorY / vectorLength * threshold;
+
+      const labelOffset = 20.0;
+      final labelX = vertexOffset.dx + normalizedX * labelOffset;
+      final labelY = vertexOffset.dy + normalizedY * labelOffset;
+
+      final rect = Rect.fromLTWH(
+        labelX - _titleTextPaint.width / 2,
+        labelY - _titleTextPaint.height / 2,
+        _titleTextPaint.width,
+        _titleTextPaint.height,
+      );
+
+      canvasWrapper.drawText(
+        _titleTextPaint,
+        rect.topLeft,
+        0,
       );
     }
   }

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -369,7 +369,7 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
 
     for (var index = 0; index < vertexPositions.length; index++) {
       final verticeLabel = data.getVerticeLabel!(index);
-      final threshold = 1.0 + (verticeLabel.positionPercentageOffset ?? 0.2);
+      final threshold = 1.0 + (verticeLabel.offset ?? 0.2);
       final span = TextSpan(
         text: verticeLabel.text,
         style: style,

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -369,9 +369,7 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
 
     for (var index = 0; index < vertexPositions.length; index++) {
       final verticeLabel = data.getVerticeLabel!(index);
-      final threshold = 1.0 +
-          (verticeLabel.positionPercentageOffset ??
-              data.verticeLabelPositionPercentageOffset);
+      final threshold = 1.0 + (verticeLabel.positionPercentageOffset ?? 0.2);
       final span = TextSpan(
         text: verticeLabel.text,
         style: style,

--- a/test/chart/radar_chart/radar_chart_painter_test.dart
+++ b/test/chart/radar_chart/radar_chart_painter_test.dart
@@ -1033,7 +1033,6 @@ void main() {
           );
         },
         verticeLabelTextStyle: MockData.textStyle4,
-        verticeLabelPositionPercentageOffset: 0.2,
         radarBorderData: const BorderSide(color: MockData.color6, width: 33),
         tickBorderData: const BorderSide(color: MockData.color5, width: 55),
         gridBorderData: const BorderSide(color: MockData.color3, width: 3),

--- a/test/chart/radar_chart/radar_chart_painter_test.dart
+++ b/test/chart/radar_chart/radar_chart_painter_test.dart
@@ -898,6 +898,193 @@ void main() {
     });
   });
 
+  group('drawVerticeLabels()', () {
+    test('test without vertice labels', () {
+      const viewSize = Size(400, 300);
+
+      final data = RadarChartData(
+        dataSets: [
+          RadarDataSet(
+            dataEntries: [
+              const RadarEntry(value: 1),
+              const RadarEntry(value: 2),
+              const RadarEntry(value: 3),
+            ],
+          ),
+        ],
+        titleTextStyle: MockData.textStyle4,
+        radarBorderData: const BorderSide(color: MockData.color6, width: 33),
+        tickBorderData: const BorderSide(color: MockData.color5, width: 55),
+        gridBorderData: const BorderSide(color: MockData.color3, width: 3),
+        radarBackgroundColor: MockData.color2,
+      );
+
+      final radarChartPainter = RadarChartPainter();
+      final holder =
+          PaintHolder<RadarChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[1] as TextStyle,
+      );
+      Utils.changeInstance(mockUtils);
+
+      final mockContext = MockBuildContext();
+
+      radarChartPainter.drawVerticeLabels(
+        mockContext,
+        mockCanvasWrapper,
+        holder,
+      );
+
+      verifyNever(mockCanvasWrapper.drawText(any, any));
+    });
+
+    test('test with vertice labels', () {
+      const viewSize = Size(400, 300);
+
+      final data = RadarChartData(
+        dataSets: [
+          RadarDataSet(
+            dataEntries: [
+              const RadarEntry(value: 1),
+              const RadarEntry(value: 2),
+              const RadarEntry(value: 3),
+            ],
+          ),
+        ],
+        getVerticeLabel: (index) {
+          return RadarChartVerticeLabel(text: 'Label $index');
+        },
+        verticeLabelTextStyle: MockData.textStyle4,
+        radarBorderData: const BorderSide(color: MockData.color6, width: 33),
+        tickBorderData: const BorderSide(color: MockData.color5, width: 55),
+        gridBorderData: const BorderSide(color: MockData.color3, width: 3),
+        radarBackgroundColor: MockData.color2,
+      );
+
+      final radarChartPainter = RadarChartPainter();
+      final holder =
+          PaintHolder<RadarChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[1] as TextStyle,
+      );
+      Utils.changeInstance(mockUtils);
+
+      final mockContext = MockBuildContext();
+
+      final results = <Map<String, dynamic>>[];
+      when(mockCanvasWrapper.drawText(captureAny, captureAny, captureAny))
+          .thenAnswer((inv) {
+        results.add({
+          'text':
+              ((inv.positionalArguments[0] as TextPainter).text as TextSpan?)!
+                  .text,
+          'style':
+              ((inv.positionalArguments[0] as TextPainter).text as TextSpan?)!
+                  .style,
+        });
+      });
+
+      radarChartPainter.drawVerticeLabels(
+        mockContext,
+        mockCanvasWrapper,
+        holder,
+      );
+      expect(results.length, 3);
+
+      expect(results[0]['text'] as String, 'Label 0');
+      expect(results[0]['style'] as TextStyle, MockData.textStyle4);
+
+      expect(results[1]['text'] as String, 'Label 1');
+      expect(results[1]['style'] as TextStyle, MockData.textStyle4);
+
+      expect(results[2]['text'] as String, 'Label 2');
+      expect(results[2]['style'] as TextStyle, MockData.textStyle4);
+    });
+
+    test('test with custom position percentage offset', () {
+      const viewSize = Size(400, 300);
+
+      final data = RadarChartData(
+        dataSets: [
+          RadarDataSet(
+            dataEntries: [
+              const RadarEntry(value: 1),
+              const RadarEntry(value: 2),
+              const RadarEntry(value: 3),
+            ],
+          ),
+        ],
+        getVerticeLabel: (index) {
+          return RadarChartVerticeLabel(
+            text: 'Label $index',
+            positionPercentageOffset: 0.5,
+          );
+        },
+        verticeLabelTextStyle: MockData.textStyle4,
+        verticeLabelPositionPercentageOffset: 0.2,
+        radarBorderData: const BorderSide(color: MockData.color6, width: 33),
+        tickBorderData: const BorderSide(color: MockData.color5, width: 55),
+        gridBorderData: const BorderSide(color: MockData.color3, width: 3),
+        radarBackgroundColor: MockData.color2,
+      );
+
+      final radarChartPainter = RadarChartPainter();
+      final holder =
+          PaintHolder<RadarChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final mockUtils = MockUtils();
+      when(mockUtils.getThemeAwareTextStyle(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[1] as TextStyle,
+      );
+      Utils.changeInstance(mockUtils);
+
+      final mockContext = MockBuildContext();
+
+      final results = <Map<String, dynamic>>[];
+      when(mockCanvasWrapper.drawText(captureAny, captureAny, captureAny))
+          .thenAnswer((inv) {
+        results.add({
+          'text':
+              ((inv.positionalArguments[0] as TextPainter).text as TextSpan?)!
+                  .text,
+          'style':
+              ((inv.positionalArguments[0] as TextPainter).text as TextSpan?)!
+                  .style,
+          'offset': inv.positionalArguments[1] as Offset,
+        });
+      });
+
+      radarChartPainter.drawVerticeLabels(
+        mockContext,
+        mockCanvasWrapper,
+        holder,
+      );
+      expect(results.length, 3);
+
+      for (var i = 0; i < results.length; i++) {
+        expect(results[i]['text'] as String, 'Label $i');
+        expect(results[i]['style'] as TextStyle, MockData.textStyle4);
+        expect(results[i]['offset'], isNotNull);
+      }
+    });
+  });
+
   group('handleTouch()', () {
     test('test 1', () {
       const viewSize = Size(400, 300);

--- a/test/chart/radar_chart/radar_chart_painter_test.dart
+++ b/test/chart/radar_chart/radar_chart_painter_test.dart
@@ -958,7 +958,7 @@ void main() {
           ),
         ],
         getVerticeLabel: (index) {
-          return RadarChartVerticeLabel(text: 'Label $index');
+          return RadarChartVertexLabel(text: 'Label $index');
         },
         verticeLabelTextStyle: MockData.textStyle4,
         radarBorderData: const BorderSide(color: MockData.color6, width: 33),
@@ -1027,9 +1027,9 @@ void main() {
           ),
         ],
         getVerticeLabel: (index) {
-          return RadarChartVerticeLabel(
+          return RadarChartVertexLabel(
             text: 'Label $index',
-            positionPercentageOffset: 0.5,
+            offset: 0.5,
           );
         },
         verticeLabelTextStyle: MockData.textStyle4,


### PR DESCRIPTION
## Summary
Added a new feature to display labels at each vertex of the RadarChart. 
Fixes this issue: https://github.com/imaNNeo/fl_chart/issues/1886

## What's included
### New Classes and Methods
- Added `RadarChartVerticeLabel` class to handle vertex label configuration
  - `text`: Displays the label text
  - `positionPercentageOffset`: Controls label position relative to vertex

### Tests
Added comprehensive test cases for `drawVerticeLabels`:
1. Test case for when no vertex labels are configured
2. Test case for basic vertex label display
3. Test case for custom position percentage offset

## Screenshot
<img width="372" alt="スクリーンショット 2025-05-01 23 47 26" src="https://github.com/user-attachments/assets/88a00c14-d83d-41ad-b030-f6e55b8eb102" />
