### PR TITLE
fix: Prevent RangeError in badgeWidgetPaint when section count increases

### DIFF
--- a/lib/src/chart/pie_chart/pie_chart_renderer.dart
+++ b/lib/src/chart/pie_chart/pie_chart_renderer.dart
@@ -151,7 +151,7 @@ class RenderPieChart extends RenderBaseChart<PieTouchResponse>
     var counter = 0;
     while (child != null) {
       final childParentData = child.parentData! as MultiChildLayoutParentData;
-      if (data.sections[counter].value > 0) {
+      if (counter < data.sections.length && data.sections[counter].value > 0) {
         context.paintChild(child, childParentData.offset + offset);
       }
       child = childParentData.nextSibling;


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a concise description of what this PR is doing. 
Keep it short and clear, as this text will be included in the permanent Git commit history.
-->
<!-- End of exclude from commit message -->

### 1. Problem

As reported in #1968 and #2029, increasing the number of PieChart sections (e.g., from 3 to 5) while using `badgeWidget` causes a RangeError crash.

### 2. Cause
The root cause is that `counter` exceeds the length of data.sections during the execution of `badgeWidgetPaint`.

https://github.com/imaNNeo/fl_chart/blob/9f74754de6bfa8edb5447529b1bf25b6e132a775/lib/src/chart/pie_chart/pie_chart_renderer.dart#L154

This issue only occurs on the first frame of an animation when the section count increases.

The loop iterates over children based on `targetData` (which always reflects the new data), whereas `data.sections` is determined by `Tween.evaluate(animation)`.

https://github.com/imaNNeo/fl_chart/blob/9f74754de6bfa8edb5447529b1bf25b6e132a775/lib/src/chart/pie_chart/pie_chart.dart#L57-L60

When t == 0.0, [Tween.transform](https://api.flutter.dev/flutter/animation/Tween/transform.html) returns the `begin` value directly.

As a result, on the first frame, `data.sections` still holds the old data (e.g., 3 sections), while the children already reflect the new count (e.g., 5 sections). This length mismatch leads to out-of-bounds access.

### 3. Fix
Added a bounds check (`counter < data.sections.length`) before accessing `data.sections[counter]`. 
This aligns with the guard logic used in [`performLayout` (`counter >= badgeOffsets.length`)](https://github.com/imaNNeo/fl_chart/blob/9f74754de6bfa8edb5447529b1bf25b6e132a775/lib/src/chart/pie_chart/pie_chart_renderer.dart#L119).

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [-] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `example`.


## Breaking Change?
<!--
Would your PR require fl_chart users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version.
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #1968
Closes #2029

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
