### PR TITLE
fix: wrong bar chart color with small value

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -306,10 +306,10 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
           // draw rod stack
           if (barRod.rodStackItems.isNotEmpty) {
             // Calculate scale factor to ensure minimum height for corner radius
-            final totalHeightPixels = (
-              getPixelY(barRod.fromY, viewSize, holder) -
-              getPixelY(barRod.toY, viewSize, holder)
-            ).abs();
+            final totalHeightPixels =
+                (getPixelY(barRod.fromY, viewSize, holder) -
+                        getPixelY(barRod.toY, viewSize, holder))
+                    .abs();
 
             final scaleFactor = totalHeightPixels < cornerHeight
                 ? cornerHeight / totalHeightPixels
@@ -324,7 +324,8 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
               // Apply scale factor only when needed
               if (scaleFactor > 1.0) {
                 final basePixelY = getPixelY(barRod.fromY, viewSize, holder);
-                stackFromY = basePixelY - (basePixelY - stackFromY) * scaleFactor;
+                stackFromY =
+                    basePixelY - (basePixelY - stackFromY) * scaleFactor;
                 stackToY = basePixelY - (basePixelY - stackToY) * scaleFactor;
               }
 

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1630,8 +1630,11 @@ void main() {
       barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
 
       // Verify that clipRect was called for each stack item
-      expect(clipRectResults.length, 2,
-          reason: 'Should have clipped for 2 stack items');
+      expect(
+        clipRectResults.length,
+        2,
+        reason: 'Should have clipped for 2 stack items',
+      );
 
       // Verify that the clip rectangles have been scaled properly
       // The total bar height in pixels would be very small (2% of 200 = 4px)
@@ -1645,17 +1648,28 @@ void main() {
       // print('rect2: $rect2, height: ${rect2.height}');
 
       // Stack items should not overlap and should be adjacent
-      expect(rect2.bottom, closeTo(rect1.top, tolerance),
-          reason: 'Stack items should be adjacent without gaps (rect2.bottom should equal rect1.top)');
+      expect(
+        rect2.bottom,
+        closeTo(rect1.top, tolerance),
+        reason:
+            'Stack items should be adjacent without gaps (rect2.bottom should equal rect1.top)',
+      );
 
       // The combined height should equal the scaled total height (cornerHeight)
       final totalScaledHeight = rect1.height + rect2.height;
-      expect(totalScaledHeight, closeTo(8.0, tolerance),
-          reason: 'Total scaled height should equal corner height (8px)');
+      expect(
+        totalScaledHeight,
+        closeTo(8.0, tolerance),
+        reason: 'Total scaled height should equal corner height (8px)',
+      );
 
       // Heights should be proportional to data values (1:1 ratio)
-      expect(rect1.height, closeTo(rect2.height, tolerance),
-          reason: 'Stack items with equal data heights (1) should have equal pixel heights');
+      expect(
+        rect1.height,
+        closeTo(rect2.height, tolerance),
+        reason:
+            'Stack items with equal data heights (1) should have equal pixel heights',
+      );
     });
   });
 


### PR DESCRIPTION
  Fixed incorrect bar chart color display when bar data values are small with large border radius set.

  Fixes #1757

  Root Cause

  1. The bar's main body (background) has a default background color
  2. Since the bar body's height cannot be lower than the border radius, the rendered bar body may be taller
   than the actual rendered height of the bar stack items (rodStackItems)
  3. The rendering logic draws the bar body background first, then overlays the bar stack items. When the
  stack items' height is insufficient to cover the entire bar body, the default background color becomes
  visible

  Solution

  When the actual height of the bar stack is smaller than the minimum height required for the corner radius,
   a scale factor is introduced to proportionally expand the rendered height of the bar stack items. This
  ensures they fully cover the bar body's height while maintaining the proportional relationships among
  stack items.

  Changes

  - Modified drawBars method in lib/src/chart/bar_chart/bar_chart_painter.dart
  - Added scale factor calculation logic, applied only when necessary
  - Added unit tests to verify the fix

  Testing

  - ✅ Added unit test covering small values with large border radius scenario
  - ✅ Verified scaled stack items have correct heights and proportions
  - ✅ All existing tests pass