### PR TITLE
feat(pie_chart): Add individual border control for pie chart sections

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -132,6 +132,99 @@ class PieChartData extends BaseChartData with EquatableMixin {
       ];
 }
 
+/// Defines individual border sides for a [PieChartSectionData].
+///
+/// A pie chart section has 4 sides:
+/// - [outer]: the outer arc (furthest from center)
+/// - [inner]: the inner arc (closest to center)
+/// - [left]: the left radial line (start of the section)
+/// - [right]: the right radial line (end of the section)
+///
+/// This allows you to control which borders are visible, useful when
+/// sections are adjacent and you don't want doubled borders.
+class PieChartSectionBorder with EquatableMixin {
+  /// Creates a border configuration for a pie chart section.
+  ///
+  /// By default, all sides use [BorderSide.none].
+  const PieChartSectionBorder({
+    this.outer = BorderSide.none,
+    this.inner = BorderSide.none,
+    this.left = BorderSide.none,
+    this.right = BorderSide.none,
+  });
+
+  /// Creates a border with the same [BorderSide] on all sides.
+  const PieChartSectionBorder.all(BorderSide side)
+      : outer = side,
+        inner = side,
+        left = side,
+        right = side;
+
+  /// Creates a border with only the arcs (outer and inner) visible.
+  /// Useful for adjacent sections where you don't want doubled radial borders.
+  const PieChartSectionBorder.arcsOnly(BorderSide side)
+      : outer = side,
+        inner = side,
+        left = BorderSide.none,
+        right = BorderSide.none;
+
+  /// Creates a border with only the outer arc visible.
+  const PieChartSectionBorder.outerOnly(BorderSide side)
+      : outer = side,
+        inner = BorderSide.none,
+        left = BorderSide.none,
+        right = BorderSide.none;
+
+  /// The border on the outer arc (furthest from center).
+  final BorderSide outer;
+
+  /// The border on the inner arc (closest to center).
+  final BorderSide inner;
+
+  /// The border on the left radial line (start of the section).
+  final BorderSide left;
+
+  /// The border on the right radial line (end of the section).
+  final BorderSide right;
+
+  /// Copies this border with the given fields replaced.
+  PieChartSectionBorder copyWith({
+    BorderSide? outer,
+    BorderSide? inner,
+    BorderSide? left,
+    BorderSide? right,
+  }) =>
+      PieChartSectionBorder(
+        outer: outer ?? this.outer,
+        inner: inner ?? this.inner,
+        left: left ?? this.left,
+        right: right ?? this.right,
+      );
+
+  /// Linearly interpolates between two [PieChartSectionBorder]s.
+  static PieChartSectionBorder lerp(
+    PieChartSectionBorder a,
+    PieChartSectionBorder b,
+    double t,
+  ) =>
+      PieChartSectionBorder(
+        outer: BorderSide.lerp(a.outer, b.outer, t),
+        inner: BorderSide.lerp(a.inner, b.inner, t),
+        left: BorderSide.lerp(a.left, b.left, t),
+        right: BorderSide.lerp(a.right, b.right, t),
+      );
+
+  /// Returns true if any border side is visible.
+  bool get hasVisibleBorder =>
+      (outer.width > 0 && outer.color.a > 0) ||
+      (inner.width > 0 && inner.color.a > 0) ||
+      (left.width > 0 && left.color.a > 0) ||
+      (right.width > 0 && right.color.a > 0);
+
+  @override
+  List<Object?> get props => [outer, inner, left, right];
+}
+
 /// Holds data related to drawing each [PieChart] section.
 class PieChartSectionData with EquatableMixin {
   /// [PieChart] draws section from right side of the circle (0 degrees),
@@ -161,7 +254,9 @@ class PieChartSectionData with EquatableMixin {
     bool? showTitle,
     this.titleStyle,
     String? title,
+    @Deprecated('Use border instead for individual border control')
     BorderSide? borderSide,
+    PieChartSectionBorder? border,
     this.badgeWidget,
     double? titlePositionPercentageOffset,
     double? badgePositionPercentageOffset,
@@ -171,6 +266,10 @@ class PieChartSectionData with EquatableMixin {
         showTitle = showTitle ?? true,
         title = title ?? (value == null ? '' : value.toString()),
         borderSide = borderSide ?? const BorderSide(width: 0),
+        border = border ??
+            (borderSide != null
+                ? PieChartSectionBorder.all(borderSide)
+                : const PieChartSectionBorder()),
         titlePositionPercentageOffset = titlePositionPercentageOffset ?? 0.5,
         badgePositionPercentageOffset = badgePositionPercentageOffset ?? 0.5;
 
@@ -200,8 +299,22 @@ class PieChartSectionData with EquatableMixin {
   /// Defines text of showing title at the middle of section.
   final String title;
 
-  /// Defines border stroke around the section
+  /// Defines border stroke around the section.
+  ///
+  /// @deprecated Use [border] instead for individual border control.
   final BorderSide borderSide;
+
+  /// Defines individual border sides for the section.
+  ///
+  /// This allows you to control which borders are visible on each side:
+  /// - [PieChartSectionBorder.outer]: the outer arc
+  /// - [PieChartSectionBorder.inner]: the inner arc
+  /// - [PieChartSectionBorder.left]: the left radial line
+  /// - [PieChartSectionBorder.right]: the right radial line
+  ///
+  /// Useful when sections are adjacent and you don't want doubled borders.
+  /// For example, use [PieChartSectionBorder.arcsOnly] to only show arc borders.
+  final PieChartSectionBorder border;
 
   /// Defines a widget that represents the section.
   ///
@@ -233,7 +346,8 @@ class PieChartSectionData with EquatableMixin {
     bool? showTitle,
     TextStyle? titleStyle,
     String? title,
-    BorderSide? borderSide,
+    @Deprecated('Use border instead') BorderSide? borderSide,
+    PieChartSectionBorder? border,
     Widget? badgeWidget,
     double? titlePositionPercentageOffset,
     double? badgePositionPercentageOffset,
@@ -247,6 +361,7 @@ class PieChartSectionData with EquatableMixin {
         titleStyle: titleStyle ?? this.titleStyle,
         title: title ?? this.title,
         borderSide: borderSide ?? this.borderSide,
+        border: border ?? this.border,
         badgeWidget: badgeWidget ?? this.badgeWidget,
         titlePositionPercentageOffset:
             titlePositionPercentageOffset ?? this.titlePositionPercentageOffset,
@@ -269,6 +384,7 @@ class PieChartSectionData with EquatableMixin {
         titleStyle: TextStyle.lerp(a.titleStyle, b.titleStyle, t),
         title: b.title,
         borderSide: BorderSide.lerp(a.borderSide, b.borderSide, t),
+        border: PieChartSectionBorder.lerp(a.border, b.border, t),
         badgeWidget: b.badgeWidget,
         titlePositionPercentageOffset: lerpDouble(
           a.titlePositionPercentageOffset,
@@ -293,6 +409,7 @@ class PieChartSectionData with EquatableMixin {
         titleStyle,
         title,
         borderSide,
+        border,
         badgeWidget,
         titlePositionPercentageOffset,
         badgePositionPercentageOffset,

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -175,17 +175,6 @@ class PieChartSectionBorder with EquatableMixin {
         left = BorderSide.none,
         right = BorderSide.none;
 
-  /// Creates a "smart" border that avoids doubled borders between adjacent sections.
-  ///
-  /// This shows borders on outer arc, inner arc, and right side only.
-  /// Since each section only draws its right border, adjacent sections
-  /// won't have overlapping borders (section A's right = section B's left).
-  const PieChartSectionBorder.smart(BorderSide side)
-      : outer = side,
-        inner = side,
-        left = BorderSide.none,
-        right = side;
-
   /// The border on the outer arc (furthest from center).
   final BorderSide outer;
 
@@ -277,10 +266,7 @@ class PieChartSectionData with EquatableMixin {
         showTitle = showTitle ?? true,
         title = title ?? (value == null ? '' : value.toString()),
         borderSide = borderSide ?? const BorderSide(width: 0),
-        border = border ??
-            (borderSide != null
-                ? PieChartSectionBorder.all(borderSide)
-                : const PieChartSectionBorder()),
+        border = border ?? const PieChartSectionBorder(),
         titlePositionPercentageOffset = titlePositionPercentageOffset ?? 0.5,
         badgePositionPercentageOffset = badgePositionPercentageOffset ?? 0.5;
 

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -175,6 +175,17 @@ class PieChartSectionBorder with EquatableMixin {
         left = BorderSide.none,
         right = BorderSide.none;
 
+  /// Creates a "smart" border that avoids doubled borders between adjacent sections.
+  ///
+  /// This shows borders on outer arc, inner arc, and right side only.
+  /// Since each section only draws its right border, adjacent sections
+  /// won't have overlapping borders (section A's right = section B's left).
+  const PieChartSectionBorder.smart(BorderSide side)
+      : outer = side,
+        inner = side,
+        left = BorderSide.none,
+        right = side;
+
   /// The border on the outer arc (furthest from center).
   final BorderSide outer;
 

--- a/test/chart/pie_chart/pie_chart_data_test.dart
+++ b/test/chart/pie_chart/pie_chart_data_test.dart
@@ -165,4 +165,157 @@ void main() {
       expect(sample1 == zeroLongPressDuration, false);
     });
   });
+
+  group('PieChartSectionBorder', () {
+    test('default constructor creates border with all sides none', () {
+      const border = PieChartSectionBorder();
+      expect(border.outer, BorderSide.none);
+      expect(border.inner, BorderSide.none);
+      expect(border.left, BorderSide.none);
+      expect(border.right, BorderSide.none);
+      expect(border.hasVisibleBorder, false);
+    });
+
+    test('.all constructor creates border with same side on all', () {
+      const side = BorderSide(color: Colors.red, width: 2);
+      const border = PieChartSectionBorder.all(side);
+      expect(border.outer, side);
+      expect(border.inner, side);
+      expect(border.left, side);
+      expect(border.right, side);
+      expect(border.hasVisibleBorder, true);
+    });
+
+    test('.arcsOnly constructor creates border with only arcs', () {
+      const side = BorderSide(color: Colors.blue, width: 3);
+      const border = PieChartSectionBorder.arcsOnly(side);
+      expect(border.outer, side);
+      expect(border.inner, side);
+      expect(border.left, BorderSide.none);
+      expect(border.right, BorderSide.none);
+      expect(border.hasVisibleBorder, true);
+    });
+
+    test('.outerOnly constructor creates border with only outer arc', () {
+      const side = BorderSide(color: Colors.green, width: 1);
+      const border = PieChartSectionBorder.outerOnly(side);
+      expect(border.outer, side);
+      expect(border.inner, BorderSide.none);
+      expect(border.left, BorderSide.none);
+      expect(border.right, BorderSide.none);
+      expect(border.hasVisibleBorder, true);
+    });
+
+    test('hasVisibleBorder returns false for zero width', () {
+      const border = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.red, width: 0),
+      );
+      expect(border.hasVisibleBorder, false);
+    });
+
+    test('hasVisibleBorder returns false for transparent color', () {
+      const border = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.transparent, width: 2),
+      );
+      expect(border.hasVisibleBorder, false);
+    });
+
+    test('copyWith creates new instance with replaced values', () {
+      const original = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.red, width: 1),
+        inner: BorderSide(color: Colors.blue, width: 2),
+      );
+      final copied = original.copyWith(
+        outer: const BorderSide(color: Colors.green, width: 3),
+      );
+      expect(copied.outer, const BorderSide(color: Colors.green, width: 3));
+      expect(copied.inner, const BorderSide(color: Colors.blue, width: 2));
+      expect(copied.left, BorderSide.none);
+      expect(copied.right, BorderSide.none);
+    });
+
+    test('lerp interpolates between two borders', () {
+      const a = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.red, width: 0),
+      );
+      const b = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.red, width: 10),
+      );
+      final result = PieChartSectionBorder.lerp(a, b, 0.5);
+      expect(result.outer.width, 5);
+    });
+
+    test('equality check works correctly', () {
+      const border1 = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.red, width: 2),
+      );
+      const border2 = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.red, width: 2),
+      );
+      const border3 = PieChartSectionBorder(
+        outer: BorderSide(color: Colors.blue, width: 2),
+      );
+      expect(border1 == border2, true);
+      expect(border1 == border3, false);
+    });
+  });
+
+  group('PieChartSectionData with border', () {
+    test('section with border has correct equality', () {
+      final section1 = PieChartSectionData(
+        value: 10,
+        border: const PieChartSectionBorder.all(
+          BorderSide(color: Colors.red, width: 2),
+        ),
+      );
+      final section2 = PieChartSectionData(
+        value: 10,
+        border: const PieChartSectionBorder.all(
+          BorderSide(color: Colors.red, width: 2),
+        ),
+      );
+      final section3 = PieChartSectionData(
+        value: 10,
+        border: const PieChartSectionBorder.all(
+          BorderSide(color: Colors.blue, width: 2),
+        ),
+      );
+      expect(section1 == section2, true);
+      expect(section1 == section3, false);
+    });
+
+    test('copyWith border works correctly', () {
+      final section = PieChartSectionData(
+        value: 10,
+        border: const PieChartSectionBorder.all(
+          BorderSide(color: Colors.red, width: 2),
+        ),
+      );
+      final copied = section.copyWith(
+        border: const PieChartSectionBorder.outerOnly(
+          BorderSide(color: Colors.blue, width: 3),
+        ),
+      );
+      expect(copied.border.outer.color, Colors.blue);
+      expect(copied.border.outer.width, 3);
+      expect(copied.border.inner, BorderSide.none);
+    });
+
+    test('lerp interpolates border correctly', () {
+      final a = PieChartSectionData(
+        value: 10,
+        border: const PieChartSectionBorder(
+          outer: BorderSide(color: Colors.red, width: 0),
+        ),
+      );
+      final b = PieChartSectionData(
+        value: 10,
+        border: const PieChartSectionBorder(
+          outer: BorderSide(color: Colors.red, width: 10),
+        ),
+      );
+      final result = PieChartSectionData.lerp(a, b, 0.5);
+      expect(result.border.outer.width, 5);
+    });
+  });
 }

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -1263,4 +1263,189 @@ void main() {
       );
     });
   });
+
+  group('drawSectionIndividualBorders()', () {
+    test('does nothing when border has no visible sides', () {
+      const viewSize = Size(200, 200);
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        value: 1,
+        radius: 40,
+        border: const PieChartSectionBorder(),
+      );
+
+      final pieChartPainter = PieChartPainter();
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      pieChartPainter.drawSectionIndividualBorders(
+        section,
+        0,
+        0,
+        90,
+        const Offset(100, 100),
+        30,
+        mockCanvasWrapper,
+      );
+
+      verifyNever(mockCanvasWrapper.drawArc(any, any, any, any, any));
+      verifyNever(mockCanvasWrapper.drawLine(any, any, any));
+    });
+
+    test('draws outer arc when outer border is set', () {
+      const viewSize = Size(200, 200);
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        value: 1,
+        radius: 40,
+        border: const PieChartSectionBorder(
+          outer: BorderSide(color: MockData.color2, width: 2),
+        ),
+      );
+
+      final pieChartPainter = PieChartPainter();
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      pieChartPainter.drawSectionIndividualBorders(
+        section,
+        0,
+        0,
+        90,
+        const Offset(100, 100),
+        30,
+        mockCanvasWrapper,
+      );
+
+      verify(mockCanvasWrapper.drawArc(any, any, any, false, any)).called(1);
+      verifyNever(mockCanvasWrapper.drawLine(any, any, any));
+    });
+
+    test('draws inner arc when inner border is set', () {
+      const viewSize = Size(200, 200);
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        value: 1,
+        radius: 40,
+        border: const PieChartSectionBorder(
+          inner: BorderSide(color: MockData.color2, width: 2),
+        ),
+      );
+
+      final pieChartPainter = PieChartPainter();
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      pieChartPainter.drawSectionIndividualBorders(
+        section,
+        0,
+        0,
+        90,
+        const Offset(100, 100),
+        30,
+        mockCanvasWrapper,
+      );
+
+      verify(mockCanvasWrapper.drawArc(any, any, any, false, any)).called(1);
+      verifyNever(mockCanvasWrapper.drawLine(any, any, any));
+    });
+
+    test('draws left and right lines when radial borders are set', () {
+      const viewSize = Size(200, 200);
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        value: 1,
+        radius: 40,
+        border: const PieChartSectionBorder(
+          left: BorderSide(color: MockData.color3, width: 2),
+          right: BorderSide(color: MockData.color4, width: 2),
+        ),
+      );
+
+      final pieChartPainter = PieChartPainter();
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      pieChartPainter.drawSectionIndividualBorders(
+        section,
+        0,
+        0,
+        90,
+        const Offset(100, 100),
+        30,
+        mockCanvasWrapper,
+      );
+
+      verifyNever(mockCanvasWrapper.drawArc(any, any, any, any, any));
+      verify(mockCanvasWrapper.drawLine(any, any, any)).called(2);
+    });
+
+    test('draws all borders when .all() is used', () {
+      const viewSize = Size(200, 200);
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        value: 1,
+        radius: 40,
+        border: const PieChartSectionBorder.all(
+          BorderSide(color: MockData.color2, width: 2),
+        ),
+      );
+
+      final pieChartPainter = PieChartPainter();
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      pieChartPainter.drawSectionIndividualBorders(
+        section,
+        0,
+        0,
+        90,
+        const Offset(100, 100),
+        30,
+        mockCanvasWrapper,
+      );
+
+      // 2 arcs (outer + inner)
+      verify(mockCanvasWrapper.drawArc(any, any, any, false, any)).called(2);
+      // 2 lines (left + right)
+      verify(mockCanvasWrapper.drawLine(any, any, any)).called(2);
+    });
+
+    test('draws only arcs when .arcsOnly() is used', () {
+      const viewSize = Size(200, 200);
+      final section = PieChartSectionData(
+        color: MockData.color1,
+        value: 1,
+        radius: 40,
+        border: const PieChartSectionBorder.arcsOnly(
+          BorderSide(color: MockData.color2, width: 2),
+        ),
+      );
+
+      final pieChartPainter = PieChartPainter();
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      pieChartPainter.drawSectionIndividualBorders(
+        section,
+        0,
+        0,
+        90,
+        const Offset(100, 100),
+        30,
+        mockCanvasWrapper,
+      );
+
+      // 2 arcs (outer + inner)
+      verify(mockCanvasWrapper.drawArc(any, any, any, false, any)).called(2);
+      // No lines
+      verifyNever(mockCanvasWrapper.drawLine(any, any, any));
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Add `PieChartSectionBorder` class to allow controlling each border side independently on pie chart sections
- New border sides: `outer` (outer arc), `inner` (inner arc), `left` (left radial), `right` (right radial)
- Convenience constructors: `.all()`, `.arcsOnly()`, `.outerOnly()`
- Deprecate existing `borderSide` parameter (still works for backwards compatibility)

Fixes #2052

## Problem
When pie chart sections are adjacent, borders appear doubled/thicker because `borderSide` applies the same border to all sides.

## Changes
- Added `PieChartSectionBorder` class with individual border properties
- Added `drawSectionIndividualBorders` method in `PieChartPainter`
- Updated `PieChartSectionData` with new `border` parameter
- Added unit tests for new functionality

## Usage
```dart
PieChartSectionData(
  value: 40,
  color: Colors.blue,
  // Only draw borders on arcs, not on radial lines
  border: PieChartSectionBorder.arcsOnly(
    BorderSide(color: Colors.white, width: 2),
  ),
)
```


Test plan
- [x]  All existing tests pass
- [x]  Added tests for PieChartSectionBorder (constructors, lerp, copyWith, equality)
- [x]  Added tests for drawSectionIndividualBorders
- [x]  Backwards compatibility with deprecated borderSide maintained