### PR TITLE
feat: Add stacked segment support for PieChart sections

### DIFF
--- a/example/lib/presentation/samples/chart_samples.dart
+++ b/example/lib/presentation/samples/chart_samples.dart
@@ -26,6 +26,7 @@ import 'line/line_chart_sample9.dart';
 import 'pie/pie_chart_sample1.dart';
 import 'pie/pie_chart_sample2.dart';
 import 'pie/pie_chart_sample3.dart';
+import 'pie/pie_chart_sample4.dart';
 import 'radar/radar_chart_sample1.dart';
 import 'scatter/scatter_chart_sample1.dart';
 import 'scatter/scatter_chart_sample2.dart';
@@ -61,6 +62,7 @@ class ChartSamples {
       PieChartSample(1, (context) => const PieChartSample1()),
       PieChartSample(2, (context) => const PieChartSample2()),
       PieChartSample(3, (context) => const PieChartSample3()),
+      PieChartSample(4, (context) => const PieChartSample4()),
     ],
     ChartType.scatter: [
       ScatterChartSample(1, (context) => ScatterChartSample1()),

--- a/example/lib/presentation/samples/pie/pie_chart_sample4.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample4.dart
@@ -1,0 +1,162 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class PieChartSample4 extends StatefulWidget {
+  const PieChartSample4({super.key});
+
+  @override
+  State<PieChartSample4> createState() => _PieChartSample4State();
+}
+
+class _PieChartSample4State extends State<PieChartSample4> {
+  int touchedIndex = 0;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1.3,
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: PieChart(
+          PieChartData(
+            pieTouchData: PieTouchData(
+              touchCallback: (FlTouchEvent event, pieTouchResponse) {
+                setState(() {
+                  if (!event.isInterestedForInteractions ||
+                      pieTouchResponse == null ||
+                      pieTouchResponse.touchedSection == null) {
+                    touchedIndex = -1;
+                    return;
+                  }
+                  touchedIndex =
+                      pieTouchResponse.touchedSection!.touchedSectionIndex;
+                });
+              },
+            ),
+            borderData: FlBorderData(
+              show: false,
+            ),
+            sectionsSpace: 2,
+            centerSpaceRadius: 0,
+            sections: showingSections(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<PieChartSectionData> showingSections() {
+    return List.generate(5, (i) {
+      final isTouched = i == touchedIndex;
+      final fontSize = isTouched ? 20.0 : 16.0;
+      const shadows = [Shadow(color: Colors.black, blurRadius: 2)];
+      final value = 90.0;
+      final scaleFactor = isTouched ? 1.05 : 1.0;
+
+      return switch (i) {
+        0 => PieChartSectionData(
+            color: AppColors.contentColorGreen,
+            value: value,
+            title: 'A',
+            radius: 30 * scaleFactor,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: const Color(0xffffffff),
+              shadows: shadows,
+            ),
+            titlePositionPercentageOffset: 0.75,
+            segments: [
+              PieChartStackSegmentData(
+                radius: 70 * scaleFactor,
+                color: AppColors.contentColorRed,
+              )
+            ],
+            segmentsSpace: 2,
+          ),
+        1 => PieChartSectionData(
+            color: AppColors.contentColorGreen,
+            value: value,
+            title: 'B',
+            radius: 65 * scaleFactor,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: const Color(0xffffffff),
+              shadows: shadows,
+            ),
+            titlePositionPercentageOffset: 0.75,
+            segments: [
+              PieChartStackSegmentData(
+                radius: 35 * scaleFactor,
+                color: AppColors.contentColorRed,
+              )
+            ],
+            segmentsSpace: 2,
+          ),
+        2 => PieChartSectionData(
+            color: AppColors.contentColorGreen,
+            value: value,
+            title: 'C',
+            radius: 50 * scaleFactor,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: const Color(0xffffffff),
+              shadows: shadows,
+            ),
+            titlePositionPercentageOffset: 0.75,
+            segments: [
+              PieChartStackSegmentData(
+                radius: 50 * scaleFactor,
+                color: AppColors.contentColorRed,
+              )
+            ],
+            segmentsSpace: 2,
+          ),
+        3 => PieChartSectionData(
+            color: AppColors.contentColorGreen,
+            value: value,
+            title: 'D',
+            radius: 90 * scaleFactor,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: const Color(0xffffffff),
+              shadows: shadows,
+            ),
+            titlePositionPercentageOffset: 0.75,
+            segments: [
+              PieChartStackSegmentData(
+                radius: 10 * scaleFactor,
+                color: AppColors.contentColorRed,
+              )
+            ],
+            segmentsSpace: 2,
+          ),
+        4 => PieChartSectionData(
+            color: AppColors.contentColorGreen,
+            value: value,
+            title: 'E',
+            radius: 70 * scaleFactor,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: const Color(0xffffffff),
+              shadows: shadows,
+            ),
+            titlePositionPercentageOffset: 0.75,
+            segments: [
+              PieChartStackSegmentData(
+                radius: 30 * scaleFactor,
+                color: AppColors.contentColorRed,
+              )
+            ],
+            segmentsSpace: 2,
+          ),
+        _ => throw StateError('Invalid'),
+      };
+    });
+  }
+}

--- a/example/lib/presentation/samples/pie/pie_chart_sample4.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample4.dart
@@ -59,7 +59,7 @@ class _PieChartSample4State extends State<PieChartSample4> {
             color: AppColors.contentColorGreen,
             value: value,
             title: 'A',
-            radius: 30 * scaleFactor,
+            radius: 100 * scaleFactor,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -69,17 +69,22 @@ class _PieChartSample4State extends State<PieChartSample4> {
             titlePositionPercentageOffset: 0.75,
             segments: [
               PieChartStackSegmentData(
-                radius: 70 * scaleFactor,
+                fromRadius: 30 * scaleFactor,
+                toRadius: 32 * scaleFactor,
+                color: AppColors.pageBackground,
+              ),
+              PieChartStackSegmentData(
+                fromRadius: 32 * scaleFactor,
+                toRadius: 100 * scaleFactor,
                 color: AppColors.contentColorRed,
-              )
+              ),
             ],
-            segmentsSpace: 2,
           ),
         1 => PieChartSectionData(
             color: AppColors.contentColorGreen,
             value: value,
             title: 'B',
-            radius: 65 * scaleFactor,
+            radius: 100 * scaleFactor,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -89,17 +94,22 @@ class _PieChartSample4State extends State<PieChartSample4> {
             titlePositionPercentageOffset: 0.75,
             segments: [
               PieChartStackSegmentData(
-                radius: 35 * scaleFactor,
+                fromRadius: 65 * scaleFactor,
+                toRadius: 67 * scaleFactor,
+                color: AppColors.pageBackground,
+              ),
+              PieChartStackSegmentData(
+                fromRadius: 67 * scaleFactor,
+                toRadius: 100 * scaleFactor,
                 color: AppColors.contentColorRed,
-              )
+              ),
             ],
-            segmentsSpace: 2,
           ),
         2 => PieChartSectionData(
             color: AppColors.contentColorGreen,
             value: value,
             title: 'C',
-            radius: 50 * scaleFactor,
+            radius: 100 * scaleFactor,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -109,17 +119,22 @@ class _PieChartSample4State extends State<PieChartSample4> {
             titlePositionPercentageOffset: 0.75,
             segments: [
               PieChartStackSegmentData(
-                radius: 50 * scaleFactor,
+                fromRadius: 50 * scaleFactor,
+                toRadius: 52 * scaleFactor,
+                color: AppColors.pageBackground,
+              ),
+              PieChartStackSegmentData(
+                fromRadius: 52 * scaleFactor,
+                toRadius: 100 * scaleFactor,
                 color: AppColors.contentColorRed,
-              )
+              ),
             ],
-            segmentsSpace: 2,
           ),
         3 => PieChartSectionData(
             color: AppColors.contentColorGreen,
             value: value,
             title: 'D',
-            radius: 90 * scaleFactor,
+            radius: 100 * scaleFactor,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -129,17 +144,22 @@ class _PieChartSample4State extends State<PieChartSample4> {
             titlePositionPercentageOffset: 0.75,
             segments: [
               PieChartStackSegmentData(
-                radius: 10 * scaleFactor,
+                fromRadius: 90 * scaleFactor,
+                toRadius: 92 * scaleFactor,
+                color: AppColors.pageBackground,
+              ),
+              PieChartStackSegmentData(
+                fromRadius: 92 * scaleFactor,
+                toRadius: 100 * scaleFactor,
                 color: AppColors.contentColorRed,
-              )
+              ),
             ],
-            segmentsSpace: 2,
           ),
         4 => PieChartSectionData(
             color: AppColors.contentColorGreen,
             value: value,
             title: 'E',
-            radius: 70 * scaleFactor,
+            radius: 100 * scaleFactor,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -149,11 +169,16 @@ class _PieChartSample4State extends State<PieChartSample4> {
             titlePositionPercentageOffset: 0.75,
             segments: [
               PieChartStackSegmentData(
-                radius: 30 * scaleFactor,
+                fromRadius: 70 * scaleFactor,
+                toRadius: 72 * scaleFactor,
+                color: AppColors.pageBackground,
+              ),
+              PieChartStackSegmentData(
+                fromRadius: 72 * scaleFactor,
+                toRadius: 100 * scaleFactor,
                 color: AppColors.contentColorRed,
-              )
+              ),
             ],
-            segmentsSpace: 2,
           ),
         _ => throw StateError('Invalid'),
       };

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -252,7 +252,10 @@ class PieChartSectionData with EquatableMixin {
       0,
       (sum, segment) => sum + segment.radius,
     );
-    final spaces = (segments.where((s) => s.radius > 0).length) * segmentsSpace;
+    // final spaces = (segments.where((s) => s.radius > 0).length) * segmentsSpace;
+    final nonZeroSegments = segments.where((s) => s.radius > 0).length;
+    final gapCount = nonZeroSegments > 1 ? nonZeroSegments - 1 : 0;
+    final spaces = gapCount * segmentsSpace;
     return radius + segmentsRadius + spaces;
   }
 
@@ -348,10 +351,10 @@ class PieChartSectionData with EquatableMixin {
       ];
 }
 
-/// A stylized segment of Stacked Pie Chart section item
+/// A stylized segment of a Stacked Pie Chart section item.
 ///
 /// Each [PieChartSectionData] can have a list of [PieChartStackSegmentData] (with different radius, color
-/// and gradient) to represent a Stacked Pie Chart section,
+/// and gradient) to represent a Stacked Pie Chart section.
 class PieChartStackSegmentData with EquatableMixin {
   /// Renders a segment of Stacked Pie Chart with given [radius] and [color] or [gradient]
   /// for example if you want to have a Stacked Pie Chart with three colors:
@@ -366,7 +369,7 @@ class PieChartStackSegmentData with EquatableMixin {
   ///   ]
   /// )
   /// ```
-  /// To use the [gradient], set [color] to null
+  /// If [gradient] is specified, it overrides the [color] setting.
   PieChartStackSegmentData({
     double? radius,
     Color? color,

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -67,9 +67,8 @@ class PieChartData extends BaseChartData with EquatableMixin {
   final bool titleSunbeamLayout;
 
   /// We hold this value to determine weight of each [PieChartSectionData.value].
-  double get sumValue => sections
-      .map((data) => data.value)
-      .reduce((first, second) => first + second);
+  double get sumValue =>
+      sections.fold<double>(0, (sumVal, second) => sumVal + second.value);
 
   /// Copies current [PieChartData] to a new [PieChartData],
   /// and replaces provided values.
@@ -166,6 +165,8 @@ class PieChartSectionData with EquatableMixin {
     this.badgeWidget,
     double? titlePositionPercentageOffset,
     double? badgePositionPercentageOffset,
+    List<PieChartStackSegmentData>? segments,
+    double? segmentsSpace,
   })  : value = value ?? 10,
         color = color ?? Colors.cyan,
         radius = (radius ?? 40).clamp(0, double.infinity).toDouble(),
@@ -175,7 +176,9 @@ class PieChartSectionData with EquatableMixin {
         cornerRadius =
             (cornerRadius ?? 0.0).clamp(0, double.infinity).toDouble(),
         titlePositionPercentageOffset = titlePositionPercentageOffset ?? 0.5,
-        badgePositionPercentageOffset = badgePositionPercentageOffset ?? 0.5;
+        badgePositionPercentageOffset = badgePositionPercentageOffset ?? 0.5,
+        segments = segments ?? const [],
+        segmentsSpace = segmentsSpace ?? 0.0;
 
   /// It determines how much space it should occupy around the circle.
   ///
@@ -229,6 +232,30 @@ class PieChartSectionData with EquatableMixin {
   /// 1.0 means near the outside of the [PieChart].
   final double badgePositionPercentageOffset;
 
+  /// Fill up the [segments] to add stacked segments to a pie chart section.
+  final List<PieChartStackSegmentData> segments;
+
+  /// Defines the spacing between [segments].
+  final double segmentsSpace;
+
+  /// Transform section to a segment to help while rendering
+  PieChartStackSegmentData get asSegment => PieChartStackSegmentData(
+        radius: radius,
+        color: color,
+        gradient: gradient,
+      );
+
+  /// Total radius including the section radius, segments radii and segment spaces.
+  double get totalRadius {
+    if (segments.isEmpty) return radius;
+    final segmentsRadius = segments.fold<double>(
+      0,
+      (sum, segment) => sum + segment.radius,
+    );
+    final spaces = (segments.where((s) => s.radius > 0).length) * segmentsSpace;
+    return radius + segmentsRadius + spaces;
+  }
+
   /// Copies current [PieChartSectionData] to a new [PieChartSectionData],
   /// and replaces provided values.
   PieChartSectionData copyWith({
@@ -244,6 +271,8 @@ class PieChartSectionData with EquatableMixin {
     Widget? badgeWidget,
     double? titlePositionPercentageOffset,
     double? badgePositionPercentageOffset,
+    List<PieChartStackSegmentData>? segments,
+    double? segmentsSpace,
   }) =>
       PieChartSectionData(
         value: value ?? this.value,
@@ -260,6 +289,8 @@ class PieChartSectionData with EquatableMixin {
             titlePositionPercentageOffset ?? this.titlePositionPercentageOffset,
         badgePositionPercentageOffset:
             badgePositionPercentageOffset ?? this.badgePositionPercentageOffset,
+        segments: segments ?? this.segments,
+        segmentsSpace: segmentsSpace ?? this.segmentsSpace,
       );
 
   /// Lerps a [PieChartSectionData] based on [t] value, check [Tween.lerp].
@@ -289,6 +320,12 @@ class PieChartSectionData with EquatableMixin {
           b.badgePositionPercentageOffset,
           t,
         ),
+        segments: lerpPieChartStackSegmentDataList(
+          a.segments,
+          b.segments,
+          t,
+        ),
+        segmentsSpace: lerpDouble(a.segmentsSpace, b.segmentsSpace, t),
       );
 
   /// Used for equality check, see [EquatableMixin].
@@ -306,6 +343,77 @@ class PieChartSectionData with EquatableMixin {
         badgeWidget,
         titlePositionPercentageOffset,
         badgePositionPercentageOffset,
+        segments,
+        segmentsSpace,
+      ];
+}
+
+/// A stylized segment of Stacked Pie Chart section item
+///
+/// Each [PieChartSectionData] can have a list of [PieChartStackSegmentData] (with different radius, color
+/// and gradient) to represent a Stacked Pie Chart section,
+class PieChartStackSegmentData with EquatableMixin {
+  /// Renders a segment of Stacked Pie Chart with given [radius] and [color] or [gradient]
+  /// for example if you want to have a Stacked Pie Chart with three colors:
+  ///
+  /// ```dart
+  /// PieChartSectionData(
+  ///   color: Colors.red,
+  ///   radius: 10,
+  ///   segments: [
+  ///     PieChartStackSegmentData(radius: 20, color: Colors.green),
+  ///     PieChartStackSegmentData(radius: 30, color: Colors.blue),
+  ///   ]
+  /// )
+  /// ```
+  /// To use the [gradient], set [color] to null
+  PieChartStackSegmentData({
+    double? radius,
+    Color? color,
+    this.gradient,
+  })  : radius = radius ?? 10,
+        color = color ?? Colors.purple;
+
+  /// The radius that defines the "thickness" of a segment
+  final double radius;
+
+  /// Defines the color of section.
+  final Color color;
+
+  /// Defines the gradient of section. If specified, overrides the color setting.
+  final Gradient? gradient;
+
+  /// Copies current [PieChartStackSegmentData] to a new [PieChartStackSegmentData],
+  /// and replaces provided values.
+  PieChartStackSegmentData copyWith({
+    double? radius,
+    Color? color,
+    Gradient? gradient,
+  }) =>
+      PieChartStackSegmentData(
+        radius: radius ?? this.radius,
+        color: color ?? this.color,
+        gradient: gradient ?? this.gradient,
+      );
+
+  /// Lerps a [PieChartStackSegmentData] based on [t] value, check [Tween.lerp].
+  static PieChartStackSegmentData lerp(
+    PieChartStackSegmentData a,
+    PieChartStackSegmentData b,
+    double t,
+  ) =>
+      PieChartStackSegmentData(
+        radius: lerpDouble(a.radius, b.radius, t),
+        color: lerpColor(a.color, b.color, t),
+        gradient: Gradient.lerp(a.gradient, b.gradient, t),
+      );
+
+  /// Used for equality check, see [EquatableMixin].
+  @override
+  List<Object?> get props => [
+        radius,
+        color,
+        gradient,
       ];
 }
 

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -166,7 +166,6 @@ class PieChartSectionData with EquatableMixin {
     double? titlePositionPercentageOffset,
     double? badgePositionPercentageOffset,
     List<PieChartStackSegmentData>? segments,
-    double? segmentsSpace,
   })  : value = value ?? 10,
         color = color ?? Colors.cyan,
         radius = (radius ?? 40).clamp(0, double.infinity).toDouble(),
@@ -177,8 +176,7 @@ class PieChartSectionData with EquatableMixin {
             (cornerRadius ?? 0.0).clamp(0, double.infinity).toDouble(),
         titlePositionPercentageOffset = titlePositionPercentageOffset ?? 0.5,
         badgePositionPercentageOffset = badgePositionPercentageOffset ?? 0.5,
-        segments = segments ?? const [],
-        segmentsSpace = segmentsSpace ?? 0.0;
+        segments = segments ?? const [];
 
   /// It determines how much space it should occupy around the circle.
   ///
@@ -232,32 +230,12 @@ class PieChartSectionData with EquatableMixin {
   /// 1.0 means near the outside of the [PieChart].
   final double badgePositionPercentageOffset;
 
-  /// Fill up the [segments] to add stacked segments to a pie chart section.
+  /// Stacked segments rendered on top of the main section.
+  ///
+  /// Each segment defines [PieChartStackSegmentData.fromRadius] and
+  /// [PieChartStackSegmentData.toRadius] to specify its position within
+  /// the section's [radius]. Values are clamped to [0, radius] at render time.
   final List<PieChartStackSegmentData> segments;
-
-  /// Defines the spacing between [segments].
-  final double segmentsSpace;
-
-  /// Transform section to a segment to help while rendering
-  PieChartStackSegmentData get asSegment => PieChartStackSegmentData(
-        radius: radius,
-        color: color,
-        gradient: gradient,
-      );
-
-  /// Total radius including the section radius, segments radii and segment spaces.
-  double get totalRadius {
-    if (segments.isEmpty) return radius;
-    final segmentsRadius = segments.fold<double>(
-      0,
-      (sum, segment) => sum + segment.radius,
-    );
-    // final spaces = (segments.where((s) => s.radius > 0).length) * segmentsSpace;
-    final nonZeroSegments = segments.where((s) => s.radius > 0).length;
-    final gapCount = nonZeroSegments > 1 ? nonZeroSegments - 1 : 0;
-    final spaces = gapCount * segmentsSpace;
-    return radius + segmentsRadius + spaces;
-  }
 
   /// Copies current [PieChartSectionData] to a new [PieChartSectionData],
   /// and replaces provided values.
@@ -275,7 +253,6 @@ class PieChartSectionData with EquatableMixin {
     double? titlePositionPercentageOffset,
     double? badgePositionPercentageOffset,
     List<PieChartStackSegmentData>? segments,
-    double? segmentsSpace,
   }) =>
       PieChartSectionData(
         value: value ?? this.value,
@@ -293,7 +270,6 @@ class PieChartSectionData with EquatableMixin {
         badgePositionPercentageOffset:
             badgePositionPercentageOffset ?? this.badgePositionPercentageOffset,
         segments: segments ?? this.segments,
-        segmentsSpace: segmentsSpace ?? this.segmentsSpace,
       );
 
   /// Lerps a [PieChartSectionData] based on [t] value, check [Tween.lerp].
@@ -328,7 +304,6 @@ class PieChartSectionData with EquatableMixin {
           b.segments,
           t,
         ),
-        segmentsSpace: lerpDouble(a.segmentsSpace, b.segmentsSpace, t),
       );
 
   /// Used for equality check, see [EquatableMixin].
@@ -347,54 +322,71 @@ class PieChartSectionData with EquatableMixin {
         titlePositionPercentageOffset,
         badgePositionPercentageOffset,
         segments,
-        segmentsSpace,
       ];
 }
 
 /// A stylized segment of a Stacked Pie Chart section item.
 ///
-/// Each [PieChartSectionData] can have a list of [PieChartStackSegmentData] (with different radius, color
-/// and gradient) to represent a Stacked Pie Chart section.
+/// Each [PieChartSectionData] can have a list of [PieChartStackSegmentData]
+/// that are rendered on top of the main section, similar to how
+/// [BarChartRodStackItem] works in bar charts.
+///
+/// Each segment defines [fromRadius] and [toRadius] to specify its position
+/// within the section's total [PieChartSectionData.radius]. Values are clamped
+/// to the valid range [0, sectionRadius].
 class PieChartStackSegmentData with EquatableMixin {
-  /// Renders a segment of Stacked Pie Chart with given [radius] and [color] or [gradient]
-  /// for example if you want to have a Stacked Pie Chart with three colors:
+  /// Renders a segment of Stacked Pie Chart with given [fromRadius], [toRadius]
+  /// and [color] or [gradient].
+  ///
+  /// For example, to have a section with a colored overlay in the outer half:
   ///
   /// ```dart
   /// PieChartSectionData(
   ///   color: Colors.red,
-  ///   radius: 10,
+  ///   radius: 100,
   ///   segments: [
-  ///     PieChartStackSegmentData(radius: 20, color: Colors.green),
-  ///     PieChartStackSegmentData(radius: 30, color: Colors.blue),
+  ///     PieChartStackSegmentData(
+  ///       fromRadius: 50,
+  ///       toRadius: 100,
+  ///       color: Colors.green,
+  ///     ),
   ///   ]
   /// )
   /// ```
   /// If [gradient] is specified, it overrides the [color] setting.
   PieChartStackSegmentData({
-    double? radius,
+    double? fromRadius,
+    required this.toRadius,
     Color? color,
     this.gradient,
-  })  : radius = radius ?? 10,
+  })  : fromRadius = fromRadius ?? 0,
         color = color ?? Colors.purple;
 
-  /// The radius that defines the "thickness" of a segment
-  final double radius;
+  /// The start radius of this segment (distance from center of the section).
+  /// Clamped to [0, sectionRadius] at render time.
+  final double fromRadius;
 
-  /// Defines the color of section.
+  /// The end radius of this segment (distance from center of the section).
+  /// Clamped to [0, sectionRadius] at render time.
+  final double toRadius;
+
+  /// Defines the color of segment.
   final Color color;
 
-  /// Defines the gradient of section. If specified, overrides the color setting.
+  /// Defines the gradient of segment. If specified, overrides the color setting.
   final Gradient? gradient;
 
   /// Copies current [PieChartStackSegmentData] to a new [PieChartStackSegmentData],
   /// and replaces provided values.
   PieChartStackSegmentData copyWith({
-    double? radius,
+    double? fromRadius,
+    double? toRadius,
     Color? color,
     Gradient? gradient,
   }) =>
       PieChartStackSegmentData(
-        radius: radius ?? this.radius,
+        fromRadius: fromRadius ?? this.fromRadius,
+        toRadius: toRadius ?? this.toRadius,
         color: color ?? this.color,
         gradient: gradient ?? this.gradient,
       );
@@ -406,7 +398,8 @@ class PieChartStackSegmentData with EquatableMixin {
     double t,
   ) =>
       PieChartStackSegmentData(
-        radius: lerpDouble(a.radius, b.radius, t),
+        fromRadius: lerpDouble(a.fromRadius, b.fromRadius, t),
+        toRadius: lerpDouble(a.toRadius, b.toRadius, t)!,
         color: lerpColor(a.color, b.color, t),
         gradient: Gradient.lerp(a.gradient, b.gradient, t),
       );
@@ -414,7 +407,8 @@ class PieChartStackSegmentData with EquatableMixin {
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props => [
-        radius,
+        fromRadius,
+        toRadius,
         color,
         gradient,
       ];

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -22,8 +22,6 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
   PieChartPainter() : super() {
     _sectionPaint = Paint()..style = PaintingStyle.stroke;
 
-    _sectionSaveLayerPaint = Paint();
-
     _sectionStrokePaint = Paint()..style = PaintingStyle.stroke;
 
     _centerSpacePaint = Paint()..style = PaintingStyle.fill;
@@ -33,7 +31,6 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
   static const double _kRadiusSafetyMargin = 0.499;
 
   late Paint _sectionPaint;
-  late Paint _sectionSaveLayerPaint;
   late Paint _sectionStrokePaint;
   late Paint _centerSpacePaint;
   late Paint _clipPaint;
@@ -114,34 +111,15 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       final sectionDegree = sectionsAngle[i];
 
       if (sectionDegree == 360) {
-        final radius = centerRadius + section.radius / 2;
-        final rect = Rect.fromCircle(center: center, radius: radius);
-        _sectionPaint
-          ..setColorOrGradient(
-            section.color,
-            section.gradient,
-            rect,
-          )
-          ..strokeWidth = section.radius
-          ..style = PaintingStyle.fill;
-
-        final bounds = Rect.fromCircle(
-          center: center,
-          radius: centerRadius + section.radius,
+        drawSegments(
+          canvasWrapper,
+          section,
+          sectionDegree,
+          centerRadius,
+          0,
+          center,
         );
-        canvasWrapper
-          ..saveLayer(bounds, _sectionSaveLayerPaint)
-          ..drawCircle(
-            center,
-            centerRadius + section.radius,
-            _sectionPaint..blendMode = BlendMode.srcOver,
-          )
-          ..drawCircle(
-            center,
-            centerRadius,
-            _sectionPaint..blendMode = BlendMode.srcOut,
-          )
-          ..restore();
+
         _sectionPaint.blendMode = BlendMode.srcOver;
         if (section.borderSide.width != 0.0 &&
             section.borderSide.color.a != 0.0) {
@@ -152,7 +130,9 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           canvasWrapper
             ..drawCircle(
               center,
-              centerRadius + section.radius - (section.borderSide.width / 2),
+              centerRadius +
+                  section.totalRadius -
+                  (section.borderSide.width / 2),
               _sectionStrokePaint,
             )
 
@@ -166,6 +146,8 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         return;
       }
 
+      if (section.value == 0 || section.totalRadius == 0) continue;
+
       final sectionPath = generateSectionPath(
         section,
         data.sectionsSpace,
@@ -175,10 +157,124 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         centerRadius,
       );
 
-      drawSection(section, sectionPath, canvasWrapper);
+      canvasWrapper
+        ..save()
+        ..clipPath(sectionPath);
+
+      drawSegments(
+        canvasWrapper,
+        section,
+        sectionDegree,
+        centerRadius,
+        tempAngle,
+        center,
+      );
+      canvasWrapper.restore();
+
       drawSectionStroke(section, sectionPath, canvasWrapper, viewSize);
+
       tempAngle += sectionDegree;
     }
+  }
+
+  /// Draws all segments of a section. To support old pie chart logic the
+  /// section radius, color, and gradient will be wrapped in a [PieChartStackSegmentData]
+  void drawSegments(
+    CanvasWrapper canvasWrapper,
+    PieChartSectionData section,
+    double sweepAngle,
+    double startRadius,
+    double startAngle,
+    Offset center,
+  ) {
+    final nonZeroSegments = [
+      if (section.radius > 0) section.asSegment,
+      ...section.segments.where((s) => s.radius > 0),
+    ];
+
+    if (nonZeroSegments.isEmpty) {
+      return;
+    }
+
+    var currentSegmentRadius = startRadius;
+
+    for (var i = 0; i < nonZeroSegments.length; i++) {
+      final seg = nonZeroSegments[i];
+
+      final segPath = generateSegmentPath(
+        center,
+        currentSegmentRadius,
+        seg.radius,
+        startAngle,
+        sweepAngle,
+      );
+      drawSegment(seg, segPath, canvasWrapper);
+
+      currentSegmentRadius += seg.radius;
+      if (i == 0 && nonZeroSegments.length > 1 && section.segments.isNotEmpty) {
+        currentSegmentRadius += section.segmentsSpace;
+      } else if (i > 0 && i < nonZeroSegments.length - 1) {
+        currentSegmentRadius += section.segmentsSpace;
+      }
+    }
+  }
+
+  @visibleForTesting
+  void drawSegment(
+    PieChartStackSegmentData segment,
+    Path segmentPath,
+    CanvasWrapper canvasWrapper,
+  ) {
+    _sectionPaint
+      ..setColorOrGradient(
+        segment.color,
+        segment.gradient,
+        segmentPath.getBounds(),
+      )
+      ..style = PaintingStyle.fill;
+    canvasWrapper.drawPath(segmentPath, _sectionPaint);
+  }
+
+  @visibleForTesting
+  Path generateSegmentPath(
+    Offset center,
+    double innerRadius,
+    double segmentRadius,
+    double startAngle,
+    double sweepAngle,
+  ) {
+    if (sweepAngle == 360) {
+      return Path()
+        ..addOval(
+          Rect.fromCircle(
+            center: center,
+            radius: innerRadius + segmentRadius,
+          ),
+        )
+        ..addOval(Rect.fromCircle(center: center, radius: innerRadius))
+        ..fillType = PathFillType.evenOdd
+        ..close();
+    }
+
+    final outerRadius = innerRadius + segmentRadius;
+    final rectOuter = Rect.fromCircle(center: center, radius: outerRadius);
+    final rectInner = Rect.fromCircle(center: center, radius: innerRadius);
+
+    final startRadians = Utils().radians(startAngle);
+    final sweepRadians = Utils().radians(sweepAngle);
+
+    return Path()
+      ..moveTo(
+        center.dx + innerRadius * math.cos(startRadians),
+        center.dy + innerRadius * math.sin(startRadians),
+      )
+      ..arcTo(rectOuter, startRadians, sweepRadians, false)
+      ..lineTo(
+        center.dx + innerRadius * math.cos(startRadians + sweepRadians),
+        center.dy + innerRadius * math.sin(startRadians + sweepRadians),
+      )
+      ..arcTo(rectInner, startRadians + sweepRadians, -sweepRadians, false)
+      ..close();
   }
 
   /// Generates a path around a section
@@ -193,7 +289,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
   ) {
     final sectionRadiusRect = Rect.fromCircle(
       center: center,
-      radius: centerRadius + section.radius,
+      radius: centerRadius + section.totalRadius,
     );
 
     final centerRadiusRect = Rect.fromCircle(
@@ -209,13 +305,14 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         Offset(math.cos(startRadians), math.sin(startRadians));
 
     final startLineFrom = center + startLineDirection * centerRadius;
-    final startLineTo = startLineFrom + startLineDirection * section.radius;
+    final startLineTo =
+        startLineFrom + startLineDirection * section.totalRadius;
     final startLine = Line(startLineFrom, startLineTo);
 
     final endLineDirection = Offset(math.cos(endRadians), math.sin(endRadians));
 
     final endLineFrom = center + endLineDirection * centerRadius;
-    final endLineTo = endLineFrom + endLineDirection * section.radius;
+    final endLineTo = endLineFrom + endLineDirection * section.totalRadius;
     final endLine = Line(endLineFrom, endLineTo);
 
     Path sectionPath;
@@ -557,22 +654,6 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
   }
 
   @visibleForTesting
-  void drawSection(
-    PieChartSectionData section,
-    Path sectionPath,
-    CanvasWrapper canvasWrapper,
-  ) {
-    _sectionPaint
-      ..setColorOrGradient(
-        section.color,
-        section.gradient,
-        sectionPath.getBounds(),
-      )
-      ..style = PaintingStyle.fill;
-    canvasWrapper.drawPath(sectionPath, _sectionPaint);
-  }
-
-  @visibleForTesting
   void drawSectionStroke(
     PieChartSectionData section,
     Path sectionPath,
@@ -637,9 +718,9 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           center +
           Offset(
             math.cos(Utils().radians(sectionCenterAngle)) *
-                (centerRadius + (section.radius * percentageOffset)),
+                (centerRadius + (section.totalRadius * percentageOffset)),
             math.sin(Utils().radians(sectionCenterAngle)) *
-                (centerRadius + (section.radius * percentageOffset)),
+                (centerRadius + (section.totalRadius * percentageOffset)),
           );
 
       final sectionCenterOffsetTitle =
@@ -678,8 +759,10 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     if (data.centerSpaceRadius.isFinite) {
       return data.centerSpaceRadius;
     }
-    final maxRadius =
-        data.sections.reduce((a, b) => a.radius > b.radius ? a : b).radius;
+    if (data.sections.isEmpty) {
+      return 0;
+    }
+    final maxRadius = data.sections.map((s) => s.totalRadius).reduce(math.max);
     return (viewSize.shortestSide - (maxRadius * 2)) / 2;
   }
 
@@ -722,7 +805,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
               math.pow(localPosition.dy - center.dy, 2),
         );
         if (distance >= centerRadius &&
-            distance <= section.radius + centerRadius) {
+            distance <= section.totalRadius + centerRadius) {
           foundSectionData = section;
           foundSectionDataPosition = i;
         }

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -110,9 +110,17 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       final sectionDegree = sectionsAngle[i];
 
       if (sectionDegree == 360) {
+        final fullCirclePath = generateSegmentPath(
+          center,
+          centerRadius,
+          section.radius,
+          0,
+          sectionDegree,
+        );
         drawSegments(
           canvasWrapper,
           section,
+          fullCirclePath,
           sectionDegree,
           centerRadius,
           0,
@@ -161,6 +169,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       drawSegments(
         canvasWrapper,
         section,
+        sectionPath,
         sectionDegree,
         centerRadius,
         tempAngle,
@@ -177,27 +186,23 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
   /// Draws the main section background first, then renders stacked segments
   /// on top, similar to how [BarChartRodStackItem] works in bar charts.
   ///
-  /// The main section spans the full [PieChartSectionData.radius].
+  /// [mainPath] is the path for the full section fill, to avoid recalculating
+  /// the same geometry. The [PieChartStackSegmentData] overlays must still be
+  /// generated here since they use different radii.
+  ///
   /// Each segment's [PieChartStackSegmentData.fromRadius] and
   /// [PieChartStackSegmentData.toRadius] are clamped to [0, section.radius]
   /// and rendered as overlays.
+  @visibleForTesting
   void drawSegments(
     CanvasWrapper canvasWrapper,
     PieChartSectionData section,
+    Path mainPath,
     double sweepAngle,
     double startRadius,
     double startAngle,
     Offset center,
   ) {
-    if (section.radius <= 0) return;
-
-    final mainPath = generateSegmentPath(
-      center,
-      startRadius,
-      section.radius,
-      startAngle,
-      sweepAngle,
-    );
     _sectionPaint
       ..setColorOrGradient(
         section.color,

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -3,7 +3,6 @@ import 'dart:math' as math;
 import 'package:fl_chart/fl_chart.dart';
 import 'package:fl_chart/src/chart/base/base_chart/base_chart_painter.dart';
 import 'package:fl_chart/src/chart/base/line.dart';
-import 'package:fl_chart/src/chart/pie_chart/pie_chart_data.dart';
 import 'package:fl_chart/src/extensions/paint_extension.dart';
 import 'package:fl_chart/src/utils/canvas_wrapper.dart';
 import 'package:fl_chart/src/utils/utils.dart';
@@ -130,9 +129,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           canvasWrapper
             ..drawCircle(
               center,
-              centerRadius +
-                  section.totalRadius -
-                  (section.borderSide.width / 2),
+              centerRadius + section.radius - (section.borderSide.width / 2),
               _sectionStrokePaint,
             )
 
@@ -146,7 +143,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         return;
       }
 
-      if (section.value == 0 || section.totalRadius == 0) continue;
+      if (section.value == 0 || section.radius == 0) continue;
 
       final sectionPath = generateSectionPath(
         section,
@@ -177,8 +174,13 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     }
   }
 
-  /// Draws all segments of a section. To support old pie chart logic the
-  /// section radius, color, and gradient will be wrapped in a [PieChartStackSegmentData]
+  /// Draws the main section background first, then renders stacked segments
+  /// on top, similar to how [BarChartRodStackItem] works in bar charts.
+  ///
+  /// The main section spans the full [PieChartSectionData.radius].
+  /// Each segment's [PieChartStackSegmentData.fromRadius] and
+  /// [PieChartStackSegmentData.toRadius] are clamped to [0, section.radius]
+  /// and rendered as overlays.
   void drawSegments(
     CanvasWrapper canvasWrapper,
     PieChartSectionData section,
@@ -187,35 +189,38 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     double startAngle,
     Offset center,
   ) {
-    final nonZeroSegments = [
-      if (section.radius > 0) section.asSegment,
-      ...section.segments.where((s) => s.radius > 0),
-    ];
+    if (section.radius <= 0) return;
 
-    if (nonZeroSegments.isEmpty) {
-      return;
-    }
+    final mainPath = generateSegmentPath(
+      center,
+      startRadius,
+      section.radius,
+      startAngle,
+      sweepAngle,
+    );
+    _sectionPaint
+      ..setColorOrGradient(
+        section.color,
+        section.gradient,
+        mainPath.getBounds(),
+      )
+      ..style = PaintingStyle.fill;
+    canvasWrapper.drawPath(mainPath, _sectionPaint);
 
-    var currentSegmentRadius = startRadius;
-
-    for (var i = 0; i < nonZeroSegments.length; i++) {
-      final seg = nonZeroSegments[i];
+    for (final seg in section.segments) {
+      final clampedFrom = seg.fromRadius.clamp(0.0, section.radius);
+      final clampedTo = seg.toRadius.clamp(0.0, section.radius);
+      final segRadius = clampedTo - clampedFrom;
+      if (segRadius <= 0) continue;
 
       final segPath = generateSegmentPath(
         center,
-        currentSegmentRadius,
-        seg.radius,
+        startRadius + clampedFrom,
+        segRadius,
         startAngle,
         sweepAngle,
       );
       drawSegment(seg, segPath, canvasWrapper);
-
-      currentSegmentRadius += seg.radius;
-      if (i == 0 && nonZeroSegments.length > 1 && section.segments.isNotEmpty) {
-        currentSegmentRadius += section.segmentsSpace;
-      } else if (i > 0 && i < nonZeroSegments.length - 1) {
-        currentSegmentRadius += section.segmentsSpace;
-      }
     }
   }
 
@@ -289,7 +294,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
   ) {
     final sectionRadiusRect = Rect.fromCircle(
       center: center,
-      radius: centerRadius + section.totalRadius,
+      radius: centerRadius + section.radius,
     );
 
     final centerRadiusRect = Rect.fromCircle(
@@ -305,14 +310,13 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         Offset(math.cos(startRadians), math.sin(startRadians));
 
     final startLineFrom = center + startLineDirection * centerRadius;
-    final startLineTo =
-        startLineFrom + startLineDirection * section.totalRadius;
+    final startLineTo = startLineFrom + startLineDirection * section.radius;
     final startLine = Line(startLineFrom, startLineTo);
 
     final endLineDirection = Offset(math.cos(endRadians), math.sin(endRadians));
 
     final endLineFrom = center + endLineDirection * centerRadius;
-    final endLineTo = endLineFrom + endLineDirection * section.totalRadius;
+    final endLineTo = endLineFrom + endLineDirection * section.radius;
     final endLine = Line(endLineFrom, endLineTo);
 
     Path sectionPath;
@@ -718,9 +722,9 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           center +
           Offset(
             math.cos(Utils().radians(sectionCenterAngle)) *
-                (centerRadius + (section.totalRadius * percentageOffset)),
+                (centerRadius + (section.radius * percentageOffset)),
             math.sin(Utils().radians(sectionCenterAngle)) *
-                (centerRadius + (section.totalRadius * percentageOffset)),
+                (centerRadius + (section.radius * percentageOffset)),
           );
 
       final sectionCenterOffsetTitle =
@@ -762,7 +766,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     if (data.sections.isEmpty) {
       return 0;
     }
-    final maxRadius = data.sections.map((s) => s.totalRadius).reduce(math.max);
+    final maxRadius = data.sections.map((s) => s.radius).reduce(math.max);
     return (viewSize.shortestSide - (maxRadius * 2)) / 2;
   }
 
@@ -805,7 +809,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
               math.pow(localPosition.dy - center.dy, 2),
         );
         if (distance >= centerRadius &&
-            distance <= section.totalRadius + centerRadius) {
+            distance <= section.radius + centerRadius) {
           foundSectionData = section;
           foundSectionDataPosition = i;
         }

--- a/lib/src/utils/lerp.dart
+++ b/lib/src/utils/lerp.dart
@@ -135,6 +135,7 @@ List<PieChartSectionData>? lerpPieChartSectionDataList(
 ) =>
     lerpList(a, b, t, lerp: PieChartSectionData.lerp);
 
+/// Lerps [PieChartStackSegmentData] list based on [t] value, check [Tween.lerp].
 List<PieChartStackSegmentData>? lerpPieChartStackSegmentDataList(
   List<PieChartStackSegmentData>? a,
   List<PieChartStackSegmentData>? b,

--- a/lib/src/utils/lerp.dart
+++ b/lib/src/utils/lerp.dart
@@ -135,6 +135,13 @@ List<PieChartSectionData>? lerpPieChartSectionDataList(
 ) =>
     lerpList(a, b, t, lerp: PieChartSectionData.lerp);
 
+List<PieChartStackSegmentData>? lerpPieChartStackSegmentDataList(
+  List<PieChartStackSegmentData>? a,
+  List<PieChartStackSegmentData>? b,
+  double t,
+) =>
+    lerpList(a, b, t, lerp: PieChartStackSegmentData.lerp);
+
 /// Lerps [ScatterSpot] list based on [t] value, check [Tween.lerp].
 List<ScatterSpot>? lerpScatterSpotList(
   List<ScatterSpot>? a,

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -45,6 +45,16 @@ When you change the chart's state, it animates to the new state internally (usin
 |badgeWidget| badge component of the section| null|
 |titlePositionPercentageOffset|the place of the title in the section, this field should be between 0 and 1|0.5|
 |badgePositionPercentageOffset|the place of the badge component in the section, this field should be between 0 and 1|0.5|
+|segments| list of [PieChartStackSegmentData](#PieChartStackSegmentData) rendered on top of the section fill, similar to bar chart rod stacks. Each segment's `fromRadius`/`toRadius` are clamped to `[0, radius]` at render time|[]|
+
+
+### PieChartStackSegmentData
+|PropName|Description|default value|
+|:-------|:----------|:------------|
+|fromRadius| start of the segment, measured as a distance from the section's inner edge, clamped to `[0, sectionRadius]` at render time|0|
+|toRadius| end of the segment, clamped to `[0, sectionRadius]` at render time|required|
+|color| fill color of the segment|Colors.purple|
+|gradient| gradient fill, overrides `color` when set|null|
 
 
 ### PieTouchData ([read about touch handling](handle_touches.md))

--- a/test/chart/pie_chart/pie_chart_data_test.dart
+++ b/test/chart/pie_chart/pie_chart_data_test.dart
@@ -165,4 +165,113 @@ void main() {
       expect(sample1 == zeroLongPressDuration, false);
     });
   });
+
+  group('PieChartStackSegmentData', () {
+    test('equality', () {
+      final a = PieChartStackSegmentData(
+        fromRadius: 10,
+        toRadius: 30,
+        color: Colors.red,
+      );
+      final b = PieChartStackSegmentData(
+        fromRadius: 10,
+        toRadius: 30,
+        color: Colors.red,
+      );
+      expect(a == b, true);
+
+      expect(
+        a ==
+            PieChartStackSegmentData(
+              fromRadius: 20,
+              toRadius: 30,
+              color: Colors.red,
+            ),
+        false,
+      );
+      expect(
+        a ==
+            PieChartStackSegmentData(
+              fromRadius: 10,
+              toRadius: 40,
+              color: Colors.red,
+            ),
+        false,
+      );
+      expect(
+        a ==
+            PieChartStackSegmentData(
+              fromRadius: 10,
+              toRadius: 30,
+              color: Colors.blue,
+            ),
+        false,
+      );
+    });
+
+    test('copyWith', () {
+      final original = PieChartStackSegmentData(
+        fromRadius: 10,
+        toRadius: 40,
+        color: Colors.red,
+      );
+
+      expect(original.copyWith() == original, true);
+
+      expect(
+        original.copyWith(fromRadius: 5) ==
+            PieChartStackSegmentData(
+              fromRadius: 5,
+              toRadius: 40,
+              color: Colors.red,
+            ),
+        true,
+      );
+
+      expect(
+        original.copyWith(toRadius: 50) ==
+            PieChartStackSegmentData(
+              fromRadius: 10,
+              toRadius: 50,
+              color: Colors.red,
+            ),
+        true,
+      );
+
+      expect(
+        original.copyWith(color: Colors.green) ==
+            PieChartStackSegmentData(
+              fromRadius: 10,
+              toRadius: 40,
+              color: Colors.green,
+            ),
+        true,
+      );
+    });
+
+    test('lerp', () {
+      final a = PieChartStackSegmentData(
+        fromRadius: 0,
+        toRadius: 20,
+        color: const Color(0xFF000000),
+      );
+      final b = PieChartStackSegmentData(
+        fromRadius: 40,
+        toRadius: 80,
+        color: const Color(0xFFFFFFFF),
+      );
+
+      final atZero = PieChartStackSegmentData.lerp(a, b, 0);
+      expect(atZero.fromRadius, 0);
+      expect(atZero.toRadius, 20);
+
+      final atOne = PieChartStackSegmentData.lerp(a, b, 1);
+      expect(atOne.fromRadius, 40);
+      expect(atOne.toRadius, 80);
+
+      final mid = PieChartStackSegmentData.lerp(a, b, 0.5);
+      expect(mid.fromRadius, 20);
+      expect(mid.toRadius, 50);
+    });
+  });
 }

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -202,39 +202,31 @@ void main() {
       when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
       barChartPainter.drawSections(mockCanvasWrapper, [360], 10, holder);
 
-      final rect = Rect.fromCircle(
-        center: viewSize.center(Offset.zero),
-        radius: radius + centerSpace,
-      );
-      final results = verifyInOrder([
-        mockCanvasWrapper.saveLayer(
-          rect,
-          any,
-        ),
-        mockCanvasWrapper.drawCircle(
-          const Offset(100, 100),
-          10 + 30,
-          captureAny,
-        ),
-        mockCanvasWrapper.drawCircle(
-          const Offset(100, 100),
-          10,
-          captureAny,
-        ),
-        mockCanvasWrapper.restore(),
-      ]);
-      final result = results[1];
+      final result = verify(mockCanvasWrapper.drawPath(captureAny, captureAny));
       expect(result.callCount, 1);
+      final path = result.captured[0] as Path;
+      final paint = result.captured[1] as Paint;
+
+      final expectedPath = barChartPainter.generateSegmentPath(
+        viewSize.center(Offset.zero),
+        centerSpace,
+        radius,
+        0,
+        360,
+      );
+      expect(HelperMethods.equalsPaths(path, expectedPath), true);
       expect(
-        (result.captured.single as Paint).color,
+        paint.color,
         isSameColorAs(MockData.color2),
       );
-      expect((result.captured.single as Paint).style, PaintingStyle.fill);
 
+      expect(paint.style, PaintingStyle.fill);
+
+      // Outer border
       final result2 = verify(
         mockCanvasWrapper.drawCircle(
           const Offset(100, 100),
-          10 + (3 / 2),
+          centerSpace + radius - (3 / 2),
           captureAny,
         ),
       );
@@ -245,6 +237,22 @@ void main() {
       );
       expect((result2.captured.single as Paint).strokeWidth, 3);
       expect((result2.captured.single as Paint).style, PaintingStyle.stroke);
+
+      // Inner border
+      final result3 = verify(
+        mockCanvasWrapper.drawCircle(
+          const Offset(100, 100),
+          centerSpace + (3 / 2),
+          captureAny,
+        ),
+      );
+      expect(result3.callCount, 1);
+      expect(
+        (result3.captured.single as Paint).color,
+        isSameColorAs(MockData.color3),
+      );
+      expect((result3.captured.single as Paint).strokeWidth, 3);
+      expect((result3.captured.single as Paint).style, PaintingStyle.stroke);
     });
 
     test('test 2', () {
@@ -289,13 +297,12 @@ void main() {
 
       expect(results.length, 4);
 
-      final path0 = barChartPainter.generateSectionPath(
-        data.sections[0],
-        10,
-        0,
-        36,
+      final path0 = barChartPainter.generateSegmentPath(
         const Offset(100, 100),
         10,
+        data.sections[0].radius,
+        0,
+        36,
       );
       expect(
         HelperMethods.equalsPaths(results[0]['path'] as Path, path0),
@@ -307,13 +314,12 @@ void main() {
       );
       expect(results[0]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
-      final path1 = barChartPainter.generateSectionPath(
-        data.sections[1],
-        10,
-        36,
-        72,
+      final path1 = barChartPainter.generateSegmentPath(
         const Offset(100, 100),
         10,
+        data.sections[1].radius,
+        36,
+        72,
       );
       expect(
         HelperMethods.equalsPaths(results[1]['path'] as Path, path1),
@@ -325,13 +331,12 @@ void main() {
       );
       expect(results[1]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
-      final path2 = barChartPainter.generateSectionPath(
-        data.sections[2],
-        10,
-        108,
-        108,
+      final path2 = barChartPainter.generateSegmentPath(
         const Offset(100, 100),
         10,
+        data.sections[2].radius,
+        108,
+        108,
       );
       expect(
         HelperMethods.equalsPaths(results[2]['path'] as Path, path2),
@@ -343,13 +348,12 @@ void main() {
       );
       expect(results[2]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
-      final path3 = barChartPainter.generateSectionPath(
-        data.sections[3],
-        10,
-        216,
-        144,
+      final path3 = barChartPainter.generateSegmentPath(
         const Offset(100, 100),
         10,
+        data.sections[3].radius,
+        216,
+        144,
       );
       expect(
         HelperMethods.equalsPaths(results[3]['path'] as Path, path3),
@@ -821,7 +825,7 @@ void main() {
           PieChartSectionData(color: MockData.color4, value: 4),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
       final mockCanvasWrapper = MockCanvasWrapper();
       when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
@@ -838,24 +842,24 @@ void main() {
         });
       });
 
-      barChartPainter
-        ..drawSection(
-          data.sections[0],
+      pieChartPainter
+        ..drawSegment(
+          data.sections[0].asSegment,
           MockData.path1,
           mockCanvasWrapper,
         )
-        ..drawSection(
-          data.sections[1],
+        ..drawSegment(
+          data.sections[1].asSegment,
           MockData.path2,
           mockCanvasWrapper,
         )
-        ..drawSection(
-          data.sections[2],
+        ..drawSegment(
+          data.sections[2].asSegment,
           MockData.path3,
           mockCanvasWrapper,
         )
-        ..drawSection(
-          data.sections[3],
+        ..drawSegment(
+          data.sections[3].asSegment,
           MockData.path4,
           mockCanvasWrapper,
         );

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -844,22 +844,34 @@ void main() {
 
       pieChartPainter
         ..drawSegment(
-          data.sections[0].asSegment,
+          PieChartStackSegmentData(
+            toRadius: data.sections[0].radius,
+            color: data.sections[0].color,
+          ),
           MockData.path1,
           mockCanvasWrapper,
         )
         ..drawSegment(
-          data.sections[1].asSegment,
+          PieChartStackSegmentData(
+            toRadius: data.sections[1].radius,
+            color: data.sections[1].color,
+          ),
           MockData.path2,
           mockCanvasWrapper,
         )
         ..drawSegment(
-          data.sections[2].asSegment,
+          PieChartStackSegmentData(
+            toRadius: data.sections[2].radius,
+            color: data.sections[2].color,
+          ),
           MockData.path3,
           mockCanvasWrapper,
         )
         ..drawSegment(
-          data.sections[3].asSegment,
+          PieChartStackSegmentData(
+            toRadius: data.sections[3].radius,
+            color: data.sections[3].color,
+          ),
           MockData.path4,
           mockCanvasWrapper,
         );

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -98,14 +98,14 @@ void main() {
         centerSpaceColor: MockData.color1,
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
       final holder =
           PaintHolder<PieChartData>(data, data, TextScaler.noScaling);
 
       final mockCanvasWrapper = MockCanvasWrapper();
       when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
       when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-      barChartPainter.drawCenterSpace(mockCanvasWrapper, 10, holder);
+      pieChartPainter.drawCenterSpace(mockCanvasWrapper, 10, holder);
 
       final result = verify(
         mockCanvasWrapper.drawCircle(const Offset(100, 100), 10, captureAny),
@@ -193,21 +193,21 @@ void main() {
         sections: sections,
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
       final holder =
           PaintHolder<PieChartData>(data, data, TextScaler.noScaling);
 
       final mockCanvasWrapper = MockCanvasWrapper();
       when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
       when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-      barChartPainter.drawSections(mockCanvasWrapper, [360], 10, holder);
+      pieChartPainter.drawSections(mockCanvasWrapper, [360], 10, holder);
 
       final result = verify(mockCanvasWrapper.drawPath(captureAny, captureAny));
       expect(result.callCount, 1);
       final path = result.captured[0] as Path;
       final paint = result.captured[1] as Paint;
 
-      final expectedPath = barChartPainter.generateSegmentPath(
+      final expectedPath = pieChartPainter.generateSegmentPath(
         viewSize.center(Offset.zero),
         centerSpace,
         radius,
@@ -269,7 +269,7 @@ void main() {
         ],
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
       final holder =
           PaintHolder<PieChartData>(data, data, TextScaler.noScaling);
 
@@ -287,7 +287,7 @@ void main() {
         });
       });
 
-      barChartPainter.drawSections(
+      pieChartPainter.drawSections(
         mockCanvasWrapper,
         [36, 72, 108, 144],
         10,
@@ -297,12 +297,13 @@ void main() {
 
       expect(results.length, 4);
 
-      final path0 = barChartPainter.generateSegmentPath(
-        const Offset(100, 100),
-        10,
-        data.sections[0].radius,
+      final path0 = pieChartPainter.generateSectionPath(
+        data.sections[0],
+        data.sectionsSpace,
         0,
         36,
+        const Offset(100, 100),
+        10,
       );
       expect(
         HelperMethods.equalsPaths(results[0]['path'] as Path, path0),
@@ -314,12 +315,13 @@ void main() {
       );
       expect(results[0]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
-      final path1 = barChartPainter.generateSegmentPath(
-        const Offset(100, 100),
-        10,
-        data.sections[1].radius,
+      final path1 = pieChartPainter.generateSectionPath(
+        data.sections[1],
+        data.sectionsSpace,
         36,
         72,
+        const Offset(100, 100),
+        10,
       );
       expect(
         HelperMethods.equalsPaths(results[1]['path'] as Path, path1),
@@ -331,12 +333,13 @@ void main() {
       );
       expect(results[1]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
-      final path2 = barChartPainter.generateSegmentPath(
+      final path2 = pieChartPainter.generateSectionPath(
+        data.sections[2],
+        data.sectionsSpace,
+        108,
+        108,
         const Offset(100, 100),
         10,
-        data.sections[2].radius,
-        108,
-        108,
       );
       expect(
         HelperMethods.equalsPaths(results[2]['path'] as Path, path2),
@@ -348,12 +351,13 @@ void main() {
       );
       expect(results[2]['paint_style'] as PaintingStyle, PaintingStyle.fill);
 
-      final path3 = barChartPainter.generateSegmentPath(
-        const Offset(100, 100),
-        10,
-        data.sections[3].radius,
+      final path3 = pieChartPainter.generateSectionPath(
+        data.sections[3],
+        data.sectionsSpace,
         216,
         144,
+        const Offset(100, 100),
+        10,
       );
       expect(
         HelperMethods.equalsPaths(results[3]['path'] as Path, path3),
@@ -379,9 +383,9 @@ void main() {
           PieChartSectionData(color: MockData.color4, value: 4),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
-      final path0 = barChartPainter.generateSectionPath(
+      final path0 = pieChartPainter.generateSectionPath(
         data.sections[0],
         10,
         0,
@@ -396,7 +400,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path0Length, 90.08028411865234);
 
-      final path1 = barChartPainter.generateSectionPath(
+      final path1 = pieChartPainter.generateSectionPath(
         data.sections[1],
         10,
         36,
@@ -411,7 +415,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path1Length, 136.93048095703125);
 
-      final path2 = barChartPainter.generateSectionPath(
+      final path2 = pieChartPainter.generateSectionPath(
         data.sections[2],
         10,
         108,
@@ -426,7 +430,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path2Length, closeTo(174.6013, tolerance));
 
-      final path3 = barChartPainter.generateSectionPath(
+      final path3 = pieChartPainter.generateSectionPath(
         data.sections[3],
         10,
         216,
@@ -453,9 +457,9 @@ void main() {
           PieChartSectionData(color: MockData.color4, value: 4),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
-      final path0 = barChartPainter.generateSectionPath(
+      final path0 = pieChartPainter.generateSectionPath(
         data.sections[0],
         0,
         0,
@@ -470,7 +474,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path0Length, 117.56398010253906);
 
-      final path1 = barChartPainter.generateSectionPath(
+      final path1 = pieChartPainter.generateSectionPath(
         data.sections[1],
         0,
         36,
@@ -485,7 +489,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path1Length, 155.1278076171875);
 
-      final path2 = barChartPainter.generateSectionPath(
+      final path2 = pieChartPainter.generateSectionPath(
         data.sections[2],
         0,
         108,
@@ -500,7 +504,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path2Length, closeTo(192.8401, tolerance));
 
-      final path3 = barChartPainter.generateSectionPath(
+      final path3 = pieChartPainter.generateSectionPath(
         data.sections[3],
         0,
         216,
@@ -527,9 +531,9 @@ void main() {
           PieChartSectionData(color: MockData.color4, value: 4),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
-      final path0 = barChartPainter.generateSectionPath(
+      final path0 = pieChartPainter.generateSectionPath(
         data.sections[0],
         0,
         0,
@@ -544,7 +548,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path0Length, 108.80243682861328);
 
-      final path1 = barChartPainter.generateSectionPath(
+      final path1 = pieChartPainter.generateSectionPath(
         data.sections[1],
         0,
         36,
@@ -559,7 +563,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path1Length, 140.05465698242188);
 
-      final path2 = barChartPainter.generateSectionPath(
+      final path2 = pieChartPainter.generateSectionPath(
         data.sections[2],
         0,
         108,
@@ -574,7 +578,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path2Length, 173.86875915527344);
 
-      final path3 = barChartPainter.generateSectionPath(
+      final path3 = pieChartPainter.generateSectionPath(
         data.sections[3],
         0,
         216,
@@ -603,9 +607,9 @@ void main() {
         cornerRadius: 10,
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
-      final generatedPath = barChartPainter.generateSectionPath(
+      final generatedPath = pieChartPainter.generateSectionPath(
         section,
         0,
         tempAngle,
@@ -616,7 +620,7 @@ void main() {
 
       final startRadians = Utils().radians(tempAngle);
       final sweepRadians = Utils().radians(sectionDegree);
-      final expectedRoundedPath = barChartPainter.generateRoundedSectionPath(
+      final expectedRoundedPath = pieChartPainter.generateRoundedSectionPath(
         section,
         startRadians,
         sweepRadians,
@@ -645,9 +649,9 @@ void main() {
         cornerRadius: 10,
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
-      final pathWithoutSpace = barChartPainter.generateSectionPath(
+      final pathWithoutSpace = pieChartPainter.generateSectionPath(
         section,
         0,
         tempAngle,
@@ -656,7 +660,7 @@ void main() {
         centerRadius,
       );
 
-      final pathWithSpace = barChartPainter.generateSectionPath(
+      final pathWithSpace = pieChartPainter.generateSectionPath(
         section,
         10,
         tempAngle,
@@ -685,7 +689,7 @@ void main() {
         cornerRadius: 1,
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
       final sectionRadiusRect = Rect.fromCircle(
         center: center,
@@ -696,7 +700,7 @@ void main() {
         radius: centerRadius,
       );
 
-      final result = barChartPainter.generateRoundedSectionPath(
+      final result = pieChartPainter.generateRoundedSectionPath(
         section,
         startRadians,
         sweepRadians,
@@ -738,9 +742,9 @@ void main() {
         cornerRadius: 10,
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
-      final result = barChartPainter.generateRoundedSectionPath(
+      final result = pieChartPainter.generateRoundedSectionPath(
         section,
         startRadians,
         sweepRadians,
@@ -767,9 +771,9 @@ void main() {
         cornerRadius: 10,
       );
 
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
-      final result = barChartPainter.generateRoundedSectionPath(
+      final result = pieChartPainter.generateRoundedSectionPath(
         section,
         startRadians,
         sweepRadians,
@@ -787,8 +791,8 @@ void main() {
 
   group('createRectPathAroundLine()', () {
     test('test 1', () {
-      final barChartPainter = PieChartPainter();
-      final path0 = barChartPainter.createRectPathAroundLine(
+      final pieChartPainter = PieChartPainter();
+      final path0 = pieChartPainter.createRectPathAroundLine(
         const Line(Offset.zero, Offset(10, 0)),
         4,
       );
@@ -799,7 +803,7 @@ void main() {
           .reduce((a, b) => a + b);
       expect(path0Length, 32.0);
 
-      final path1 = barChartPainter.createRectPathAroundLine(
+      final path1 = pieChartPainter.createRectPathAroundLine(
         const Line(Offset(32, 11), Offset(12, 5)),
         66,
       );
@@ -921,7 +925,7 @@ void main() {
           PieChartSectionData(color: MockData.color4, value: 4),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
       final mockCanvasWrapper = MockCanvasWrapper();
       when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
@@ -938,7 +942,7 @@ void main() {
         });
       });
 
-      barChartPainter
+      pieChartPainter
         ..drawSectionStroke(
           data.sections[0],
           MockData.path1,
@@ -998,7 +1002,7 @@ void main() {
           ),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
       final mockCanvasWrapper = MockCanvasWrapper();
       when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
@@ -1023,7 +1027,7 @@ void main() {
         });
       });
 
-      barChartPainter
+      pieChartPainter
         ..drawSectionStroke(
           data.sections[0],
           MockData.path1,
@@ -1149,17 +1153,17 @@ void main() {
           radius: 44,
         ),
       ];
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
 
       final data1 = PieChartData(sections: sections, centerSpaceRadius: 15);
-      final result1 = barChartPainter.calculateCenterRadius(
+      final result1 = pieChartPainter.calculateCenterRadius(
         viewSize,
         PaintHolder<PieChartData>(data1, data1, TextScaler.noScaling),
       );
       expect(result1, 15);
 
       final data2 = PieChartData(sections: sections);
-      final result2 = barChartPainter.calculateCenterRadius(
+      final result2 = pieChartPainter.calculateCenterRadius(
         viewSize,
         PaintHolder<PieChartData>(data2, data2, TextScaler.noScaling),
       );
@@ -1200,226 +1204,226 @@ void main() {
           ),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
       final holder =
           PaintHolder<PieChartData>(data, data, TextScaler.noScaling);
 
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(191, 110), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(156, 110), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(107, 190), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(90, 156), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(53, 131), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(53, 131), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(43, 94), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(36, 57), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(36, 57), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(65, 4.3), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(7, 108), viewSize, holder)
             .touchedSectionIndex,
         -1,
       );
 
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(159.76, 135.56), viewSize, holder)
             .touchedSectionIndex,
         0,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(169.35, 108.4), viewSize, holder)
             .touchedSectionIndex,
         0,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(162.32, 109.37), viewSize, holder)
             .touchedSectionIndex,
         0,
       );
 
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(146.67, 144.94), viewSize, holder)
             .touchedSectionIndex,
         1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(121.06, 160.38), viewSize, holder)
             .touchedSectionIndex,
         1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(89.66, 163.60), viewSize, holder)
             .touchedSectionIndex,
         1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(85.04, 177.85), viewSize, holder)
             .touchedSectionIndex,
         1,
       );
 
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(75.2, 158.4), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(66.2, 177), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(40.3, 124.8), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(19.1, 131), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(19.1, 131), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(17.7, 83.7), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(27.8, 59.4), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(44.1, 75.2), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
 
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(56.1, 55.6), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(42.1, 46.3), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(30.9, 38.4), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(55.3, 17.8), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(81.2, 39.8), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(100.5, 4.1), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(126.7, 40.6), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(181.8, 51.3), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(174.5, 40.2), viewSize, holder)
             .touchedSectionIndex,
         3,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(164.5, 91.4), viewSize, holder)
             .touchedSectionIndex,
         3,
@@ -1437,30 +1441,30 @@ void main() {
           PieChartSectionData(value: 4, radius: 40, cornerRadius: 12),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
       final holder =
           PaintHolder<PieChartData>(data, data, TextScaler.noScaling);
 
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(159.76, 135.56), viewSize, holder)
             .touchedSectionIndex,
         0,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(121.06, 160.38), viewSize, holder)
             .touchedSectionIndex,
         1,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(40.3, 124.8), viewSize, holder)
             .touchedSectionIndex,
         2,
       );
       expect(
-        barChartPainter
+        pieChartPainter
             .handleTouch(const Offset(126.7, 40.6), viewSize, holder)
             .touchedSectionIndex,
         3,
@@ -1497,14 +1501,14 @@ void main() {
           ),
         ],
       );
-      final barChartPainter = PieChartPainter();
+      final pieChartPainter = PieChartPainter();
       final holder = PaintHolder<PieChartData>(
         data,
         data,
         TextScaler.noScaling,
       );
 
-      final result = barChartPainter.getBadgeOffsets(viewSize, holder);
+      final result = pieChartPainter.getBadgeOffsets(viewSize, holder);
       expect(
         result,
         {
@@ -1514,6 +1518,206 @@ void main() {
           3: const Offset(124.72135954999578, 23.91547869638771),
         },
       );
+    });
+  });
+
+  group('drawSegments()', () {
+    test('draws main section with no stacked segments', () {
+      const viewSize = Size(200, 200);
+      const center = Offset(100, 100);
+      const startRadius = 10.0;
+      const sweepAngle = 90.0;
+      const startAngle = 0.0;
+
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        radius: 40,
+      );
+
+      final painter = PieChartPainter();
+      final mainPath = painter.generateSegmentPath(
+        center,
+        startRadius,
+        section.radius,
+        startAngle,
+        sweepAngle,
+      );
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      painter.drawSegments(
+        mockCanvasWrapper,
+        section,
+        mainPath,
+        sweepAngle,
+        startRadius,
+        startAngle,
+        center,
+      );
+
+      // Only the main section should be drawn — no segments
+      final result = verify(mockCanvasWrapper.drawPath(captureAny, captureAny));
+      expect(result.callCount, 1);
+      expect(
+        (result.captured[1] as Paint).color,
+        isSameColorAs(MockData.color1),
+      );
+      expect((result.captured[1] as Paint).style, PaintingStyle.fill);
+    });
+
+    test('draws main section plus one stacked segment', () {
+      const viewSize = Size(200, 200);
+      const center = Offset(100, 100);
+      const startRadius = 10.0;
+      const sweepAngle = 90.0;
+      const startAngle = 0.0;
+
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        radius: 40,
+        segments: [
+          PieChartStackSegmentData(
+            fromRadius: 10,
+            toRadius: 30,
+            color: MockData.color2,
+          ),
+        ],
+      );
+
+      final painter = PieChartPainter();
+      final mainPath = painter.generateSegmentPath(
+        center,
+        startRadius,
+        section.radius,
+        startAngle,
+        sweepAngle,
+      );
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final drawnColors = <Color>[];
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
+          .thenAnswer((inv) {
+        drawnColors.add((inv.positionalArguments[1] as Paint).color);
+      });
+
+      painter.drawSegments(
+        mockCanvasWrapper,
+        section,
+        mainPath,
+        sweepAngle,
+        startRadius,
+        startAngle,
+        center,
+      );
+
+      // main + one segment = 2 drawPath calls
+      expect(drawnColors.length, 2);
+      expect(drawnColors[0], isSameColorAs(MockData.color1));
+      expect(drawnColors[1], isSameColorAs(MockData.color2));
+    });
+
+    test('skips segment when clamped segRadius <= 0', () {
+      const viewSize = Size(200, 200);
+      const center = Offset(100, 100);
+      const startRadius = 10.0;
+      const sweepAngle = 90.0;
+      const startAngle = 0.0;
+
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        radius: 40,
+        segments: [
+          // entirely outside [0, radius]: fromRadius > toRadius after clamping
+          PieChartStackSegmentData(
+            fromRadius: 50,
+            toRadius: 50,
+            color: MockData.color3,
+          ),
+          // negative range: toRadius < fromRadius after clamping
+          PieChartStackSegmentData(
+            fromRadius: 30,
+            toRadius: 20,
+            color: MockData.color4,
+          ),
+        ],
+      );
+
+      final painter = PieChartPainter();
+      final mainPath = painter.generateSegmentPath(
+        center,
+        startRadius,
+        section.radius,
+        startAngle,
+        sweepAngle,
+      );
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      painter.drawSegments(
+        mockCanvasWrapper,
+        section,
+        mainPath,
+        sweepAngle,
+        startRadius,
+        startAngle,
+        center,
+      );
+
+      // Only the main section — both segments are skipped
+      verify(mockCanvasWrapper.drawPath(any, any)).called(1);
+    });
+
+    test('draws full-circle (360°) section with a segment', () {
+      const viewSize = Size(200, 200);
+      const center = Offset(100, 100);
+      const startRadius = 10.0;
+      const sweepAngle = 360.0;
+      const startAngle = 0.0;
+
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        radius: 40,
+        segments: [
+          PieChartStackSegmentData(
+            fromRadius: 0,
+            toRadius: 20,
+            color: MockData.color2,
+          ),
+        ],
+      );
+
+      final painter = PieChartPainter();
+      final mainPath = painter.generateSegmentPath(
+        center,
+        startRadius,
+        section.radius,
+        startAngle,
+        sweepAngle,
+      );
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      painter.drawSegments(
+        mockCanvasWrapper,
+        section,
+        mainPath,
+        sweepAngle,
+        startRadius,
+        startAngle,
+        center,
+      );
+
+      // main + one segment = 2 drawPath calls
+      verify(mockCanvasWrapper.drawPath(any, any)).called(2);
     });
   });
 }

--- a/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
+++ b/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
@@ -1412,6 +1412,82 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
       );
 
   @override
+  void drawSegments(
+    _i12.CanvasWrapper? canvasWrapper,
+    _i7.PieChartSectionData? section,
+    double? sweepAngle,
+    double? startRadius,
+    double? startAngle,
+    _i2.Offset? center,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #drawSegments,
+          [
+            canvasWrapper,
+            section,
+            sweepAngle,
+            startRadius,
+            startAngle,
+            center,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  void drawSegment(
+    _i7.PieChartStackSegmentData? segment,
+    _i2.Path? segmentPath,
+    _i12.CanvasWrapper? canvasWrapper,
+  ) =>
+      super.noSuchMethod(
+        Invocation.method(
+          #drawSegment,
+          [
+            segment,
+            segmentPath,
+            canvasWrapper,
+          ],
+        ),
+        returnValueForMissingStub: null,
+      );
+
+  @override
+  _i2.Path generateSegmentPath(
+    _i2.Offset? center,
+    double? innerRadius,
+    double? segmentRadius,
+    double? startAngle,
+    double? sweepAngle,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #generateSegmentPath,
+          [
+            center,
+            innerRadius,
+            segmentRadius,
+            startAngle,
+            sweepAngle,
+          ],
+        ),
+        returnValue: _FakePath_8(
+          this,
+          Invocation.method(
+            #generateSegmentPath,
+            [
+              center,
+              innerRadius,
+              segmentRadius,
+              startAngle,
+              sweepAngle,
+            ],
+          ),
+        ),
+      ) as _i2.Path);
+
+  @override
   _i2.Path generateSectionPath(
     _i7.PieChartSectionData? section,
     double? sectionSpace,
@@ -1472,24 +1548,6 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
           ),
         ),
       ) as _i2.Path);
-
-  @override
-  void drawSection(
-    _i7.PieChartSectionData? section,
-    _i2.Path? sectionPath,
-    _i12.CanvasWrapper? canvasWrapper,
-  ) =>
-      super.noSuchMethod(
-        Invocation.method(
-          #drawSection,
-          [
-            section,
-            sectionPath,
-            canvasWrapper,
-          ],
-        ),
-        returnValueForMissingStub: null,
-      );
 
   @override
   void drawSectionStroke(

--- a/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
+++ b/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
@@ -1435,6 +1435,7 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
   void drawSegments(
     _i12.CanvasWrapper? canvasWrapper,
     _i7.PieChartSectionData? section,
+    _i2.Path? mainPath,
     double? sweepAngle,
     double? startRadius,
     double? startAngle,
@@ -1446,6 +1447,7 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
           [
             canvasWrapper,
             section,
+            mainPath,
             sweepAngle,
             startRadius,
             startAngle,

--- a/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
+++ b/test/chart/pie_chart/pie_chart_renderer_test.mocks.dart
@@ -45,8 +45,9 @@ class _FakeRect_0 extends _i1.SmartFake implements _i2.Rect {
         );
 }
 
-class _FakeCanvas_1 extends _i1.SmartFake implements _i2.Canvas {
-  _FakeCanvas_1(
+class _FakePictureRecorder_1 extends _i1.SmartFake
+    implements _i2.PictureRecorder {
+  _FakePictureRecorder_1(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -55,9 +56,19 @@ class _FakeCanvas_1 extends _i1.SmartFake implements _i2.Canvas {
         );
 }
 
-class _FakePaintingContext_2 extends _i1.SmartFake
+class _FakeCanvas_2 extends _i1.SmartFake implements _i2.Canvas {
+  _FakeCanvas_2(
+    Object parent,
+    Invocation parentInvocation,
+  ) : super(
+          parent,
+          parentInvocation,
+        );
+}
+
+class _FakePaintingContext_3 extends _i1.SmartFake
     implements _i3.PaintingContext {
-  _FakePaintingContext_2(
+  _FakePaintingContext_3(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -66,9 +77,9 @@ class _FakePaintingContext_2 extends _i1.SmartFake
         );
 }
 
-class _FakeColorFilterLayer_3 extends _i1.SmartFake
+class _FakeColorFilterLayer_4 extends _i1.SmartFake
     implements _i4.ColorFilterLayer {
-  _FakeColorFilterLayer_3(
+  _FakeColorFilterLayer_4(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -81,8 +92,8 @@ class _FakeColorFilterLayer_3 extends _i1.SmartFake
       super.toString();
 }
 
-class _FakeOpacityLayer_4 extends _i1.SmartFake implements _i4.OpacityLayer {
-  _FakeOpacityLayer_4(
+class _FakeOpacityLayer_5 extends _i1.SmartFake implements _i4.OpacityLayer {
+  _FakeOpacityLayer_5(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -95,8 +106,8 @@ class _FakeOpacityLayer_4 extends _i1.SmartFake implements _i4.OpacityLayer {
       super.toString();
 }
 
-class _FakeWidget_5 extends _i1.SmartFake implements _i6.Widget {
-  _FakeWidget_5(
+class _FakeWidget_6 extends _i1.SmartFake implements _i6.Widget {
+  _FakeWidget_6(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -109,9 +120,9 @@ class _FakeWidget_5 extends _i1.SmartFake implements _i6.Widget {
       super.toString();
 }
 
-class _FakeInheritedWidget_6 extends _i1.SmartFake
+class _FakeInheritedWidget_7 extends _i1.SmartFake
     implements _i6.InheritedWidget {
-  _FakeInheritedWidget_6(
+  _FakeInheritedWidget_7(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -124,9 +135,9 @@ class _FakeInheritedWidget_6 extends _i1.SmartFake
       super.toString();
 }
 
-class _FakeDiagnosticsNode_7 extends _i1.SmartFake
+class _FakeDiagnosticsNode_8 extends _i1.SmartFake
     implements _i5.DiagnosticsNode {
-  _FakeDiagnosticsNode_7(
+  _FakeDiagnosticsNode_8(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -142,8 +153,8 @@ class _FakeDiagnosticsNode_7 extends _i1.SmartFake
       super.toString();
 }
 
-class _FakePath_8 extends _i1.SmartFake implements _i2.Path {
-  _FakePath_8(
+class _FakePath_9 extends _i1.SmartFake implements _i2.Path {
+  _FakePath_9(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -152,9 +163,9 @@ class _FakePath_8 extends _i1.SmartFake implements _i2.Path {
         );
 }
 
-class _FakePieTouchedSection_9 extends _i1.SmartFake
+class _FakePieTouchedSection_10 extends _i1.SmartFake
     implements _i7.PieTouchedSection {
-  _FakePieTouchedSection_9(
+  _FakePieTouchedSection_10(
     Object parent,
     Invocation parentInvocation,
   ) : super(
@@ -797,9 +808,18 @@ class MockPaintingContext extends _i1.Mock implements _i3.PaintingContext {
       ) as _i2.Rect);
 
   @override
+  _i2.PictureRecorder get recorder => (super.noSuchMethod(
+        Invocation.getter(#recorder),
+        returnValue: _FakePictureRecorder_1(
+          this,
+          Invocation.getter(#recorder),
+        ),
+      ) as _i2.PictureRecorder);
+
+  @override
   _i2.Canvas get canvas => (super.noSuchMethod(
         Invocation.getter(#canvas),
-        returnValue: _FakeCanvas_1(
+        returnValue: _FakeCanvas_2(
           this,
           Invocation.getter(#canvas),
         ),
@@ -909,7 +929,7 @@ class MockPaintingContext extends _i1.Mock implements _i3.PaintingContext {
             bounds,
           ],
         ),
-        returnValue: _FakePaintingContext_2(
+        returnValue: _FakePaintingContext_3(
           this,
           Invocation.method(
             #createChildContext,
@@ -1036,7 +1056,7 @@ class MockPaintingContext extends _i1.Mock implements _i3.PaintingContext {
           ],
           {#oldLayer: oldLayer},
         ),
-        returnValue: _FakeColorFilterLayer_3(
+        returnValue: _FakeColorFilterLayer_4(
           this,
           Invocation.method(
             #pushColorFilter,
@@ -1086,7 +1106,7 @@ class MockPaintingContext extends _i1.Mock implements _i3.PaintingContext {
           ],
           {#oldLayer: oldLayer},
         ),
-        returnValue: _FakeOpacityLayer_4(
+        returnValue: _FakeOpacityLayer_5(
           this,
           Invocation.method(
             #pushOpacity,
@@ -1192,7 +1212,7 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
   @override
   _i6.Widget get widget => (super.noSuchMethod(
         Invocation.getter(#widget),
-        returnValue: _FakeWidget_5(
+        returnValue: _FakeWidget_6(
           this,
           Invocation.getter(#widget),
         ),
@@ -1221,7 +1241,7 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
           [ancestor],
           {#aspect: aspect},
         ),
-        returnValue: _FakeInheritedWidget_6(
+        returnValue: _FakeInheritedWidget_7(
           this,
           Invocation.method(
             #dependOnInheritedElement,
@@ -1271,7 +1291,7 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
           [name],
           {#style: style},
         ),
-        returnValue: _FakeDiagnosticsNode_7(
+        returnValue: _FakeDiagnosticsNode_8(
           this,
           Invocation.method(
             #describeElement,
@@ -1292,7 +1312,7 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
           [name],
           {#style: style},
         ),
-        returnValue: _FakeDiagnosticsNode_7(
+        returnValue: _FakeDiagnosticsNode_8(
           this,
           Invocation.method(
             #describeWidget,
@@ -1321,7 +1341,7 @@ class MockBuildContext extends _i1.Mock implements _i6.BuildContext {
           #describeOwnershipChain,
           [name],
         ),
-        returnValue: _FakeDiagnosticsNode_7(
+        returnValue: _FakeDiagnosticsNode_8(
           this,
           Invocation.method(
             #describeOwnershipChain,
@@ -1472,7 +1492,7 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
             sweepAngle,
           ],
         ),
-        returnValue: _FakePath_8(
+        returnValue: _FakePath_9(
           this,
           Invocation.method(
             #generateSegmentPath,
@@ -1508,7 +1528,7 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
             centerRadius,
           ],
         ),
-        returnValue: _FakePath_8(
+        returnValue: _FakePath_9(
           this,
           Invocation.method(
             #generateSectionPath,
@@ -1519,6 +1539,46 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
               sectionDegree,
               center,
               centerRadius,
+            ],
+          ),
+        ),
+      ) as _i2.Path);
+
+  @override
+  _i2.Path generateRoundedSectionPath(
+    _i7.PieChartSectionData? section,
+    double? startRadians,
+    double? sweepRadians,
+    _i2.Offset? center,
+    double? centerRadius,
+    _i2.Rect? sectionRadiusRect,
+    _i2.Rect? centerRadiusRect,
+  ) =>
+      (super.noSuchMethod(
+        Invocation.method(
+          #generateRoundedSectionPath,
+          [
+            section,
+            startRadians,
+            sweepRadians,
+            center,
+            centerRadius,
+            sectionRadiusRect,
+            centerRadiusRect,
+          ],
+        ),
+        returnValue: _FakePath_9(
+          this,
+          Invocation.method(
+            #generateRoundedSectionPath,
+            [
+              section,
+              startRadians,
+              sweepRadians,
+              center,
+              centerRadius,
+              sectionRadiusRect,
+              centerRadiusRect,
             ],
           ),
         ),
@@ -1537,7 +1597,7 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
             width,
           ],
         ),
-        returnValue: _FakePath_8(
+        returnValue: _FakePath_9(
           this,
           Invocation.method(
             #createRectPathAroundLine,
@@ -1620,7 +1680,7 @@ class MockPieChartPainter extends _i1.Mock implements _i11.PieChartPainter {
             holder,
           ],
         ),
-        returnValue: _FakePieTouchedSection_9(
+        returnValue: _FakePieTouchedSection_10(
           this,
           Invocation.method(
             #handleTouch,


### PR DESCRIPTION
As described in https://github.com/imaNNeo/fl_chart/issues/2003 a "Stacked Pie Chart" was requested. This Pull Request aims to add this feature.

# Solution
The Implementation of [StackedPieChart] is very similar to [PieChart]. The biggest difference is drawing a Section with multiple Segments.

The radius of a segment is calculated like this:

SegmentRadius = SectionRadius * SegmentValue / TotalSectionValues

The sweep angles are then calculated like in [PieChart] 

# Todo's and Improvements
- Add drawing strokes
- Extend the Demo (add icon and more examples)
- Add tests
- Extract duplicate logic from [PieChart] and [StackedPieChart]