### PR TITLE
Feat/radar max value config

### DIFF
--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -76,6 +76,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     RadarTouchData? radarTouchData,
     this.isMinValueAtCenter = false,
     this.maxValue,
+    this.showMaxTick = false,
     super.borderData,
   })  : assert(dataSets != null && dataSets.hasEqualDataEntriesLength),
         assert(
@@ -171,6 +172,11 @@ class RadarChartData extends BaseChartData with EquatableMixin {
   /// for future data growth. If null, the maximum value will be calculated from the data.
   final double? maxValue;
 
+  /// Whether to show the maximum tick value on the radar chart.
+  /// If true, displays the tick at the maximum value position.
+  /// If false (default), hides the maximum tick to avoid overlap with chart border.
+  final bool showMaxTick;
+
   /// [titleCount] we use this value to determine number of [RadarChart] grid or lines.
   int get titleCount => dataSets[0].dataEntries.length;
 
@@ -224,6 +230,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     RadarTouchData? radarTouchData,
     bool? isMinValueAtCenter,
     double? maxValue,
+    bool? showMaxTick,
     FlBorderData? borderData,
   }) =>
       RadarChartData(
@@ -242,6 +249,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         radarTouchData: radarTouchData ?? this.radarTouchData,
         isMinValueAtCenter: isMinValueAtCenter ?? this.isMinValueAtCenter,
         maxValue: maxValue ?? this.maxValue,
+        showMaxTick: showMaxTick ?? this.showMaxTick,
         borderData: borderData ?? this.borderData,
       );
 
@@ -270,6 +278,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         borderData: FlBorderData.lerp(a.borderData, b.borderData, t),
         isMinValueAtCenter: b.isMinValueAtCenter,
         maxValue: lerpDouble(a.maxValue, b.maxValue, t),
+        showMaxTick: b.showMaxTick,
         radarTouchData: b.radarTouchData,
       );
     } else {
@@ -295,6 +304,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         radarTouchData,
         isMinValueAtCenter,
         maxValue,
+        showMaxTick,
       ];
 }
 

--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -75,6 +75,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? gridBorderData,
     RadarTouchData? radarTouchData,
     this.isMinValueAtCenter = false,
+    this.maxValue,
     super.borderData,
   })  : assert(dataSets != null && dataSets.hasEqualDataEntriesLength),
         assert(
@@ -86,6 +87,10 @@ class RadarChartData extends BaseChartData with EquatableMixin {
               titlePositionPercentageOffset >= 0 &&
                   titlePositionPercentageOffset <= 1,
           'titlePositionPercentageOffset must be something between 0 and 1 ',
+        ),
+        assert(
+          maxValue == null || maxValue.isFinite,
+          'maxValue must be a finite number',
         ),
         dataSets = dataSets ?? const [],
         radarBackgroundColor = radarBackgroundColor ?? Colors.transparent,
@@ -160,12 +165,24 @@ class RadarChartData extends BaseChartData with EquatableMixin {
   /// If [isMinValueAtCenter] is true, the minimum value of the [RadarChart] will be at the center of the chart.
   final bool isMinValueAtCenter;
 
+  /// Custom maximum value for the [RadarChart]. If provided, this value will be used
+  /// instead of the automatically calculated maximum from the data.
+  /// This is useful for standardizing display across multiple charts or reserving space
+  /// for future data growth. If null, the maximum value will be calculated from the data.
+  final double? maxValue;
+
   /// [titleCount] we use this value to determine number of [RadarChart] grid or lines.
   int get titleCount => dataSets[0].dataEntries.length;
 
   /// defines the maximum [RadarEntry] value in all [dataSets]
   /// we use this value to calculate the maximum value of ticks.
   RadarEntry get maxEntry {
+    // If custom maxValue is provided, use it
+    if (maxValue != null) {
+      return RadarEntry(value: maxValue!);
+    }
+
+    // Otherwise, calculate from data
     var maximum = dataSets.first.dataEntries.first;
 
     for (final dataSet in dataSets) {
@@ -206,6 +223,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? gridBorderData,
     RadarTouchData? radarTouchData,
     bool? isMinValueAtCenter,
+    double? maxValue,
     FlBorderData? borderData,
   }) =>
       RadarChartData(
@@ -223,6 +241,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         gridBorderData: gridBorderData ?? this.gridBorderData,
         radarTouchData: radarTouchData ?? this.radarTouchData,
         isMinValueAtCenter: isMinValueAtCenter ?? this.isMinValueAtCenter,
+        maxValue: maxValue ?? this.maxValue,
         borderData: borderData ?? this.borderData,
       );
 
@@ -250,6 +269,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         tickBorderData: BorderSide.lerp(a.tickBorderData, b.tickBorderData, t),
         borderData: FlBorderData.lerp(a.borderData, b.borderData, t),
         isMinValueAtCenter: b.isMinValueAtCenter,
+        maxValue: lerpDouble(a.maxValue, b.maxValue, t),
         radarTouchData: b.radarTouchData,
       );
     } else {
@@ -274,6 +294,7 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         gridBorderData,
         radarTouchData,
         isMinValueAtCenter,
+        maxValue,
       ];
 }
 

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -192,7 +192,11 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
       ..strokeWidth = data.tickBorderData.width;
 
     /// draw radar ticks
-    ticks.sublist(0, ticks.length - 1).asMap().forEach(
+    final ticksToShow = data.showMaxTick
+        ? ticks                               // Show all ticks including max
+        : ticks.sublist(0, ticks.length - 1); // Hide max tick (current behavior)
+
+    ticksToShow.asMap().forEach(
       (index, tick) {
         final tickRadius =
             tickDistance * (index + (data.isMinValueAtCenter ? 0 : 1));

--- a/test/chart/radar_chart/radar_chart_data_test.dart
+++ b/test/chart/radar_chart/radar_chart_data_test.dart
@@ -158,6 +158,16 @@ void main() {
         radarChartData1 == radarChartData1Clone.copyWith(maxValue: 200.0),
         false,
       );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(showMaxTick: false),
+        true,
+      );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(showMaxTick: true),
+        false,
+      );
     });
 
     test('RadarDataSet equality test', () {
@@ -327,6 +337,33 @@ void main() {
         ),
         throwsAssertionError,
       );
+    });
+  });
+
+  group('RadarChart showMaxTick functionality', () {
+    test('showMaxTick defaults to false and preserves original behavior', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1],
+      );
+      expect(data.showMaxTick, equals(false));
+    });
+
+    test('showMaxTick can be set to true to enable max tick display', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1],
+        showMaxTick: true,
+      );
+      expect(data.showMaxTick, equals(true));
+    });
+
+    test('showMaxTick works correctly with custom maxValue', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1],
+        maxValue: 200.0,
+        showMaxTick: true,
+      );
+      expect(data.showMaxTick, equals(true));
+      expect(data.maxEntry.value, equals(200.0));
     });
   });
 }

--- a/test/chart/radar_chart/radar_chart_data_test.dart
+++ b/test/chart/radar_chart/radar_chart_data_test.dart
@@ -143,6 +143,21 @@ void main() {
             ),
         false,
       );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(maxValue: null),
+        true,
+      );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(maxValue: 100.0),
+        false,
+      );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(maxValue: 200.0),
+        false,
+      );
     });
 
     test('RadarDataSet equality test', () {
@@ -268,6 +283,50 @@ void main() {
       expect(radarTouchedSpot1 == radarTouchedSpot5, false);
       expect(radarTouchedSpot1 == radarTouchedSpot6, false);
       expect(radarTouchedSpot1 == radarTouchedSpot7, false);
+    });
+  });
+
+  group('RadarChart maxValue functionality', () {
+    test('maxEntry returns data max when maxValue is null', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1],
+      );
+      expect(data.maxEntry.value, equals(4.0));
+    });
+
+    test('maxEntry returns data max from multiple datasets when maxValue is null', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1, radarDataSet2],
+      );
+      expect(data.maxEntry.value, equals(10.0));
+    });
+
+    test('maxEntry returns custom maxValue when provided', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1],
+        maxValue: 150.0,
+      );
+      expect(data.maxEntry.value, equals(150.0));
+    });
+
+    test('maxValue validation throws on NaN', () {
+      expect(
+        () => RadarChartData(
+          dataSets: [radarDataSet1],
+          maxValue: double.nan,
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('maxValue validation throws on infinity', () {
+      expect(
+        () => RadarChartData(
+          dataSets: [radarDataSet1],
+          maxValue: double.infinity,
+        ),
+        throwsAssertionError,
+      );
     });
   });
 }


### PR DESCRIPTION
hello ，This PR is aims to add this feature in https://github.com/imaNNeo/fl_chart/issues/2002

Problem background
---
We encountered two problems in the issue.

* How to set the maximum value of the Radar Chart to a specified value.
* How to display the maximum tick value on the chart.


Solution
---
This PR introduces two new parameters to RadarChartData:

1. maxValue Parameter

  `RadarChartData(
    dataSets: myDataSets,
    maxValue: 100.0,  // Set custom maximum value
  )`
  - Type: double? (optional)
  - Default: null (uses data maximum)
  - Purpose: Allows setting a custom maximum value instead of calculating from data

2. showMaxTick Parameter

 ` RadarChartData(
    dataSets: myDataSets,
    showMaxTick: true,  // Show maximum tick value
  )`
  - Type: bool
  - Default: false (preserves existing behavior)
  - Purpose: Controls whether the maximum tick is displayed on the chart


Result
---
<img width="530" height="466" alt="image" src="https://github.com/user-attachments/assets/b8080ad2-4f72-443b-8fba-c7f264946589" />

