### PR TITLE
Feat/hatched bar chart pattern

### DIFF
--- a/example/lib/presentation/samples/bar/bar_chart_sample9.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample9.dart
@@ -1,0 +1,198 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:flutter/material.dart';
+
+/// Example demonstrating the new hatching support for BarChartRodStackItem
+class BarChartSample9 extends StatefulWidget {
+  const BarChartSample9({super.key});
+
+  @override
+  State<BarChartSample9> createState() => _BarChartSample9State();
+}
+
+class _BarChartSample9State extends State<BarChartSample9> {
+  final Duration animDuration = const Duration(milliseconds: 250);
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: BarChart(
+          BarChartData(
+            alignment: BarChartAlignment.spaceAround,
+            maxY: 30,
+            barTouchData: BarTouchData(
+              touchTooltipData: BarTouchTooltipData(
+                getTooltipColor: (_) => Colors.blueGrey,
+                tooltipHorizontalAlignment: FLHorizontalAlignment.right,
+                tooltipMargin: -10,
+                getTooltipItem: (group, groupIndex, rod, rodIndex) {
+                  String weekDay;
+                  switch (group.x) {
+                    case 0:
+                      weekDay = 'Monday';
+                      break;
+                    case 1:
+                      weekDay = 'Tuesday';
+                      break;
+                    case 2:
+                      weekDay = 'Wednesday';
+                      break;
+                    case 3:
+                      weekDay = 'Thursday';
+                      break;
+                    case 4:
+                      weekDay = 'Friday';
+                      break;
+                    case 5:
+                      weekDay = 'Saturday';
+                      break;
+                    case 6:
+                      weekDay = 'Sunday';
+                      break;
+                    default:
+                      throw Error();
+                  }
+                  return BarTooltipItem(
+                    '$weekDay\n',
+                    const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      fontSize: 18,
+                    ),
+                    children: <TextSpan>[
+                      TextSpan(
+                        text: (rod.toY - rod.fromY).toString(),
+                        style: const TextStyle(
+                          color: Colors.yellow,
+                          fontSize: 16,
+                          fontWeight: FontWeight.w500,
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              ),
+            ),
+            titlesData: FlTitlesData(
+              show: true,
+              rightTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              topTitles: const AxisTitles(
+                sideTitles: SideTitles(showTitles: false),
+              ),
+              bottomTitles: AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: true,
+                  getTitlesWidget: _getTitles,
+                  reservedSize: 38,
+                ),
+              ),
+              leftTitles: const AxisTitles(
+                sideTitles: SideTitles(
+                  showTitles: false,
+                ),
+              ),
+            ),
+            borderData: FlBorderData(
+              show: false,
+            ),
+            barGroups: [
+              _makeGroupData(0, 5, 12),
+              _makeGroupData(1, 6.5, 10),
+              _makeGroupData(2, 5, 14),
+              _makeGroupData(3, 7.5, 15),
+              _makeGroupData(4, 9, 11.5),
+              _makeGroupData(5, 11.5, 16),
+              _makeGroupData(6, 6.5, 13),
+            ],
+            gridData: const FlGridData(show: false),
+          ),
+          swapAnimationDuration: animDuration,
+        ),
+      ),
+    );
+  }
+
+  Widget _getTitles(double value, TitleMeta meta) {
+    const style = TextStyle(
+      color: Colors.white,
+      fontWeight: FontWeight.bold,
+      fontSize: 14,
+    );
+    Widget text;
+    switch (value.toInt()) {
+      case 0:
+        text = const Text('M', style: style);
+        break;
+      case 1:
+        text = const Text('T', style: style);
+        break;
+      case 2:
+        text = const Text('W', style: style);
+        break;
+      case 3:
+        text = const Text('T', style: style);
+        break;
+      case 4:
+        text = const Text('F', style: style);
+        break;
+      case 5:
+        text = const Text('S', style: style);
+        break;
+      case 6:
+        text = const Text('S', style: style);
+        break;
+      default:
+        text = const Text('', style: style);
+        break;
+    }
+    return SideTitleWidget(
+      meta: meta,
+      space: 16,
+      child: text,
+    );
+  }
+
+  BarChartGroupData _makeGroupData(
+    int x,
+    double y1,
+    double y2,
+  ) {
+    return BarChartGroupData(
+      x: x,
+      barRods: [
+        BarChartRodData(
+          toY: y1 + y2,
+          color: Colors.transparent, // Make the main rod transparent
+          width: 22,
+          borderRadius: BorderRadius.circular(4),
+          rodStackItems: [
+            // Regular solid color stack item
+            BarChartRodStackItem(
+              0,
+              y1,
+              const Color(0xff0293ee),
+            ),
+            // Hatched stack item with diagonal lines
+            BarChartRodStackItem(
+              y1,
+              y1 + y2,
+              null, // No solid color
+              isHatched: true,
+              hatchPattern: const HatchPattern(
+                hatchColor: Color(0xff38f3f3),
+                backgroundColor: Color(0xff0293ee),
+                spacing: 6.0,
+                angle: -45.0,
+                strokeWidth: 2.5,
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/example/lib/presentation/samples/chart_samples.dart
+++ b/example/lib/presentation/samples/chart_samples.dart
@@ -9,6 +9,7 @@ import 'bar/bar_chart_sample5.dart';
 import 'bar/bar_chart_sample6.dart';
 import 'bar/bar_chart_sample7.dart';
 import 'bar/bar_chart_sample8.dart';
+import 'bar/bar_chart_sample9.dart';
 import 'chart_sample.dart';
 import 'line/line_chart_sample1.dart';
 import 'line/line_chart_sample10.dart';
@@ -56,6 +57,7 @@ class ChartSamples {
       BarChartSample(6, (context) => const BarChartSample6()),
       BarChartSample(7, (context) => BarChartSample7()),
       BarChartSample(8, (context) => BarChartSample8()),
+      BarChartSample(9, (context) => const BarChartSample9()),
     ],
     ChartType.pie: [
       PieChartSample(1, (context) => const PieChartSample1()),

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -493,9 +493,11 @@ class BarChartRodStackItem with EquatableMixin {
     this.label,
     this.labelStyle,
     this.borderSide = Utils.defaultBorderSide,
+    this.isHatched = false,
+    this.hatchPattern,
   }) : assert(
-          color != null || gradient != null,
-          'You must provide either a color or gradient',
+          color != null || gradient != null || (isHatched && hatchPattern != null),
+          'You must provide either a color, gradient, or hatch pattern',
         );
   final String? label;
   final TextStyle? labelStyle;
@@ -515,6 +517,12 @@ class BarChartRodStackItem with EquatableMixin {
   /// Renders border stroke for a Stacked Chart section
   final BorderSide borderSide;
 
+  /// Whether this stack item should use hatching instead of solid color/gradient
+  final bool isHatched;
+
+  /// Hatching pattern configuration (required if isHatched is true)
+  final HatchPattern? hatchPattern;
+
   /// Copies current [BarChartRodStackItem] to a new [BarChartRodStackItem],
   /// and replaces provided values.
   BarChartRodStackItem copyWith({
@@ -525,6 +533,8 @@ class BarChartRodStackItem with EquatableMixin {
     String? label,
     TextStyle? labelStyle,
     BorderSide? borderSide,
+    bool? isHatched,
+    HatchPattern? hatchPattern,
   }) =>
       BarChartRodStackItem(
         fromY ?? this.fromY,
@@ -534,6 +544,8 @@ class BarChartRodStackItem with EquatableMixin {
         label: label ?? this.label,
         labelStyle: labelStyle ?? this.labelStyle,
         borderSide: borderSide ?? this.borderSide,
+        isHatched: isHatched ?? this.isHatched,
+        hatchPattern: hatchPattern ?? this.hatchPattern,
       );
 
   /// Lerps a [BarChartRodStackItem] based on [t] value, check [Tween.lerp].
@@ -550,12 +562,79 @@ class BarChartRodStackItem with EquatableMixin {
         label: b.label,
         labelStyle: b.labelStyle,
         borderSide: BorderSide.lerp(a.borderSide, b.borderSide, t),
+        isHatched: b.isHatched,
+        hatchPattern: b.hatchPattern != null && a.hatchPattern != null
+            ? HatchPattern.lerp(a.hatchPattern!, b.hatchPattern!, t)
+            : b.hatchPattern,
       );
 
   /// Used for equality check, see [EquatableMixin].
   @override
   List<Object?> get props =>
-      [fromY, toY, color, gradient, label, labelStyle, borderSide];
+      [fromY, toY, color, gradient, label, labelStyle, borderSide, isHatched, hatchPattern];
+}
+
+/// Configuration for hatching pattern in bar chart stack items
+class HatchPattern with EquatableMixin {
+  /// Creates a hatch pattern configuration
+  /// 
+  /// [spacing] - Distance between parallel hatch lines in logical pixels (default: 6.0)
+  /// [angle] - Angle of hatch lines in degrees (default: -45.0 for diagonal)
+  /// [strokeWidth] - Thickness of each hatch line (default: 1.0)
+  /// [hatchColor] - Color of the hatch lines
+  /// [backgroundColor] - Optional background color behind hatching
+  const HatchPattern({
+    this.spacing = 6.0,
+    this.angle = -45.0,
+    this.strokeWidth = 1.0,
+    required this.hatchColor,
+    this.backgroundColor,
+  }) : assert(spacing > 0.0, 'Spacing must be greater than 0'),
+       assert(strokeWidth >= 0.0, 'Stroke width must be non-negative');
+
+  /// Distance between parallel hatch lines in logical pixels
+  final double spacing;
+
+  /// Angle of hatch lines in degrees
+  final double angle;
+
+  /// Thickness of each hatch line
+  final double strokeWidth;
+
+  /// Color of the hatch lines
+  final Color hatchColor;
+
+  /// Optional background color behind hatching
+  final Color? backgroundColor;
+
+  /// Creates a copy with modified properties
+  HatchPattern copyWith({
+    double? spacing,
+    double? angle,
+    double? strokeWidth,
+    Color? hatchColor,
+    Color? backgroundColor,
+  }) =>
+      HatchPattern(
+        spacing: spacing ?? this.spacing,
+        angle: angle ?? this.angle,
+        strokeWidth: strokeWidth ?? this.strokeWidth,
+        hatchColor: hatchColor ?? this.hatchColor,
+        backgroundColor: backgroundColor ?? this.backgroundColor,
+      );
+
+  /// Lerps between two HatchPattern instances
+  static HatchPattern lerp(HatchPattern a, HatchPattern b, double t) =>
+      HatchPattern(
+        spacing: lerpDouble(a.spacing, b.spacing, t)!,
+        angle: lerpDouble(a.angle, b.angle, t)!,
+        strokeWidth: lerpDouble(a.strokeWidth, b.strokeWidth, t)!,
+        hatchColor: Color.lerp(a.hatchColor, b.hatchColor, t)!,
+        backgroundColor: Color.lerp(a.backgroundColor, b.backgroundColor, t),
+      );
+
+  @override
+  List<Object?> get props => [spacing, angle, strokeWidth, hatchColor, backgroundColor];
 }
 
 /// Holds values to draw a rod in rear of the main rod.

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -765,7 +765,16 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       ..strokeCap = StrokeCap.round;
 
     canvasWrapper.save();
-    canvasWrapper.clipRect(rect);
+    // Create a rounded rectangle for just this stack item's area
+    // by intersecting the stack item rect with the bar's border radius
+    final stackItemRRect = RRect.fromRectAndCorners(
+      rect,
+      topLeft: rect.top <= barRRect.top + barRRect.tlRadius.y ? barRRect.tlRadius : Radius.zero,
+      topRight: rect.top <= barRRect.top + barRRect.trRadius.y ? barRRect.trRadius : Radius.zero,  
+      bottomLeft: rect.bottom >= barRRect.bottom - barRRect.blRadius.y ? barRRect.blRadius : Radius.zero,
+      bottomRight: rect.bottom >= barRRect.bottom - barRRect.brRadius.y ? barRRect.brRadius : Radius.zero,
+    );
+    canvasWrapper.clipPath(Path()..addRRect(stackItemRRect));
 
     // Convert angle to radians
     final angleRadians = hatchPattern.angle * (pi / 180.0);

--- a/lib/src/chart/base/axis_chart/axis_chart_data.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_data.dart
@@ -183,7 +183,7 @@ class SideTitles with EquatableMixin {
   /// It draws some title on an axis, per axis values,
   /// [showTitles] determines showing or hiding this side,
   ///
-  /// Texts are depend on the axis value, you can override [getTitles],
+  /// Texts are depend on the axis value, you can override [_getTitles],
   /// it gives you an axis value (double value) and a [TitleMeta] which contains
   /// additional information about the axis.
   /// Then you should return a [Widget] to show.

--- a/test/chart/bar_chart/bar_chart_data_test.dart
+++ b/test/chart/bar_chart/bar_chart_data_test.dart
@@ -145,5 +145,198 @@ void main() {
       expect(barChartData1 == barChartData14, false);
       expect(barChartData1 == barChartData15, false);
     });
+
+    test('HatchPattern equality test', () {
+      const pattern1 = HatchPattern(hatchColor: Colors.red);
+      const pattern1Clone = HatchPattern(hatchColor: Colors.red);
+      const pattern2 = HatchPattern(
+        hatchColor: Colors.blue,
+        spacing: 8.0,
+        angle: -60.0,
+      );
+      const pattern3 = HatchPattern(
+        hatchColor: Colors.red,
+        backgroundColor: Colors.white,
+      );
+
+      expect(pattern1 == pattern1Clone, true);
+      expect(pattern1 == pattern2, false);
+      expect(pattern1 == pattern3, false);
+      expect(pattern2 == pattern3, false);
+    });
+
+    test('HatchPattern default values test', () {
+      const pattern = HatchPattern(hatchColor: Colors.red);
+      
+      expect(pattern.spacing, 6.0);
+      expect(pattern.angle, -45.0);
+      expect(pattern.strokeWidth, 1.0);
+      expect(pattern.hatchColor, Colors.red);
+      expect(pattern.backgroundColor, null);
+    });
+
+    test('HatchPattern copyWith test', () {
+      const original = HatchPattern(
+        hatchColor: Colors.red,
+        spacing: 8.0,
+        angle: -30.0,
+        strokeWidth: 2.0,
+        backgroundColor: Colors.white,
+      );
+
+      final copied = original.copyWith(
+        hatchColor: Colors.blue,
+        spacing: 4.0,
+      );
+
+      expect(copied.hatchColor, Colors.blue);
+      expect(copied.spacing, 4.0);
+      expect(copied.angle, -30.0); // unchanged
+      expect(copied.strokeWidth, 2.0); // unchanged
+      expect(copied.backgroundColor, Colors.white); // unchanged
+    });
+
+    test('HatchPattern lerp test', () {
+      const patternA = HatchPattern(
+        hatchColor: Colors.red,
+        spacing: 4.0,
+        angle: -30.0,
+        strokeWidth: 1.0,
+      );
+      const patternB = HatchPattern(
+        hatchColor: Colors.blue,
+        spacing: 8.0,
+        angle: -60.0,
+        strokeWidth: 3.0,
+      );
+
+      final lerped = HatchPattern.lerp(patternA, patternB, 0.5);
+      
+      expect(lerped.spacing, 6.0);
+      expect(lerped.angle, -45.0);
+      expect(lerped.strokeWidth, 2.0);
+      // Color lerping is handled by Flutter's Color.lerp
+      expect(lerped.hatchColor, Color.lerp(Colors.red, Colors.blue, 0.5));
+    });
+
+    test('BarChartRodStackItem with hatching equality test', () {
+      const hatchPattern = HatchPattern(hatchColor: Colors.red);
+      
+      final stackItem1 = BarChartRodStackItem(
+        0,
+        5,
+        null,
+        isHatched: true,
+        hatchPattern: hatchPattern,
+      );
+      
+      final stackItem1Clone = BarChartRodStackItem(
+        0,
+        5,
+        null,
+        isHatched: true,
+        hatchPattern: hatchPattern,
+      );
+      
+      final stackItem2 = BarChartRodStackItem(
+        0,
+        5,
+        Colors.blue,
+        isHatched: false,
+      );
+
+      expect(stackItem1 == stackItem1Clone, true);
+      expect(stackItem1 == stackItem2, false);
+    });
+
+    test('BarChartRodStackItem hatching copyWith test', () {
+      const hatchPattern1 = HatchPattern(hatchColor: Colors.red);
+      const hatchPattern2 = HatchPattern(hatchColor: Colors.blue);
+      
+      final original = BarChartRodStackItem(
+        0,
+        5,
+        null,
+        isHatched: true,
+        hatchPattern: hatchPattern1,
+      );
+
+      final copied = original.copyWith(
+        color: Colors.green,
+        isHatched: false,
+        hatchPattern: hatchPattern2,
+      );
+
+      expect(copied.isHatched, false);
+      expect(copied.hatchPattern, hatchPattern2);
+      expect(copied.fromY, 0); // unchanged
+      expect(copied.toY, 5); // unchanged
+    });
+
+    test('BarChartRodStackItem hatching lerp test', () {
+      const hatchPattern1 = HatchPattern(
+        hatchColor: Colors.red,
+        spacing: 4.0,
+      );
+      const hatchPattern2 = HatchPattern(
+        hatchColor: Colors.blue,
+        spacing: 8.0,
+      );
+      
+      final stackItemA = BarChartRodStackItem(
+        0,
+        5,
+        null,
+        isHatched: true,
+        hatchPattern: hatchPattern1,
+      );
+      
+      final stackItemB = BarChartRodStackItem(
+        2,
+        7,
+        null,
+        isHatched: true,
+        hatchPattern: hatchPattern2,
+      );
+
+      final lerped = BarChartRodStackItem.lerp(stackItemA, stackItemB, 0.5);
+
+      expect(lerped.fromY, 1.0);
+      expect(lerped.toY, 6.0);
+      expect(lerped.isHatched, true);
+      expect(lerped.hatchPattern?.spacing, 6.0);
+      expect(lerped.hatchPattern?.hatchColor, Color.lerp(Colors.red, Colors.blue, 0.5));
+    });
+
+    test('HatchPattern validation test', () {
+      // Valid pattern should not throw
+      expect(
+        () => const HatchPattern(hatchColor: Colors.red, spacing: 1.0),
+        returnsNormally,
+      );
+
+      // Invalid spacing should throw assertion error
+      expect(
+        () => HatchPattern(hatchColor: Colors.red, spacing: 0.0),
+        throwsA(isA<AssertionError>()),
+      );
+
+      expect(
+        () => HatchPattern(hatchColor: Colors.red, spacing: -1.0),
+        throwsA(isA<AssertionError>()),
+      );
+
+      // Invalid stroke width should throw assertion error
+      expect(
+        () => HatchPattern(hatchColor: Colors.red, strokeWidth: -1.0),
+        throwsA(isA<AssertionError>()),
+      );
+
+      // Zero stroke width should be allowed (invisible lines)
+      expect(
+        () => const HatchPattern(hatchColor: Colors.red, strokeWidth: 0.0),
+        returnsNormally,
+      );
+    });
   });
 }


### PR DESCRIPTION
This PR aims to add this feature #2008 

## Summary

Adds native, customizable hatch pattern (diagonal lines) support to ‎`BarChartRodStackItem` in FL Chart, allowing for visually distinctive stacked bar segments.

## Main Changes
####  • New Properties:
 ▫ ‎`isHatched` and ‎`hatchPattern` on ‎`BarChartRodStackItem` for enabling and configuring hatching.
 ▫ ‎`HatchPattern` class supports color, background, angle, spacing, and stroke width.

####  • Rendering:
 ▫ Bar chart painter now draws hatch patterns with proper rounded clipping.

#### Examples & Tests:
 ▫ New ‎`BarChartSample9` demonstrates hatching.
 ▫ Comprehensive tests for hatch pattern and stack item logic.

Usage
```
BarChartRodStackItem(
  fromY, toY, null,
  isHatched: true,
  hatchPattern: HatchPattern(
    hatchColor: Color(0xff38f3f3),
    backgroundColor: Color(0xff0293ee),
    spacing: 6.0,
    angle: -45.0,
    strokeWidth: 2.5,
  ),
)
```

Backwards compatible: Solid/gradient fills remain unchanged; hatching is opt-in.

## Result

<img width="461" height="497" alt="image" src="https://github.com/user-attachments/assets/b659842f-7ae3-4e1a-ba4d-5bbb4c91969c" />

