### PR TITLE
Add missing breaking change to 0.70.1 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 * **FEATURE** (by @mitulagr2) Add `renderPriority` feature in our [ScatterSpot](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/scatter_chart.md#scatterspot), #1545
 * **FEATURE** (by @imaNNeo) Add `rotationQuarterTurns` property in our Axis-Based charts (such as [LineChart](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/line_chart.md), [BarChart](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/bar_chart.md) and [ScatterChart](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/scatter_chart.md)). It allows you to rotate the chart 90 degrees (clockwise) in each turn. For example you can have Horizontal Bar Charts by setting `rotationQuarterTurns` to 1 (which rotates the chart 90 degrees clockwise). It works exactly like [RotatesBox](https://api.flutter.dev/flutter/widgets/RotatedBox-class.html) widget, #113
 * **FEATURE** (by @soraef) Add `isMinValueAtCenter` property in the [RadarChart](https://github.com/imaNNeo/fl_chart/blob/main/repo_files/documentations/radar_chart.md) to allow the user to set the minimum value at the center of the chart, #1351, #1442
+* **BREAKING** (by @imaNNeo) Add `TitleMeta` parameter in the `SideTitleWidget` instead of `axisSide`
 
 ## 0.70.0
 * **FEATURE** (by @Peetee06) Implemented a 5 years-old feature request about scroll and zoom support in our axis-based charts. Special thanks to @Peetee06 who made it happen, #71


### PR DESCRIPTION
Adds details of the following breaking change, that was included in the 0.70.1 release, to the changelog:
[https://github.com/imaNNeo/fl_chart/commit/83e4dda1b7669aaac33bea8d773f97b1345e90b9](https://github.com/imaNNeo/fl_chart/commit/83e4dda1b7669aaac33bea8d773f97b1345e90b9)

Fixes part of #1971, although I suspect the release notes themselves in the releases page may need to be manually edited as well, unless there's some automation or repo settings magic going on.

