### PR TITLE
feat: candlestick chart support trade indicator

### DIFF
--- a/example/lib/presentation/samples/candlestick/candlestick_chart_sample1.dart
+++ b/example/lib/presentation/samples/candlestick/candlestick_chart_sample1.dart
@@ -151,12 +151,24 @@ class CandlestickChartSample1State extends State<CandlestickChartSample1> {
                           .map((entry) {
                         final index = entry.key;
                         final data = entry.value;
+
+                        // Add different signal types for testing
+                        TradeSignalType signalType = TradeSignalType.none;
+                        if (index % 8 == 0 + (_currentMonthIndex % 8)) {
+                          signalType = TradeSignalType.buy;
+                        } else if (index % 8 == 3 + (_currentMonthIndex % 8)) {
+                          signalType = TradeSignalType.sell;
+                        } else if (index % 8 == 6 + (_currentMonthIndex % 8)) {
+                          signalType = TradeSignalType.trade;
+                        }
+
                         return CandlestickSpot(
                           x: index.toDouble(),
                           open: data.open,
                           high: data.high,
                           low: data.low,
                           close: data.close,
+                          tradeSignalType: signalType,
                         );
                       }).toList(),
                       minX: 0,

--- a/test/chart/candlestick_chart/candlestick_chart_data_test.dart
+++ b/test/chart/candlestick_chart/candlestick_chart_data_test.dart
@@ -295,6 +295,101 @@ void main() {
             ),
         true,
       );
+      
+      // Test trade signal type equality
+      expect(
+        candlestickSpot3 ==
+            candlestickSpot3.copyWith(
+              tradeSignalType: TradeSignalType.buy,
+            ),
+        false,
+      );
+      expect(
+        candlestickSpot3 ==
+            candlestickSpot3.copyWith(
+              tradeSignalType: TradeSignalType.none,
+            ),
+        true,
+      );
+    });
+
+    test('CandlestickSpot tradeSignalType tests', () {
+      // Test default signal type
+      final defaultSpot = CandlestickSpot(
+        x: 0,
+        open: 10,
+        high: 15,
+        low: 8,
+        close: 12,
+      );
+      expect(defaultSpot.tradeSignalType, TradeSignalType.none);
+
+      // Test explicit signal types
+      final buySpot = CandlestickSpot(
+        x: 1,
+        open: 10,
+        high: 15,
+        low: 8,
+        close: 12,
+        tradeSignalType: TradeSignalType.buy,
+      );
+      expect(buySpot.tradeSignalType, TradeSignalType.buy);
+
+      final sellSpot = CandlestickSpot(
+        x: 2,
+        open: 10,
+        high: 15,
+        low: 8,
+        close: 12,
+        tradeSignalType: TradeSignalType.sell,
+      );
+      expect(sellSpot.tradeSignalType, TradeSignalType.sell);
+
+      final tradeSpot = CandlestickSpot(
+        x: 3,
+        open: 10,
+        high: 15,
+        low: 8,
+        close: 12,
+        tradeSignalType: TradeSignalType.trade,
+      );
+      expect(tradeSpot.tradeSignalType, TradeSignalType.trade);
+
+      // Test copyWith preserves signal type
+      final copiedSpot = buySpot.copyWith(x: 5);
+      expect(copiedSpot.tradeSignalType, TradeSignalType.buy);
+      expect(copiedSpot.x, 5);
+
+      // Test copyWith changes signal type
+      final modifiedSpot = buySpot.copyWith(tradeSignalType: TradeSignalType.sell);
+      expect(modifiedSpot.tradeSignalType, TradeSignalType.sell);
+      expect(modifiedSpot.x, 1); // Other values preserved
+    });
+
+    test('CandlestickSpot lerp with tradeSignalType', () {
+      final spotA = CandlestickSpot(
+        x: 1,
+        open: 10,
+        high: 15,
+        low: 8,
+        close: 12,
+        tradeSignalType: TradeSignalType.buy,
+      );
+
+      final spotB = CandlestickSpot(
+        x: 2,
+        open: 20,
+        high: 25,
+        low: 18,
+        close: 22,
+        tradeSignalType: TradeSignalType.sell,
+      );
+
+      // Test lerp uses spotB's signal type (as per implementation)
+      final lerpedSpot = CandlestickSpot.lerp(spotA, spotB, 0.5);
+      expect(lerpedSpot.tradeSignalType, TradeSignalType.sell);
+      expect(lerpedSpot.x, 1.5);
+      expect(lerpedSpot.open, 15.0);
     });
 
     test('CandlestickTouchData equality test', () {

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -3380,6 +3380,33 @@ final candlestickSpot5 = CandlestickSpot(
   close: -50,
 );
 
+final candlestickSpotWithBuySignal = CandlestickSpot(
+  x: 100,
+  open: 50,
+  high: 60,
+  low: 45,
+  close: 55,
+  tradeSignalType: TradeSignalType.buy,
+);
+
+final candlestickSpotWithSellSignal = CandlestickSpot(
+  x: 101,
+  open: 55,
+  high: 58,
+  low: 48,
+  close: 50,
+  tradeSignalType: TradeSignalType.sell,
+);
+
+final candlestickSpotWithTradeSignal = CandlestickSpot(
+  x: 102,
+  open: 50,
+  high: 65,
+  low: 47,
+  close: 60,
+  tradeSignalType: TradeSignalType.trade,
+);
+
 final candleStickChartData1 = CandlestickChartData(
   candlestickSpots: [
     candlestickSpot1,


### PR DESCRIPTION
about https://github.com/imaNNeo/fl_chart/issues/1995
---
 I have added a new `tradeSignalType` property to `CandlestickSpot`, which includes four types:
  buy/sell/trade/none. 
  
  When the type is not `none`, it will display a corresponding trading
  signal above the candlestick based on the different types


such as
<img width="519" height="516" alt="image" src="https://github.com/user-attachments/assets/186d3708-95ce-4ff0-9468-a85997d89b1a" />
