### PR TITLE
fix: remove unused borderData from PieChartData

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -29,7 +29,6 @@ class PieChartData extends BaseChartData with EquatableMixin {
     double? sectionsSpace,
     double? startDegreeOffset,
     PieTouchData? pieTouchData,
-    FlBorderData? borderData,
     bool? titleSunbeamLayout,
   })  : sections = sections ?? const [],
         centerSpaceRadius = centerSpaceRadius ?? double.infinity,
@@ -39,7 +38,7 @@ class PieChartData extends BaseChartData with EquatableMixin {
         pieTouchData = pieTouchData ?? PieTouchData(),
         titleSunbeamLayout = titleSunbeamLayout ?? false,
         super(
-          borderData: borderData ?? FlBorderData(show: false),
+          borderData: FlBorderData(show: false),
         );
 
   /// Defines showing sections of the [PieChart].
@@ -80,7 +79,6 @@ class PieChartData extends BaseChartData with EquatableMixin {
     double? sectionsSpace,
     double? startDegreeOffset,
     PieTouchData? pieTouchData,
-    FlBorderData? borderData,
     bool? titleSunbeamLayout,
   }) =>
       PieChartData(
@@ -90,7 +88,6 @@ class PieChartData extends BaseChartData with EquatableMixin {
         sectionsSpace: sectionsSpace ?? this.sectionsSpace,
         startDegreeOffset: startDegreeOffset ?? this.startDegreeOffset,
         pieTouchData: pieTouchData ?? this.pieTouchData,
-        borderData: borderData ?? this.borderData,
         titleSunbeamLayout: titleSunbeamLayout ?? this.titleSunbeamLayout,
       );
 
@@ -99,7 +96,6 @@ class PieChartData extends BaseChartData with EquatableMixin {
   PieChartData lerp(BaseChartData a, BaseChartData b, double t) {
     if (a is PieChartData && b is PieChartData) {
       return PieChartData(
-        borderData: FlBorderData.lerp(a.borderData, b.borderData, t),
         centerSpaceColor: Color.lerp(a.centerSpaceColor, b.centerSpaceColor, t),
         centerSpaceRadius: lerpDoubleAllowInfinity(
           a.centerSpaceRadius,
@@ -127,7 +123,6 @@ class PieChartData extends BaseChartData with EquatableMixin {
         pieTouchData,
         sectionsSpace,
         startDegreeOffset,
-        borderData,
         titleSunbeamLayout,
       ];
 }

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -26,7 +26,6 @@ When you change the chart's state, it animates to the new state internally (usin
 |sectionsSpace| space between the sections (margin of them). It does not work on html-rendere, read more about it [here](https://github.com/imaNNeo/fl_chart/issues/955) |2|
 |startDegreeOffset| degree offset of the sections around the pie chart, should be between 0 and 360|0|
 |pieTouchData| [PieTouchData](#pietouchdata-read-about-touch-handling) holds the touch interactivity details| PieTouchData()|
-|borderData| shows a border around the chart, check the [FlBorderData](base_chart.md#FlBorderData)|FlBorderData()|
 |titleSunbeamLayout| whether to rotate the titles on each section of the chart|false|
 
 

--- a/test/chart/data_pool.dart
+++ b/test/chart/data_pool.dart
@@ -2269,7 +2269,6 @@ final LineChartData lineChartData21 = LineChartData(
 );
 
 final PieChartData pieChartData1 = PieChartData(
-  borderData: FlBorderData(show: false, border: Border.all()),
   startDegreeOffset: 0,
   sections: [
     PieChartSectionData(value: 12, color: Colors.red),

--- a/test/chart/pie_chart/pie_chart_data_test.dart
+++ b/test/chart/pie_chart/pie_chart_data_test.dart
@@ -12,28 +12,6 @@ void main() {
       expect(
         pieChartData1 ==
             pieChartData1Clone.copyWith(
-              borderData: FlBorderData(
-                show: false,
-                border: Border.all(),
-              ),
-            ),
-        true,
-      );
-
-      expect(
-        pieChartData1 ==
-            pieChartData1Clone.copyWith(
-              borderData: FlBorderData(
-                show: true,
-                border: Border.all(),
-              ),
-            ),
-        false,
-      );
-
-      expect(
-        pieChartData1 ==
-            pieChartData1Clone.copyWith(
               startDegreeOffset: 33,
             ),
         false,
@@ -42,10 +20,6 @@ void main() {
       expect(
         pieChartData1 ==
             PieChartData(
-              borderData: FlBorderData(
-                show: false,
-                border: Border.all(),
-              ),
               startDegreeOffset: 0,
               centerSpaceColor: Colors.white,
               centerSpaceRadius: 12,


### PR DESCRIPTION
## Summary
- Removes the unused `borderData` parameter from `PieChartData` constructor, `copyWith`, `lerp`, and equality `props`
- `PieChartPainter` never reads `borderData` from `BaseChartData`, so exposing it on `PieChartData` is misleading — pie chart section borders should be configured via `PieChartSectionData.borderSide`
- Updates tests and documentation to reflect the removal

## Related Issue
Closes #1182

## Test plan
- [x] All 581 existing tests pass (`flutter test`)
- [x] Removed borderData-related equality tests from `pie_chart_data_test.dart`
- [x] Removed borderData from test data pool

🤖 Generated with [Claude Code](https://claude.com/claude-code)