### PR TITLE
Feat/prevent curve over shooting xy variants

### DIFF
--- a/lib/src/chart/line_chart/line_chart_data.dart
+++ b/lib/src/chart/line_chart/line_chart_data.dart
@@ -246,6 +246,8 @@ class LineChartBarData with EquatableMixin {
     this.isCurved = false,
     this.curveSmoothness = 0.35,
     this.preventCurveOverShooting = false,
+    this.preventCurveOverShootingX = false,
+    this.preventCurveOverShootingY = false,
     this.preventCurveOvershootingThreshold = 10.0,
     this.isStrokeCapRound = false,
     this.isStrokeJoinRound = false,
@@ -262,7 +264,13 @@ class LineChartBarData with EquatableMixin {
   })  : color =
             color ?? ((color == null && gradient == null) ? Colors.cyan : null),
         belowBarData = belowBarData ?? BarAreaData(),
-        aboveBarData = aboveBarData ?? BarAreaData() {
+        aboveBarData = aboveBarData ?? BarAreaData(),
+        assert(
+          !(preventCurveOverShooting &&
+              (preventCurveOverShootingX || preventCurveOverShootingY)),
+          'preventCurveOverShooting cannot be used together with preventCurveOverShootingX or preventCurveOverShootingY. '
+          'Use either preventCurveOverShooting for both axes, or the specific axis variants.',
+        ) {
     FlSpot? mostLeft;
     FlSpot? mostTop;
     FlSpot? mostRight;
@@ -353,6 +361,16 @@ class LineChartBarData with EquatableMixin {
   /// check this [issue](https://github.com/imaNNeo/fl_chart/issues/25)
   final bool preventCurveOverShooting;
 
+  /// Prevent overshooting when draw curve line on the X-axis only.
+  /// When true, prevents control points from extending beyond data points horizontally,
+  /// while allowing natural Y-axis curve smoothing.
+  final bool preventCurveOverShootingX;
+
+  /// Prevent overshooting when draw curve line on the Y-axis only.
+  /// When true, prevents control points from extending beyond data points vertically,
+  /// while allowing natural X-axis curve smoothing.
+  final bool preventCurveOverShootingY;
+
   /// Applies threshold for [preventCurveOverShooting] algorithm.
   final double preventCurveOvershootingThreshold;
 
@@ -411,6 +429,8 @@ class LineChartBarData with EquatableMixin {
           b.preventCurveOvershootingThreshold,
           t,
         )!,
+        preventCurveOverShootingX: b.preventCurveOverShootingX,
+        preventCurveOverShootingY: b.preventCurveOverShootingY,
         dotData: FlDotData.lerp(a.dotData, b.dotData, t),
         errorIndicatorData: FlErrorIndicatorData.lerp(
           a.errorIndicatorData,
@@ -442,6 +462,8 @@ class LineChartBarData with EquatableMixin {
     double? curveSmoothness,
     bool? preventCurveOverShooting,
     double? preventCurveOvershootingThreshold,
+    bool? preventCurveOverShootingX,
+    bool? preventCurveOverShootingY,
     bool? isStrokeCapRound,
     bool? isStrokeJoinRound,
     BarAreaData? belowBarData,
@@ -468,6 +490,10 @@ class LineChartBarData with EquatableMixin {
             preventCurveOverShooting ?? this.preventCurveOverShooting,
         preventCurveOvershootingThreshold: preventCurveOvershootingThreshold ??
             this.preventCurveOvershootingThreshold,
+        preventCurveOverShootingX:
+            preventCurveOverShootingX ?? this.preventCurveOverShootingX,
+        preventCurveOverShootingY:
+            preventCurveOverShootingY ?? this.preventCurveOverShootingY,
         isStrokeCapRound: isStrokeCapRound ?? this.isStrokeCapRound,
         isStrokeJoinRound: isStrokeJoinRound ?? this.isStrokeJoinRound,
         belowBarData: belowBarData ?? this.belowBarData,
@@ -494,6 +520,8 @@ class LineChartBarData with EquatableMixin {
         curveSmoothness,
         preventCurveOverShooting,
         preventCurveOvershootingThreshold,
+        preventCurveOverShootingX,
+        preventCurveOverShootingY,
         isStrokeCapRound,
         isStrokeJoinRound,
         belowBarData,

--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -603,10 +603,16 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
         getPixelY(barSpots[i + 1 < size ? i + 1 : i].y, viewSize, holder),
       );
 
+      /// Determine which axes to prevent overshooting on
+      final preventCurveOverShootingY =
+          barData.preventCurveOverShooting || barData.preventCurveOverShootingY;
+      final preventCurveOverShootingX =
+          barData.preventCurveOverShooting || barData.preventCurveOverShootingX;
+
       var controlPoint1 = previous + temp;
 
       /// Prevent controlPoint1 overshooting in the x-axis
-      if (barData.preventCurveOverShooting && controlPoint1.dx > current.dx) {
+      if (preventCurveOverShootingX && controlPoint1.dx > current.dx) {
         controlPoint1 = Offset(current.dx, controlPoint1.dy);
       }
 
@@ -616,13 +622,15 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       final smoothness = barData.isCurved ? barData.curveSmoothness : 0.0;
       temp = ((next - previous) / 2) * smoothness;
 
-      if (barData.preventCurveOverShooting) {
+      if (preventCurveOverShootingY) {
         if ((next - current).dy <= barData.preventCurveOvershootingThreshold ||
             (current - previous).dy <=
                 barData.preventCurveOvershootingThreshold) {
           temp = Offset(temp.dx, 0);
         }
+      }
 
+      if (preventCurveOverShootingX) {
         if ((next - current).dx <= barData.preventCurveOvershootingThreshold ||
             (current - previous).dx <=
                 barData.preventCurveOvershootingThreshold) {
@@ -633,7 +641,7 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
       var controlPoint2 = current - temp;
 
       /// Prevent controlPoint2 overshooting in the x-axis
-      if (barData.preventCurveOverShooting && controlPoint2.dx < previous.dx) {
+      if (preventCurveOverShootingX && controlPoint2.dx < previous.dx) {
         controlPoint2 = Offset(previous.dx, controlPoint2.dy);
       }
 


### PR DESCRIPTION
Depends on #1980

**`preventCurveOverShooting: false`**

<img width="108" height="168" alt="Screenshot 2025-08-29 at 16 23 49" src="https://github.com/user-attachments/assets/0000c055-37d0-4baa-be27-dad0ac2066cd" />

**`preventCurveOverShooting: true`**

<img width="99" height="175" alt="Screenshot 2025-08-29 at 16 22 24" src="https://github.com/user-attachments/assets/debd8e75-6487-4c4f-bf63-277216a81bd0" />

**`preventCurveOverShootingX: true` (this PR)**

<img width="93" height="168" alt="Screenshot 2025-08-29 at 16 23 14" src="https://github.com/user-attachments/assets/bb51c348-e46d-432e-a4e5-571cb7f349e7" />



