### PR TITLE
fix: prevent curve overshooting

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -603,7 +603,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
         getPixelY(barSpots[i + 1 < size ? i + 1 : i].y, viewSize, holder),
       );
 
-      final controlPoint1 = previous + temp;
+      var controlPoint1 = previous + temp;
+
+      /// Prevent controlPoint1 overshooting in the x-axis
+      if (barData.preventCurveOverShooting && controlPoint1.dx > current.dx) {
+        controlPoint1 = Offset(current.dx, controlPoint1.dy);
+      }
 
       /// if the isCurved is false, we set 0 for smoothness,
       /// it means we should not have any smoothness then we face with
@@ -625,7 +630,12 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
         }
       }
 
-      final controlPoint2 = current - temp;
+      var controlPoint2 = current - temp;
+
+      /// Prevent controlPoint2 overshooting in the x-axis
+      if (barData.preventCurveOverShooting && controlPoint2.dx < previous.dx) {
+        controlPoint2 = Offset(previous.dx, controlPoint2.dy);
+      }
 
       path.cubicTo(
         controlPoint1.dx,


### PR DESCRIPTION
Fixes https://github.com/imaNNeo/fl_chart/issues/1722

Based on https://github.com/imaNNeo/fl_chart/issues/1722#issuecomment-2267489789

**Before (with `preventCurveOvershooting: true`)**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/7e585ff3-9839-409b-a224-dd2ed6487bae" />

**After (with `preventCurveOvershooting: true`)**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/e8aea780-e475-4673-b6e8-5a0f17ef5e8d" />

**Before (with `preventCurveOvershooting: true` and `preventCurveOvershootingThreshold: 0`)**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/fc23441c-e59f-4f38-9548-500475d570ef" />

**After (with `preventCurveOvershooting: true` and `preventCurveOvershootingThreshold: 0`)**

<img width="400" alt="image" src="https://github.com/user-attachments/assets/6b871ae1-9403-4779-9e5f-2c982f2e5ea5" />

