### PR TITLE
feat: add maxValue and checkToShowTick in radarChart

### DIFF
--- a/lib/src/chart/radar_chart/radar_chart_data.dart
+++ b/lib/src/chart/radar_chart/radar_chart_data.dart
@@ -12,10 +12,19 @@ typedef GetTitleByIndexFunction = RadarChartTitle Function(
   double angle,
 );
 
+typedef CheckToShowTick = bool Function(
+  int index,
+  List<double> ticks,
+);
+
 enum RadarShape {
   circle,
   polygon,
 }
+
+/// Shows all ticks except the last one.
+bool showTickWithoutLast(int index, List<double> ticks) =>
+    index != ticks.length - 1;
 
 class RadarChartTitle {
   const RadarChartTitle({
@@ -75,6 +84,8 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? gridBorderData,
     RadarTouchData? radarTouchData,
     this.isMinValueAtCenter = false,
+    this.maxValue,
+    this.checkToShowTick = showTickWithoutLast,
     super.borderData,
   })  : assert(dataSets != null && dataSets.hasEqualDataEntriesLength),
         assert(
@@ -86,6 +97,10 @@ class RadarChartData extends BaseChartData with EquatableMixin {
               titlePositionPercentageOffset >= 0 &&
                   titlePositionPercentageOffset <= 1,
           'titlePositionPercentageOffset must be something between 0 and 1 ',
+        ),
+        assert(
+          maxValue == null || maxValue.isFinite,
+          'maxValue must be a finite number',
         ),
         dataSets = dataSets ?? const [],
         radarBackgroundColor = radarBackgroundColor ?? Colors.transparent,
@@ -163,9 +178,24 @@ class RadarChartData extends BaseChartData with EquatableMixin {
   /// [titleCount] we use this value to determine number of [RadarChart] grid or lines.
   int get titleCount => dataSets[0].dataEntries.length;
 
+  /// Controls which ticks should be displayed on the radar chart.
+  final CheckToShowTick checkToShowTick;
+
+  /// Custom maximum value for the [RadarChart]. If provided, this value will be used
+  /// instead of the automatically calculated maximum from the data.
+  /// This is useful for standardizing display across multiple charts or reserving space
+  /// for future data growth. If null, the maximum value will be calculated from the data.
+  final double? maxValue;
+
   /// defines the maximum [RadarEntry] value in all [dataSets]
   /// we use this value to calculate the maximum value of ticks.
   RadarEntry get maxEntry {
+    // If custom maxValue is provided, use it
+    if (maxValue != null) {
+      return RadarEntry(value: maxValue!);
+    }
+
+    // Otherwise, calculate from data
     var maximum = dataSets.first.dataEntries.first;
 
     for (final dataSet in dataSets) {
@@ -206,7 +236,9 @@ class RadarChartData extends BaseChartData with EquatableMixin {
     BorderSide? gridBorderData,
     RadarTouchData? radarTouchData,
     bool? isMinValueAtCenter,
+    double? maxValue,
     FlBorderData? borderData,
+    CheckToShowTick? checkToShowTick,
   }) =>
       RadarChartData(
         dataSets: dataSets ?? this.dataSets,
@@ -223,7 +255,9 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         gridBorderData: gridBorderData ?? this.gridBorderData,
         radarTouchData: radarTouchData ?? this.radarTouchData,
         isMinValueAtCenter: isMinValueAtCenter ?? this.isMinValueAtCenter,
+        maxValue: maxValue ?? this.maxValue,
         borderData: borderData ?? this.borderData,
+        checkToShowTick: checkToShowTick ?? this.checkToShowTick,
       );
 
   /// Lerps a [BaseChartData] based on [t] value, check [Tween.lerp].
@@ -250,7 +284,9 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         tickBorderData: BorderSide.lerp(a.tickBorderData, b.tickBorderData, t),
         borderData: FlBorderData.lerp(a.borderData, b.borderData, t),
         isMinValueAtCenter: b.isMinValueAtCenter,
+        maxValue: lerpDouble(a.maxValue, b.maxValue, t),
         radarTouchData: b.radarTouchData,
+        checkToShowTick: b.checkToShowTick,
       );
     } else {
       throw Exception('Illegal State');
@@ -274,6 +310,8 @@ class RadarChartData extends BaseChartData with EquatableMixin {
         gridBorderData,
         radarTouchData,
         isMinValueAtCenter,
+        maxValue,
+        checkToShowTick,
       ];
 }
 

--- a/lib/src/chart/radar_chart/radar_chart_painter.dart
+++ b/lib/src/chart/radar_chart/radar_chart_painter.dart
@@ -33,6 +33,7 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
     _ticksTextPaint = TextPainter();
     _titleTextPaint = TextPainter();
   }
+
   late Paint _borderPaint;
   late Paint _backgroundPaint;
   late Paint _gridPaint;
@@ -192,18 +193,28 @@ class RadarChartPainter extends BaseChartPainter<RadarChartData> {
       ..strokeWidth = data.tickBorderData.width;
 
     /// draw radar ticks
-    ticks.sublist(0, ticks.length - 1).asMap().forEach(
+    ticks.sublist(0, ticks.length).asMap().forEach(
       (index, tick) {
         final tickRadius =
             tickDistance * (index + (data.isMinValueAtCenter ? 0 : 1));
-        if (data.radarShape == RadarShape.circle) {
-          canvasWrapper.drawCircle(centerOffset, tickRadius, _tickPaint);
-        } else {
-          canvasWrapper.drawPath(
-            _generatePolygonPath(centerX, centerY, tickRadius, data.titleCount),
-            _tickPaint,
-          );
+
+        if (index != ticks.length - 1) {
+          if (data.radarShape == RadarShape.circle) {
+            canvasWrapper.drawCircle(centerOffset, tickRadius, _tickPaint);
+          } else {
+            canvasWrapper.drawPath(
+              _generatePolygonPath(
+                centerX,
+                centerY,
+                tickRadius,
+                data.titleCount,
+              ),
+              _tickPaint,
+            );
+          }
         }
+
+        if (!data.checkToShowTick(index, ticks)) return;
 
         _ticksTextPaint
           ..text = TextSpan(

--- a/repo_files/documentations/radar_chart.md
+++ b/repo_files/documentations/radar_chart.md
@@ -32,6 +32,8 @@ When you change the chart's state, it animates to the new state internally (usin
 |gridBorderData|Style of the grid borders|BorderSide(color: Colors.black, width: 2)|
 |radarTouchData|[RadarTouchData](#radartouchdata-read-about-touch-handling) handles the touch behaviors and responses.|RadarTouchData()|
 |isMinValueAtCenter|If true, the minimum value of the [RadarChart] will be at the center of the chart.|false|
+|maxValue|Defines a custom maximum value for the [RadarChart]. If provided, this value will be used instead of the automatically calculated maximum from the data.|null|
+|checkToShowTick|Determines which ticks should be displayed on the [RadarChart]. By default, shows all ticks except the last one.|showTickWithoutLast|
 
 ### RadarDataSet
 |PropName		|Description	|default value|

--- a/test/chart/radar_chart/radar_chart_data_test.dart
+++ b/test/chart/radar_chart/radar_chart_data_test.dart
@@ -143,6 +143,21 @@ void main() {
             ),
         false,
       );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(),
+        true,
+      );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(maxValue: 100),
+        false,
+      );
+
+      expect(
+        radarChartData1 == radarChartData1Clone.copyWith(maxValue: 200),
+        false,
+      );
     });
 
     test('RadarDataSet equality test', () {
@@ -268,6 +283,84 @@ void main() {
       expect(radarTouchedSpot1 == radarTouchedSpot5, false);
       expect(radarTouchedSpot1 == radarTouchedSpot6, false);
       expect(radarTouchedSpot1 == radarTouchedSpot7, false);
+    });
+  });
+
+  group('RadarChart maxValue functionality', () {
+    test('maxEntry returns data max when maxValue is null', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1],
+      );
+      expect(data.maxEntry.value, equals(4.0));
+    });
+
+    test(
+        'maxEntry returns data max from multiple datasets when maxValue is null',
+        () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1, radarDataSet2],
+      );
+      expect(data.maxEntry.value, equals(10.0));
+    });
+
+    test('maxEntry returns custom maxValue when provided', () {
+      final data = RadarChartData(
+        dataSets: [radarDataSet1],
+        maxValue: 150,
+      );
+      expect(data.maxEntry.value, equals(150.0));
+    });
+
+    test('maxValue validation throws on NaN', () {
+      expect(
+        () => RadarChartData(
+          dataSets: [radarDataSet1],
+          maxValue: double.nan,
+        ),
+        throwsAssertionError,
+      );
+    });
+
+    test('maxValue validation throws on infinity', () {
+      expect(
+        () => RadarChartData(
+          dataSets: [radarDataSet1],
+          maxValue: double.infinity,
+        ),
+        throwsAssertionError,
+      );
+    });
+  });
+
+  group('RadarChart checkToShowTick functionality', () {
+    test('RadarChartData equality affected by checkToShowTick', () {
+      bool customCheck(int index, List<double> ticks) => index.isEven;
+
+      final data1 = RadarChartData(
+        dataSets: [radarDataSet1],
+        checkToShowTick: customCheck,
+      );
+
+      final data2 = RadarChartData(
+        dataSets: [radarDataSet1],
+      );
+
+      expect(data1 == data2, false);
+    });
+
+    test('copyWith preserves checkToShowTick', () {
+      bool customCheck(int index, List<double> ticks) => ticks[index] > 15.0;
+
+      final original = RadarChartData(
+        dataSets: [radarDataSet1],
+        checkToShowTick: customCheck,
+      );
+
+      final copied = original.copyWith(radarBackgroundColor: Colors.red);
+
+      final ticks = [10.0, 20.0];
+      expect(copied.checkToShowTick(0, ticks), false);
+      expect(copied.checkToShowTick(1, ticks), true);
     });
   });
 }


### PR DESCRIPTION
 ## Summary

  This PR implements the customization features for RadarChart as discussed in #2002.

  **Note**: This is a follow-up to PR #2007. The previous PR was submitted from the GitHub account `artsooter`, which is no longer available. 
  I've created this new PR with a fresh account to implement the feedback.

  ## Changes

  1. **maxValue parameter**: Allows setting a custom maximum value for the RadarChart instead of auto-calculating from data.

  2. **checkToShowTick callback**: Implemented as suggested in the review. This function determines which ticks should be displayed by receiving the tick
  index,  and list of all ticks. Returns a boolean to control visibility. Default behavior shows all ticks except the last one.

  3. **Documentation**: Added descriptions for both parameters to `radar_chart.md`.

  ## Documentation

  |PropName|Description|default value|
  |:-------|:----------|:------------|
  |maxValue|Defines a custom maximum value for the [RadarChart]. If provided, this value will be used instead of the automatically calculated maximum from the data.|null|
  |checkToShowTick|Determines which ticks should be displayed on the [RadarChart]. By default, shows all ticks except the last one.|showTickWithoutLast|

  ---