### PR TITLE
feat: Support per-side rod borders used for bar chart

### DIFF
--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -120,6 +120,10 @@ class BarChartSample1State extends State<BarChartSample1> {
       x: x,
       barRods: [
         BarChartRodData(
+          borderRadius: BorderRadius.circular(0),
+          border: Border(
+            top: BorderSide(color: Colors.red, width: 6),
+          ),
           toY: isTouched ? y + 1 : y,
           color: isTouched ? widget.touchedBarColor : barColor,
           width: width,
@@ -138,18 +142,17 @@ class BarChartSample1State extends State<BarChartSample1> {
   }
 
   List<BarChartGroupData> showingGroups() => List.generate(
-        7,
-        (i) => switch (i) {
-          0 => makeGroupData(0, 5, isTouched: i == touchedIndex),
-          1 => makeGroupData(1, 6.5, isTouched: i == touchedIndex),
-          2 => makeGroupData(2, 5, isTouched: i == touchedIndex),
-          3 => makeGroupData(3, 7.5, isTouched: i == touchedIndex),
-          4 => makeGroupData(4, 9, isTouched: i == touchedIndex),
-          5 => makeGroupData(5, 11.5, isTouched: i == touchedIndex),
-          6 => makeGroupData(6, 6.5, isTouched: i == touchedIndex),
-          _ => throw Error(),
-        }
-      );
+      7,
+      (i) => switch (i) {
+            0 => makeGroupData(0, 5, isTouched: i == touchedIndex),
+            1 => makeGroupData(1, 6.5, isTouched: i == touchedIndex),
+            2 => makeGroupData(2, 5, isTouched: i == touchedIndex),
+            3 => makeGroupData(3, 7.5, isTouched: i == touchedIndex),
+            4 => makeGroupData(4, 9, isTouched: i == touchedIndex),
+            5 => makeGroupData(5, 11.5, isTouched: i == touchedIndex),
+            6 => makeGroupData(6, 6.5, isTouched: i == touchedIndex),
+            _ => throw Error(),
+          });
 
   BarChartData mainBarData() {
     return BarChartData(

--- a/example/lib/presentation/samples/bar/bar_chart_sample1.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample1.dart
@@ -121,15 +121,14 @@ class BarChartSample1State extends State<BarChartSample1> {
       barRods: [
         BarChartRodData(
           borderRadius: BorderRadius.circular(0),
-          border: Border(
-            top: BorderSide(color: Colors.red, width: 6),
-          ),
+          border: isTouched
+              ? Border.all(color: widget.touchedBarColor.darken(80))
+              : Border(
+                  top: BorderSide(color: Colors.red, width: 6),
+                ),
           toY: isTouched ? y + 1 : y,
           color: isTouched ? widget.touchedBarColor : barColor,
           width: width,
-          borderSide: isTouched
-              ? BorderSide(color: widget.touchedBarColor.darken(80))
-              : const BorderSide(color: Colors.white, width: 0),
           backDrawRodData: BackgroundBarChartRodData(
             show: true,
             toY: 20,

--- a/example/lib/presentation/samples/bar/bar_chart_sample8.dart
+++ b/example/lib/presentation/samples/bar/bar_chart_sample8.dart
@@ -73,7 +73,10 @@ class BarChartSample1State extends State<BarChartSample8> {
           borderRadius: BorderRadius.zero,
           borderDashArray: x >= 4 ? [4, 4] : null,
           width: 22,
-          borderSide: BorderSide(color: widget.barColor, width: 2.0),
+          border: Border.all(
+            color: widget.barColor,
+            width: 2.0,
+          ),
         ),
       ],
     );

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -339,6 +339,10 @@ class BarChartRodData with EquatableMixin {
     double? width,
     BorderRadius? borderRadius,
     this.borderDashArray,
+    @Deprecated(
+      'Use [border] instead. '
+      'This will be removed in the next major release.',
+    )
     BorderSide? borderSide,
     Border? border,
     BackgroundBarChartRodData? backDrawRodData,
@@ -389,6 +393,8 @@ class BarChartRodData with EquatableMixin {
   final List<int>? borderDashArray;
 
   /// If you want to have a border for rod, set this value.
+  ///
+  /// Deprecated: Use [border] for per-side border configuration.
   final BorderSide borderSide;
 
   /// If you want different borders for each side of rod, set this value.
@@ -423,6 +429,10 @@ class BarChartRodData with EquatableMixin {
     double? width,
     BorderRadius? borderRadius,
     List<int>? dashArray,
+    @Deprecated(
+      'Use [border] instead. '
+      'This will be removed in the next major release.',
+    )
     BorderSide? borderSide,
     Border? border,
     BackgroundBarChartRodData? backDrawRodData,
@@ -438,6 +448,7 @@ class BarChartRodData with EquatableMixin {
         width: width ?? this.width,
         borderRadius: borderRadius ?? this.borderRadius,
         borderDashArray: borderDashArray,
+        // ignore: deprecated_member_use_from_same_package, keep fallback for backward compatibility until next major.
         borderSide: borderSide ?? this.borderSide,
         border: border ?? this.border,
         backDrawRodData: backDrawRodData ?? this.backDrawRodData,
@@ -453,6 +464,7 @@ class BarChartRodData with EquatableMixin {
         width: lerpDouble(a.width, b.width, t),
         borderRadius: BorderRadius.lerp(a.borderRadius, b.borderRadius, t),
         borderDashArray: lerpIntList(a.borderDashArray, b.borderDashArray, t),
+        // ignore: deprecated_member_use_from_same_package, keep lerp fallback for backward compatibility until next major.
         borderSide: BorderSide.lerp(a.borderSide, b.borderSide, t),
         border: Border.lerp(a.border, b.border, t),
         fromY: lerpDouble(a.fromY, b.fromY, t),

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -299,20 +299,6 @@ class BarChartGroupData with EquatableMixin {
       ];
 }
 
-Border? _normalizeBorder(Border? border, double width) {
-  if (border == null) {
-    return null;
-  }
-
-  final utils = Utils();
-  return Border(
-    top: utils.normalizeBorderSide(border.top, width),
-    right: utils.normalizeBorderSide(border.right, width),
-    bottom: utils.normalizeBorderSide(border.bottom, width),
-    left: utils.normalizeBorderSide(border.left, width),
-  );
-}
-
 /// Holds data about rendering each rod (or bar) in the [BarChart].
 class BarChartRodData with EquatableMixin {
   /// [BarChart] renders rods vertically from zero to [toY],
@@ -364,7 +350,7 @@ class BarChartRodData with EquatableMixin {
         width = width ?? 8,
         borderRadius = Utils().normalizeBorderRadius(borderRadius, width ?? 8),
         borderSide = Utils().normalizeBorderSide(borderSide, width ?? 8),
-        border = _normalizeBorder(border, width ?? 8),
+        border = Utils().normalizeBorder(border, width ?? 8),
         backDrawRodData = backDrawRodData ?? BackgroundBarChartRodData(),
         rodStackItems = rodStackItems ?? const [];
 

--- a/lib/src/chart/bar_chart/bar_chart_data.dart
+++ b/lib/src/chart/bar_chart/bar_chart_data.dart
@@ -299,12 +299,28 @@ class BarChartGroupData with EquatableMixin {
       ];
 }
 
+Border? _normalizeBorder(Border? border, double width) {
+  if (border == null) {
+    return null;
+  }
+
+  final utils = Utils();
+  return Border(
+    top: utils.normalizeBorderSide(border.top, width),
+    right: utils.normalizeBorderSide(border.right, width),
+    bottom: utils.normalizeBorderSide(border.bottom, width),
+    left: utils.normalizeBorderSide(border.left, width),
+  );
+}
+
 /// Holds data about rendering each rod (or bar) in the [BarChart].
 class BarChartRodData with EquatableMixin {
   /// [BarChart] renders rods vertically from zero to [toY],
   /// and the x is equivalent to the [BarChartGroupData.x] value.
   ///
-  /// It renders each rod using [color], [width], and [borderRadius] for rounding corners and also [borderSide] for stroke border.
+  /// It renders each rod using [color], [width], and [borderRadius] for
+  /// rounding corners and also [borderSide] or [border] for stroke
+  /// border.
   /// Optionally you can use [borderDashArray] if you want your borders to have dashed lines.
   ///
   /// This bar draws with provided [color] or [gradient].
@@ -338,6 +354,7 @@ class BarChartRodData with EquatableMixin {
     BorderRadius? borderRadius,
     this.borderDashArray,
     BorderSide? borderSide,
+    Border? border,
     BackgroundBarChartRodData? backDrawRodData,
     List<BarChartRodStackItem>? rodStackItems,
     this.label = const BarChartRodLabel(show: false),
@@ -347,6 +364,7 @@ class BarChartRodData with EquatableMixin {
         width = width ?? 8,
         borderRadius = Utils().normalizeBorderRadius(borderRadius, width ?? 8),
         borderSide = Utils().normalizeBorderSide(borderSide, width ?? 8),
+        border = _normalizeBorder(border, width ?? 8),
         backDrawRodData = backDrawRodData ?? BackgroundBarChartRodData(),
         rodStackItems = rodStackItems ?? const [];
 
@@ -387,6 +405,12 @@ class BarChartRodData with EquatableMixin {
   /// If you want to have a border for rod, set this value.
   final BorderSide borderSide;
 
+  /// If you want different borders for each side of rod, set this value.
+  ///
+  /// If both [border] and [borderSide] are provided, [border]
+  /// takes precedence in rendering.
+  final Border? border;
+
   /// If you want to have a bar drawn in rear of this rod, use [backDrawRodData],
   /// it uses to have a bar with a passive color in rear of the rod,
   /// for example you can use it as the maximum value place holder.
@@ -414,6 +438,7 @@ class BarChartRodData with EquatableMixin {
     BorderRadius? borderRadius,
     List<int>? dashArray,
     BorderSide? borderSide,
+    Border? border,
     BackgroundBarChartRodData? backDrawRodData,
     List<BarChartRodStackItem>? rodStackItems,
     BarChartRodLabel? label,
@@ -428,6 +453,7 @@ class BarChartRodData with EquatableMixin {
         borderRadius: borderRadius ?? this.borderRadius,
         borderDashArray: borderDashArray,
         borderSide: borderSide ?? this.borderSide,
+        border: border ?? this.border,
         backDrawRodData: backDrawRodData ?? this.backDrawRodData,
         rodStackItems: rodStackItems ?? this.rodStackItems,
         label: label ?? this.label,
@@ -442,6 +468,7 @@ class BarChartRodData with EquatableMixin {
         borderRadius: BorderRadius.lerp(a.borderRadius, b.borderRadius, t),
         borderDashArray: lerpIntList(a.borderDashArray, b.borderDashArray, t),
         borderSide: BorderSide.lerp(a.borderSide, b.borderSide, t),
+        border: Border.lerp(a.border, b.border, t),
         fromY: lerpDouble(a.fromY, b.fromY, t),
         toY: lerpDouble(a.toY, b.toY, t)!,
         toYErrorRange: FlErrorRange.lerp(a.toYErrorRange, b.toYErrorRange, t),
@@ -465,6 +492,7 @@ class BarChartRodData with EquatableMixin {
         borderRadius,
         borderDashArray,
         borderSide,
+        border,
         backDrawRodData,
         rodStackItems,
         color,

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -629,7 +629,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       ..style = PaintingStyle.stroke
       ..color = borderSide.color
       ..strokeWidth = borderSide.width * 2
-      ..strokeCap = StrokeCap.square
+      ..strokeCap = StrokeCap.butt
       ..strokeJoin = StrokeJoin.round;
 
     canvasWrapper

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -14,32 +14,6 @@ import 'package:flutter/material.dart';
 
 enum _BarBorderEdge { top, right, bottom, left }
 
-class _BorderEdgePathConfig {
-  const _BorderEdgePathConfig({
-    required this.startRadius,
-    required this.endRadius,
-    required this.startNoRadiusPoint,
-    required this.startRadiusMovePoint,
-    required this.startRadiusRect,
-    required this.startArcAngle,
-    required this.lineToPoint,
-    required this.endNoRadiusPoint,
-    required this.endRadiusRect,
-    required this.endArcAngle,
-  });
-
-  final Radius startRadius;
-  final Radius endRadius;
-  final Offset startNoRadiusPoint;
-  final Offset startRadiusMovePoint;
-  final Rect startRadiusRect;
-  final double startArcAngle;
-  final Offset lineToPoint;
-  final Offset endNoRadiusPoint;
-  final Rect endRadiusRect;
-  final double endArcAngle;
-}
-
 /// Paints [BarChartData] in the canvas, it can be used in a [CustomPainter]
 class BarChartPainter extends AxisChartPainter<BarChartData> {
   /// Paints [dataList] into canvas, it is the animating [BarChartData],
@@ -506,11 +480,13 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
   }) {
     for (final edge in _BarBorderEdge.values) {
       final borderSide = _borderSideForEdge(border, edge);
-      _drawSingleBarBorderSideFill(
+      _drawPerSideBorderWithClipping(
         canvasWrapper: canvasWrapper,
         barClipPath: barClipPath,
+        barRRect: barRRect,
+        edge: edge,
         borderSide: borderSide,
-        borderRect: _borderRectForEdge(barRRect, borderSide.width, edge),
+        dashArray: null,
       );
     }
   }
@@ -523,10 +499,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
     required List<int> dashArray,
   }) {
     for (final edge in _BarBorderEdge.values) {
-      _drawSingleBarBorderSide(
+      _drawPerSideBorderWithClipping(
         canvasWrapper: canvasWrapper,
         barClipPath: barClipPath,
-        borderPath: _buildBorderPathForEdge(barRRect, edge),
+        barRRect: barRRect,
+        edge: edge,
         borderSide: _borderSideForEdge(border, edge),
         dashArray: dashArray,
       );
@@ -569,55 +546,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
           ),
       };
 
-  Path _buildBorderPathForEdge(RRect barRRect, _BarBorderEdge edge) {
-    final config = _buildBorderEdgePathConfig(barRRect, edge);
-    final path = Path();
-
-    if (_hasRadius(config.startRadius)) {
-      path
-        ..moveTo(config.startRadiusMovePoint.dx, config.startRadiusMovePoint.dy)
-        ..addArc(config.startRadiusRect, config.startArcAngle, pi / 2);
-    } else {
-      path.moveTo(config.startNoRadiusPoint.dx, config.startNoRadiusPoint.dy);
-    }
-
-    path.lineTo(config.lineToPoint.dx, config.lineToPoint.dy);
-
-    if (_hasRadius(config.endRadius)) {
-      path.addArc(config.endRadiusRect, config.endArcAngle, pi / 2);
-    } else {
-      path.lineTo(config.endNoRadiusPoint.dx, config.endNoRadiusPoint.dy);
-    }
-
-    return path;
-  }
-
-  void _drawSingleBarBorderSideFill({
+  void _drawPerSideBorderWithClipping({
     required CanvasWrapper canvasWrapper,
     required Path barClipPath,
-    required BorderSide borderSide,
-    required Rect borderRect,
-  }) {
-    if (borderSide.width <= 0 || borderSide.color.a <= 0) {
-      return;
-    }
-
-    _barStrokePaint
-      ..style = PaintingStyle.fill
-      ..color = borderSide.color;
-
-    final borderPath = Path()..addRect(borderRect);
-    canvasWrapper
-      ..save()
-      ..clipPath(barClipPath)
-      ..drawPath(borderPath, _barStrokePaint)
-      ..restore();
-  }
-
-  void _drawSingleBarBorderSide({
-    required CanvasWrapper canvasWrapper,
-    required Path barClipPath,
-    required Path borderPath,
+    required RRect barRRect,
+    required _BarBorderEdge edge,
     required BorderSide borderSide,
     required List<int>? dashArray,
   }) {
@@ -630,137 +563,17 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       ..color = borderSide.color
       ..strokeWidth = borderSide.width * 2
       ..strokeCap = StrokeCap.butt
-      ..strokeJoin = StrokeJoin.round;
+      ..strokeJoin = StrokeJoin.miter;
+
+    final borderPath = Path()..addRRect(barRRect);
 
     canvasWrapper
       ..save()
+      ..clipRect(_borderRectForEdge(barRRect, borderSide.width, edge))
       ..clipPath(barClipPath)
       ..drawPath(borderPath.toDashedPath(dashArray), _barStrokePaint)
       ..restore();
   }
-
-  bool _hasRadius(Radius radius) => radius.x > 0 && radius.y > 0;
-
-  Rect _radiusRect({
-    required double left,
-    required double top,
-    required double radiusX,
-    required double radiusY,
-  }) =>
-      Rect.fromLTWH(left, top, radiusX * 2, radiusY * 2);
-
-  _BorderEdgePathConfig _buildBorderEdgePathConfig(
-    RRect barRRect,
-    _BarBorderEdge edge,
-  ) =>
-      switch (edge) {
-        _BarBorderEdge.top => _BorderEdgePathConfig(
-            startRadius: barRRect.tlRadius,
-            endRadius: barRRect.trRadius,
-            startNoRadiusPoint: Offset(barRRect.left, barRRect.top),
-            startRadiusMovePoint: Offset(
-              barRRect.left,
-              barRRect.top + barRRect.tlRadiusY,
-            ),
-            startRadiusRect: _radiusRect(
-              left: barRRect.left,
-              top: barRRect.top,
-              radiusX: barRRect.tlRadiusX,
-              radiusY: barRRect.tlRadiusY,
-            ),
-            startArcAngle: pi,
-            lineToPoint:
-                Offset(barRRect.right - barRRect.trRadiusX, barRRect.top),
-            endNoRadiusPoint: Offset(barRRect.right, barRRect.top),
-            endRadiusRect: _radiusRect(
-              left: barRRect.right - (barRRect.trRadiusX * 2),
-              top: barRRect.top,
-              radiusX: barRRect.trRadiusX,
-              radiusY: barRRect.trRadiusY,
-            ),
-            endArcAngle: -pi / 2,
-          ),
-        _BarBorderEdge.right => _BorderEdgePathConfig(
-            startRadius: barRRect.trRadius,
-            endRadius: barRRect.brRadius,
-            startNoRadiusPoint: Offset(barRRect.right, barRRect.top),
-            startRadiusMovePoint: Offset(
-              barRRect.right - barRRect.trRadiusX,
-              barRRect.top,
-            ),
-            startRadiusRect: _radiusRect(
-              left: barRRect.right - (barRRect.trRadiusX * 2),
-              top: barRRect.top,
-              radiusX: barRRect.trRadiusX,
-              radiusY: barRRect.trRadiusY,
-            ),
-            startArcAngle: -pi / 2,
-            lineToPoint: Offset(
-              barRRect.right,
-              barRRect.bottom - barRRect.brRadiusY,
-            ),
-            endNoRadiusPoint: Offset(barRRect.right, barRRect.bottom),
-            endRadiusRect: _radiusRect(
-              left: barRRect.right - (barRRect.brRadiusX * 2),
-              top: barRRect.bottom - (barRRect.brRadiusY * 2),
-              radiusX: barRRect.brRadiusX,
-              radiusY: barRRect.brRadiusY,
-            ),
-            endArcAngle: 0,
-          ),
-        _BarBorderEdge.bottom => _BorderEdgePathConfig(
-            startRadius: barRRect.brRadius,
-            endRadius: barRRect.blRadius,
-            startNoRadiusPoint: Offset(barRRect.right, barRRect.bottom),
-            startRadiusMovePoint: Offset(
-              barRRect.right,
-              barRRect.bottom - barRRect.brRadiusY,
-            ),
-            startRadiusRect: _radiusRect(
-              left: barRRect.right - (barRRect.brRadiusX * 2),
-              top: barRRect.bottom - (barRRect.brRadiusY * 2),
-              radiusX: barRRect.brRadiusX,
-              radiusY: barRRect.brRadiusY,
-            ),
-            startArcAngle: 0,
-            lineToPoint:
-                Offset(barRRect.left + barRRect.blRadiusX, barRRect.bottom),
-            endNoRadiusPoint: Offset(barRRect.left, barRRect.bottom),
-            endRadiusRect: _radiusRect(
-              left: barRRect.left,
-              top: barRRect.bottom - (barRRect.blRadiusY * 2),
-              radiusX: barRRect.blRadiusX,
-              radiusY: barRRect.blRadiusY,
-            ),
-            endArcAngle: pi / 2,
-          ),
-        _BarBorderEdge.left => _BorderEdgePathConfig(
-            startRadius: barRRect.blRadius,
-            endRadius: barRRect.tlRadius,
-            startNoRadiusPoint: Offset(barRRect.left, barRRect.bottom),
-            startRadiusMovePoint: Offset(
-              barRRect.left + barRRect.blRadiusX,
-              barRRect.bottom,
-            ),
-            startRadiusRect: _radiusRect(
-              left: barRRect.left,
-              top: barRRect.bottom - (barRRect.blRadiusY * 2),
-              radiusX: barRRect.blRadiusX,
-              radiusY: barRRect.blRadiusY,
-            ),
-            startArcAngle: pi / 2,
-            lineToPoint:
-                Offset(barRRect.left, barRRect.top + barRRect.tlRadiusY),
-            endNoRadiusPoint: Offset(barRRect.left, barRRect.top),
-            endRadiusRect: _radiusRect(
-              left: barRRect.left,
-              top: barRRect.top,
-              radiusX: barRRect.tlRadiusX,
-              radiusY: barRRect.tlRadiusY,
-            ),
-            endArcAngle: pi,
-          ),
-      };
 
   @visibleForTesting
   void drawBarLabels(

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -437,6 +437,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
     BorderSide fallbackBorderSide,
   ) {
     final barClipPath = Path()..addRRect(barRRect);
+    final dashArray = barRod.borderDashArray;
     final border = barRod.border;
     if (border == null) {
       _drawUniformBarBorderStroke(
@@ -444,12 +445,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
         barClipPath: barClipPath,
         barRRect: barRRect,
         borderSide: fallbackBorderSide,
-        dashArray: barRod.borderDashArray,
+        dashArray: dashArray,
       );
       return;
     }
 
-    final dashArray = barRod.borderDashArray;
     if (dashArray == null) {
       _drawSolidPerSideBarBorder(
         canvasWrapper: canvasWrapper,

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -410,13 +410,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
     BarChartRodData barRod,
     BorderSide fallbackBorderSide,
   ) {
-    final barClipPath = Path()..addRRect(barRRect);
     final dashArray = barRod.borderDashArray;
     final border = barRod.border;
     if (border == null) {
       _drawUniformBarBorderStroke(
         canvasWrapper: canvasWrapper,
-        barClipPath: barClipPath,
         barRRect: barRRect,
         borderSide: fallbackBorderSide,
         dashArray: dashArray,
@@ -424,19 +422,18 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       return;
     }
 
-    if (dashArray == null) {
-      _drawSolidPerSideBarBorder(
+    if (border.isUniform) {
+      _drawUniformBarBorderStroke(
         canvasWrapper: canvasWrapper,
-        barClipPath: barClipPath,
         barRRect: barRRect,
-        border: border,
+        borderSide: border.top,
+        dashArray: dashArray,
       );
       return;
     }
 
-    _drawDashedPerSideBarBorder(
+    _drawPerSideBarBorderStroke(
       canvasWrapper: canvasWrapper,
-      barClipPath: barClipPath,
       barRRect: barRRect,
       border: border,
       dashArray: dashArray,
@@ -445,7 +442,6 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
 
   void _drawUniformBarBorderStroke({
     required CanvasWrapper canvasWrapper,
-    required Path barClipPath,
     required RRect barRRect,
     required BorderSide borderSide,
     required List<int>? dashArray,
@@ -457,54 +453,35 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
     _barStrokePaint
       ..style = PaintingStyle.stroke
       ..color = borderSide.color
-      ..strokeWidth = borderSide.width * 2
+      ..strokeWidth = borderSide.width
       ..strokeCap = StrokeCap.butt
       ..strokeJoin = StrokeJoin.miter;
 
     final borderPath = Path()..addRRect(barRRect);
-    canvasWrapper
-      ..save()
-      ..clipPath(barClipPath)
-      ..drawPath(
-        borderPath.toDashedPath(dashArray),
-        _barStrokePaint,
-      )
-      ..restore();
+    canvasWrapper.drawPath(
+      borderPath.toDashedPath(dashArray),
+      _barStrokePaint,
+    );
   }
 
-  void _drawSolidPerSideBarBorder({
+  void _drawPerSideBarBorderStroke({
     required CanvasWrapper canvasWrapper,
-    required Path barClipPath,
     required RRect barRRect,
     required Border border,
+    required List<int>? dashArray,
   }) {
     for (final edge in _BarBorderEdge.values) {
       final borderSide = _borderSideForEdge(border, edge);
       _drawPerSideBorderWithClipping(
         canvasWrapper: canvasWrapper,
-        barClipPath: barClipPath,
         barRRect: barRRect,
-        edge: edge,
         borderSide: borderSide,
-        dashArray: null,
-      );
-    }
-  }
-
-  void _drawDashedPerSideBarBorder({
-    required CanvasWrapper canvasWrapper,
-    required Path barClipPath,
-    required RRect barRRect,
-    required Border border,
-    required List<int> dashArray,
-  }) {
-    for (final edge in _BarBorderEdge.values) {
-      _drawPerSideBorderWithClipping(
-        canvasWrapper: canvasWrapper,
-        barClipPath: barClipPath,
-        barRRect: barRRect,
-        edge: edge,
-        borderSide: _borderSideForEdge(border, edge),
+        borderRect: _borderRectForEdge(
+          barRRect: barRRect,
+          border: border,
+          edge: edge,
+          width: borderSide.width,
+        ),
         dashArray: dashArray,
       );
     }
@@ -518,40 +495,75 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
         _BarBorderEdge.left => border.left,
       };
 
-  Rect _borderRectForEdge(RRect barRRect, double width, _BarBorderEdge edge) =>
+  bool _isVisibleBorderSide(BorderSide side) =>
+      side.width > 0 && side.color.a > 0;
+
+  (BorderSide start, BorderSide end) _edgeNeighbors(
+    Border border,
+    _BarBorderEdge edge,
+  ) =>
       switch (edge) {
-        _BarBorderEdge.top => Rect.fromLTRB(
-            barRRect.left,
-            barRRect.top,
-            barRRect.right,
-            barRRect.top + width,
+        _BarBorderEdge.top => (
+            border.left,
+            border.right,
           ),
-        _BarBorderEdge.right => Rect.fromLTRB(
-            barRRect.right - width,
-            barRRect.top,
-            barRRect.right,
-            barRRect.bottom,
+        _BarBorderEdge.right => (
+            border.top,
+            border.bottom,
           ),
-        _BarBorderEdge.bottom => Rect.fromLTRB(
-            barRRect.left,
-            barRRect.bottom - width,
-            barRRect.right,
-            barRRect.bottom,
+        _BarBorderEdge.bottom => (
+            border.left,
+            border.right,
           ),
-        _BarBorderEdge.left => Rect.fromLTRB(
-            barRRect.left,
-            barRRect.top,
-            barRRect.left + width,
-            barRRect.bottom,
+        _BarBorderEdge.left => (
+            border.top,
+            border.bottom,
           ),
       };
 
+  Rect _borderRectForEdge({
+    required RRect barRRect,
+    required Border border,
+    required double width,
+    required _BarBorderEdge edge,
+  }) {
+    final halfWidth = width / 2;
+    final neighbors = _edgeNeighbors(border, edge);
+    final extendStart = _isVisibleBorderSide(neighbors.$1);
+    final extendEnd = _isVisibleBorderSide(neighbors.$2);
+    return switch (edge) {
+      _BarBorderEdge.top => Rect.fromLTRB(
+          barRRect.left - (extendStart ? halfWidth : 0),
+          barRRect.top - halfWidth,
+          barRRect.right + (extendEnd ? halfWidth : 0),
+          barRRect.top + halfWidth,
+        ),
+      _BarBorderEdge.right => Rect.fromLTRB(
+          barRRect.right - halfWidth,
+          barRRect.top - (extendStart ? halfWidth : 0),
+          barRRect.right + halfWidth,
+          barRRect.bottom + (extendEnd ? halfWidth : 0),
+        ),
+      _BarBorderEdge.bottom => Rect.fromLTRB(
+          barRRect.left - (extendStart ? halfWidth : 0),
+          barRRect.bottom - halfWidth,
+          barRRect.right + (extendEnd ? halfWidth : 0),
+          barRRect.bottom + halfWidth,
+        ),
+      _BarBorderEdge.left => Rect.fromLTRB(
+          barRRect.left - halfWidth,
+          barRRect.top - (extendStart ? halfWidth : 0),
+          barRRect.left + halfWidth,
+          barRRect.bottom + (extendEnd ? halfWidth : 0),
+        ),
+    };
+  }
+
   void _drawPerSideBorderWithClipping({
     required CanvasWrapper canvasWrapper,
-    required Path barClipPath,
     required RRect barRRect,
-    required _BarBorderEdge edge,
     required BorderSide borderSide,
+    required Rect borderRect,
     required List<int>? dashArray,
   }) {
     if (borderSide.width <= 0 || borderSide.color.a <= 0) {
@@ -561,7 +573,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
     _barStrokePaint
       ..style = PaintingStyle.stroke
       ..color = borderSide.color
-      ..strokeWidth = borderSide.width * 2
+      ..strokeWidth = borderSide.width
       ..strokeCap = StrokeCap.butt
       ..strokeJoin = StrokeJoin.miter;
 
@@ -569,8 +581,7 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
 
     canvasWrapper
       ..save()
-      ..clipRect(_borderRectForEdge(barRRect, borderSide.width, edge))
-      ..clipPath(barClipPath)
+      ..clipRect(borderRect)
       ..drawPath(borderPath.toDashedPath(dashArray), _barStrokePaint)
       ..restore();
   }

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -12,6 +12,34 @@ import 'package:fl_chart/src/utils/canvas_wrapper.dart';
 import 'package:fl_chart/src/utils/utils.dart';
 import 'package:flutter/material.dart';
 
+enum _BarBorderEdge { top, right, bottom, left }
+
+class _BorderEdgePathConfig {
+  const _BorderEdgePathConfig({
+    required this.startRadius,
+    required this.endRadius,
+    required this.startNoRadiusPoint,
+    required this.startRadiusMovePoint,
+    required this.startRadiusRect,
+    required this.startArcAngle,
+    required this.lineToPoint,
+    required this.endNoRadiusPoint,
+    required this.endRadiusRect,
+    required this.endArcAngle,
+  });
+
+  final Radius startRadius;
+  final Radius endRadius;
+  final Offset startNoRadiusPoint;
+  final Offset startRadiusMovePoint;
+  final Rect startRadiusRect;
+  final double startArcAngle;
+  final Offset lineToPoint;
+  final Offset endNoRadiusPoint;
+  final Rect endRadiusRect;
+  final double endArcAngle;
+}
+
 /// Paints [BarChartData] in the canvas, it can be used in a [CustomPainter]
 class BarChartPainter extends AxisChartPainter<BarChartData> {
   /// Paints [dataList] into canvas, it is the animating [BarChartData],
@@ -396,25 +424,343 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
             }
           }
 
-          // draw border stroke
-          if (borderSide.width > 0 && borderSide.color.a > 0) {
-            _barStrokePaint
-              ..color = borderSide.color
-              ..strokeWidth = borderSide.width;
-
-            final borderPath = Path()..addRRect(barRRect);
-
-            canvasWrapper.drawPath(
-              borderPath.toDashedPath(
-                barRod.borderDashArray,
-              ),
-              _barStrokePaint,
-            );
-          }
+          _drawBarBorderStroke(canvasWrapper, barRRect, barRod, borderSide);
         }
       }
     }
   }
+
+  void _drawBarBorderStroke(
+    CanvasWrapper canvasWrapper,
+    RRect barRRect,
+    BarChartRodData barRod,
+    BorderSide fallbackBorderSide,
+  ) {
+    final barClipPath = Path()..addRRect(barRRect);
+    final border = barRod.border;
+    if (border == null) {
+      _drawUniformBarBorderStroke(
+        canvasWrapper: canvasWrapper,
+        barClipPath: barClipPath,
+        barRRect: barRRect,
+        borderSide: fallbackBorderSide,
+        dashArray: barRod.borderDashArray,
+      );
+      return;
+    }
+
+    final dashArray = barRod.borderDashArray;
+    if (dashArray == null) {
+      _drawSolidPerSideBarBorder(
+        canvasWrapper: canvasWrapper,
+        barClipPath: barClipPath,
+        barRRect: barRRect,
+        border: border,
+      );
+      return;
+    }
+
+    _drawDashedPerSideBarBorder(
+      canvasWrapper: canvasWrapper,
+      barClipPath: barClipPath,
+      barRRect: barRRect,
+      border: border,
+      dashArray: dashArray,
+    );
+  }
+
+  void _drawUniformBarBorderStroke({
+    required CanvasWrapper canvasWrapper,
+    required Path barClipPath,
+    required RRect barRRect,
+    required BorderSide borderSide,
+    required List<int>? dashArray,
+  }) {
+    if (borderSide.width <= 0 || borderSide.color.a <= 0) {
+      return;
+    }
+
+    _barStrokePaint
+      ..style = PaintingStyle.stroke
+      ..color = borderSide.color
+      ..strokeWidth = borderSide.width * 2
+      ..strokeCap = StrokeCap.butt
+      ..strokeJoin = StrokeJoin.miter;
+
+    final borderPath = Path()..addRRect(barRRect);
+    canvasWrapper
+      ..save()
+      ..clipPath(barClipPath)
+      ..drawPath(
+        borderPath.toDashedPath(dashArray),
+        _barStrokePaint,
+      )
+      ..restore();
+  }
+
+  void _drawSolidPerSideBarBorder({
+    required CanvasWrapper canvasWrapper,
+    required Path barClipPath,
+    required RRect barRRect,
+    required Border border,
+  }) {
+    for (final edge in _BarBorderEdge.values) {
+      final borderSide = _borderSideForEdge(border, edge);
+      _drawSingleBarBorderSideFill(
+        canvasWrapper: canvasWrapper,
+        barClipPath: barClipPath,
+        borderSide: borderSide,
+        borderRect: _borderRectForEdge(barRRect, borderSide.width, edge),
+      );
+    }
+  }
+
+  void _drawDashedPerSideBarBorder({
+    required CanvasWrapper canvasWrapper,
+    required Path barClipPath,
+    required RRect barRRect,
+    required Border border,
+    required List<int> dashArray,
+  }) {
+    for (final edge in _BarBorderEdge.values) {
+      _drawSingleBarBorderSide(
+        canvasWrapper: canvasWrapper,
+        barClipPath: barClipPath,
+        borderPath: _buildBorderPathForEdge(barRRect, edge),
+        borderSide: _borderSideForEdge(border, edge),
+        dashArray: dashArray,
+      );
+    }
+  }
+
+  BorderSide _borderSideForEdge(Border border, _BarBorderEdge edge) =>
+      switch (edge) {
+        _BarBorderEdge.top => border.top,
+        _BarBorderEdge.right => border.right,
+        _BarBorderEdge.bottom => border.bottom,
+        _BarBorderEdge.left => border.left,
+      };
+
+  Rect _borderRectForEdge(RRect barRRect, double width, _BarBorderEdge edge) =>
+      switch (edge) {
+        _BarBorderEdge.top => Rect.fromLTRB(
+            barRRect.left,
+            barRRect.top,
+            barRRect.right,
+            barRRect.top + width,
+          ),
+        _BarBorderEdge.right => Rect.fromLTRB(
+            barRRect.right - width,
+            barRRect.top,
+            barRRect.right,
+            barRRect.bottom,
+          ),
+        _BarBorderEdge.bottom => Rect.fromLTRB(
+            barRRect.left,
+            barRRect.bottom - width,
+            barRRect.right,
+            barRRect.bottom,
+          ),
+        _BarBorderEdge.left => Rect.fromLTRB(
+            barRRect.left,
+            barRRect.top,
+            barRRect.left + width,
+            barRRect.bottom,
+          ),
+      };
+
+  Path _buildBorderPathForEdge(RRect barRRect, _BarBorderEdge edge) {
+    final config = _buildBorderEdgePathConfig(barRRect, edge);
+    final path = Path();
+
+    if (_hasRadius(config.startRadius)) {
+      path
+        ..moveTo(config.startRadiusMovePoint.dx, config.startRadiusMovePoint.dy)
+        ..addArc(config.startRadiusRect, config.startArcAngle, pi / 2);
+    } else {
+      path.moveTo(config.startNoRadiusPoint.dx, config.startNoRadiusPoint.dy);
+    }
+
+    path.lineTo(config.lineToPoint.dx, config.lineToPoint.dy);
+
+    if (_hasRadius(config.endRadius)) {
+      path.addArc(config.endRadiusRect, config.endArcAngle, pi / 2);
+    } else {
+      path.lineTo(config.endNoRadiusPoint.dx, config.endNoRadiusPoint.dy);
+    }
+
+    return path;
+  }
+
+  void _drawSingleBarBorderSideFill({
+    required CanvasWrapper canvasWrapper,
+    required Path barClipPath,
+    required BorderSide borderSide,
+    required Rect borderRect,
+  }) {
+    if (borderSide.width <= 0 || borderSide.color.a <= 0) {
+      return;
+    }
+
+    _barStrokePaint
+      ..style = PaintingStyle.fill
+      ..color = borderSide.color;
+
+    final borderPath = Path()..addRect(borderRect);
+    canvasWrapper
+      ..save()
+      ..clipPath(barClipPath)
+      ..drawPath(borderPath, _barStrokePaint)
+      ..restore();
+  }
+
+  void _drawSingleBarBorderSide({
+    required CanvasWrapper canvasWrapper,
+    required Path barClipPath,
+    required Path borderPath,
+    required BorderSide borderSide,
+    required List<int>? dashArray,
+  }) {
+    if (borderSide.width <= 0 || borderSide.color.a <= 0) {
+      return;
+    }
+
+    _barStrokePaint
+      ..style = PaintingStyle.stroke
+      ..color = borderSide.color
+      ..strokeWidth = borderSide.width * 2
+      ..strokeCap = StrokeCap.square
+      ..strokeJoin = StrokeJoin.round;
+
+    canvasWrapper
+      ..save()
+      ..clipPath(barClipPath)
+      ..drawPath(borderPath.toDashedPath(dashArray), _barStrokePaint)
+      ..restore();
+  }
+
+  bool _hasRadius(Radius radius) => radius.x > 0 && radius.y > 0;
+
+  Rect _radiusRect({
+    required double left,
+    required double top,
+    required double radiusX,
+    required double radiusY,
+  }) =>
+      Rect.fromLTWH(left, top, radiusX * 2, radiusY * 2);
+
+  _BorderEdgePathConfig _buildBorderEdgePathConfig(
+    RRect barRRect,
+    _BarBorderEdge edge,
+  ) =>
+      switch (edge) {
+        _BarBorderEdge.top => _BorderEdgePathConfig(
+            startRadius: barRRect.tlRadius,
+            endRadius: barRRect.trRadius,
+            startNoRadiusPoint: Offset(barRRect.left, barRRect.top),
+            startRadiusMovePoint: Offset(
+              barRRect.left,
+              barRRect.top + barRRect.tlRadiusY,
+            ),
+            startRadiusRect: _radiusRect(
+              left: barRRect.left,
+              top: barRRect.top,
+              radiusX: barRRect.tlRadiusX,
+              radiusY: barRRect.tlRadiusY,
+            ),
+            startArcAngle: pi,
+            lineToPoint:
+                Offset(barRRect.right - barRRect.trRadiusX, barRRect.top),
+            endNoRadiusPoint: Offset(barRRect.right, barRRect.top),
+            endRadiusRect: _radiusRect(
+              left: barRRect.right - (barRRect.trRadiusX * 2),
+              top: barRRect.top,
+              radiusX: barRRect.trRadiusX,
+              radiusY: barRRect.trRadiusY,
+            ),
+            endArcAngle: -pi / 2,
+          ),
+        _BarBorderEdge.right => _BorderEdgePathConfig(
+            startRadius: barRRect.trRadius,
+            endRadius: barRRect.brRadius,
+            startNoRadiusPoint: Offset(barRRect.right, barRRect.top),
+            startRadiusMovePoint: Offset(
+              barRRect.right - barRRect.trRadiusX,
+              barRRect.top,
+            ),
+            startRadiusRect: _radiusRect(
+              left: barRRect.right - (barRRect.trRadiusX * 2),
+              top: barRRect.top,
+              radiusX: barRRect.trRadiusX,
+              radiusY: barRRect.trRadiusY,
+            ),
+            startArcAngle: -pi / 2,
+            lineToPoint: Offset(
+              barRRect.right,
+              barRRect.bottom - barRRect.brRadiusY,
+            ),
+            endNoRadiusPoint: Offset(barRRect.right, barRRect.bottom),
+            endRadiusRect: _radiusRect(
+              left: barRRect.right - (barRRect.brRadiusX * 2),
+              top: barRRect.bottom - (barRRect.brRadiusY * 2),
+              radiusX: barRRect.brRadiusX,
+              radiusY: barRRect.brRadiusY,
+            ),
+            endArcAngle: 0,
+          ),
+        _BarBorderEdge.bottom => _BorderEdgePathConfig(
+            startRadius: barRRect.brRadius,
+            endRadius: barRRect.blRadius,
+            startNoRadiusPoint: Offset(barRRect.right, barRRect.bottom),
+            startRadiusMovePoint: Offset(
+              barRRect.right,
+              barRRect.bottom - barRRect.brRadiusY,
+            ),
+            startRadiusRect: _radiusRect(
+              left: barRRect.right - (barRRect.brRadiusX * 2),
+              top: barRRect.bottom - (barRRect.brRadiusY * 2),
+              radiusX: barRRect.brRadiusX,
+              radiusY: barRRect.brRadiusY,
+            ),
+            startArcAngle: 0,
+            lineToPoint:
+                Offset(barRRect.left + barRRect.blRadiusX, barRRect.bottom),
+            endNoRadiusPoint: Offset(barRRect.left, barRRect.bottom),
+            endRadiusRect: _radiusRect(
+              left: barRRect.left,
+              top: barRRect.bottom - (barRRect.blRadiusY * 2),
+              radiusX: barRRect.blRadiusX,
+              radiusY: barRRect.blRadiusY,
+            ),
+            endArcAngle: pi / 2,
+          ),
+        _BarBorderEdge.left => _BorderEdgePathConfig(
+            startRadius: barRRect.blRadius,
+            endRadius: barRRect.tlRadius,
+            startNoRadiusPoint: Offset(barRRect.left, barRRect.bottom),
+            startRadiusMovePoint: Offset(
+              barRRect.left + barRRect.blRadiusX,
+              barRRect.bottom,
+            ),
+            startRadiusRect: _radiusRect(
+              left: barRRect.left,
+              top: barRRect.bottom - (barRRect.blRadiusY * 2),
+              radiusX: barRRect.blRadiusX,
+              radiusY: barRRect.blRadiusY,
+            ),
+            startArcAngle: pi / 2,
+            lineToPoint:
+                Offset(barRRect.left, barRRect.top + barRRect.tlRadiusY),
+            endNoRadiusPoint: Offset(barRRect.left, barRRect.top),
+            endRadiusRect: _radiusRect(
+              left: barRRect.left,
+              top: barRRect.top,
+              radiusX: barRRect.tlRadiusX,
+              radiusY: barRRect.tlRadiusY,
+            ),
+            endArcAngle: pi,
+          ),
+      };
 
   @visibleForTesting
   void drawBarLabels(
@@ -813,8 +1159,11 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
       );
     }
     _barStrokePaint
+      ..style = PaintingStyle.stroke
       ..color = stackItem.borderSide.color
-      ..strokeWidth = min(stackItem.borderSide.width, barThickSize / 2);
+      ..strokeWidth = min(stackItem.borderSide.width, barThickSize / 2)
+      ..strokeCap = StrokeCap.butt
+      ..strokeJoin = StrokeJoin.miter;
     canvasWrapper.drawRRect(strokeBarRect, _barStrokePaint);
   }
 

--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -470,6 +470,15 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
     required Border border,
     required List<int>? dashArray,
   }) {
+    if (dashArray == null && !_hasFullVisibleBorder(border)) {
+      _drawInsideNonUniformBorderUsingBoxBorder(
+        canvasWrapper: canvasWrapper,
+        barRRect: barRRect,
+        border: border,
+      );
+      return;
+    }
+
     for (final edge in _BarBorderEdge.values) {
       final borderSide = _borderSideForEdge(border, edge);
       _drawPerSideBorderWithClipping(
@@ -497,6 +506,51 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
 
   bool _isVisibleBorderSide(BorderSide side) =>
       side.width > 0 && side.color.a > 0;
+
+  bool _hasFullVisibleBorder(Border border) =>
+      _BarBorderEdge.values.every((edge) {
+        return _isVisibleBorderSide(_borderSideForEdge(border, edge));
+      });
+
+  void _drawInsideNonUniformBorderUsingBoxBorder({
+    required CanvasWrapper canvasWrapper,
+    required RRect barRRect,
+    required Border border,
+  }) {
+    final colors = <Color>{};
+    for (final edge in _BarBorderEdge.values) {
+      final side = _borderSideForEdge(border, edge);
+      if (_isVisibleBorderSide(side)) {
+        colors.add(side.color);
+      }
+    }
+
+    for (final color in colors) {
+      BoxBorder.paintNonUniformBorder(
+        canvasWrapper.canvas,
+        barRRect.getRect(),
+        borderRadius: BorderRadius.only(
+          topLeft: barRRect.tlRadius,
+          topRight: barRRect.trRadius,
+          bottomRight: barRRect.brRadius,
+          bottomLeft: barRRect.blRadius,
+        ),
+        textDirection: TextDirection.ltr,
+        top: _borderSideForColor(border.top, color),
+        right: _borderSideForColor(border.right, color),
+        bottom: _borderSideForColor(border.bottom, color),
+        left: _borderSideForColor(border.left, color),
+        color: color,
+      );
+    }
+  }
+
+  BorderSide _borderSideForColor(BorderSide side, Color color) {
+    if (!_isVisibleBorderSide(side) || side.color != color) {
+      return BorderSide.none;
+    }
+    return side;
+  }
 
   (BorderSide start, BorderSide end) _edgeNeighbors(
     Border border,

--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -107,6 +107,20 @@ class Utils {
     return borderSide.copyWith(width: borderWidth);
   }
 
+  /// Decreases each side of [border] to <= width / 2.
+  Border? normalizeBorder(Border? border, double width) {
+    if (border == null) {
+      return null;
+    }
+
+    return Border(
+      top: normalizeBorderSide(border.top, width),
+      right: normalizeBorderSide(border.right, width),
+      bottom: normalizeBorderSide(border.bottom, width),
+      left: normalizeBorderSide(border.left, width),
+    );
+  }
+
   /// Returns an efficient interval for showing axis titles, or grid lines or ...
   ///
   /// If there isn't any provided interval, we use this function to calculate an interval to apply,

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -57,7 +57,7 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
 |width|stroke width of the rod bar|8|
 |borderRadius|Determines the edge rounding of the bar corners, see [BorderRadius](https://api.flutter.dev/flutter/painting/BorderRadius-class.html). When `null`, it defaults to completely round bars. |null|
 |borderDashArray|Determines whether the border stroke is dashed. It is a circular array of dash offsets and lengths. For example, the array `[5, 10]` would result in dashes 5 pixels long followed by blank spaces 10 pixels long. The array `[5, 10, 5]` would result in a 5 pixel dash, a 10 pixel gap, a 5 pixel dash, a 5 pixel gap, a 10 pixel dash, etc.|null|
-|borderSide|Determines the border stroke around the bar, see [BorderSide](https://api.flutter.dev/flutter/painting/BorderSide-class.html). When `null`, it defaults to drawing no stroke. |null|
+|borderSide|**Deprecated**. Determines the border stroke around the bar, see [BorderSide](https://api.flutter.dev/flutter/painting/BorderSide-class.html). Use `border` instead. When `null`, it defaults to drawing no stroke. |null|
 |border|Determines the border stroke per-side, see [Border](https://api.flutter.dev/flutter/painting/Border-class.html). When provided, it takes precedence over `borderSide`. |null|
 |backDrawRodData|if provided, draws a rod in the background of the line bar, check the [BackgroundBarChartRodData](#BackgroundBarChartRodData)|null|
 |rodStackItem|if you want to have a stacked bar chart, provide a list of [BarChartRodStackItem](#BarChartRodStackItem), it will draw over your rod.|[]|

--- a/repo_files/documentations/bar_chart.md
+++ b/repo_files/documentations/bar_chart.md
@@ -58,6 +58,7 @@ enum values {`start`, `end`, `center`, `spaceEvenly`, `spaceAround`, `spaceBetwe
 |borderRadius|Determines the edge rounding of the bar corners, see [BorderRadius](https://api.flutter.dev/flutter/painting/BorderRadius-class.html). When `null`, it defaults to completely round bars. |null|
 |borderDashArray|Determines whether the border stroke is dashed. It is a circular array of dash offsets and lengths. For example, the array `[5, 10]` would result in dashes 5 pixels long followed by blank spaces 10 pixels long. The array `[5, 10, 5]` would result in a 5 pixel dash, a 10 pixel gap, a 5 pixel dash, a 5 pixel gap, a 10 pixel dash, etc.|null|
 |borderSide|Determines the border stroke around the bar, see [BorderSide](https://api.flutter.dev/flutter/painting/BorderSide-class.html). When `null`, it defaults to drawing no stroke. |null|
+|border|Determines the border stroke per-side, see [Border](https://api.flutter.dev/flutter/painting/Border-class.html). When provided, it takes precedence over `borderSide`. |null|
 |backDrawRodData|if provided, draws a rod in the background of the line bar, check the [BackgroundBarChartRodData](#BackgroundBarChartRodData)|null|
 |rodStackItem|if you want to have a stacked bar chart, provide a list of [BarChartRodStackItem](#BarChartRodStackItem), it will draw over your rod.|[]|
 |toYErrorRange|If you want to show an error range on the rod, provide [FlErrorRange](base_chart.md#FlErrorRange)|null|

--- a/test/chart/bar_chart/bar_chart_data_test.dart
+++ b/test/chart/bar_chart/bar_chart_data_test.dart
@@ -29,6 +29,25 @@ void main() {
       expect(barChartRodData1 == barChartRodData8, false);
     });
 
+    test('BarChartRodData border equality test', () {
+      final rodData1 = BarChartRodData(
+        toY: 10,
+        color: Colors.blue,
+        border: const Border(
+          top: BorderSide(color: Colors.red, width: 2),
+        ),
+      );
+      final rodData2 = rodData1.copyWith();
+      final rodData3 = rodData1.copyWith(
+        border: const Border(
+          bottom: BorderSide(color: Colors.red, width: 2),
+        ),
+      );
+
+      expect(rodData1 == rodData2, true);
+      expect(rodData1 == rodData3, false);
+    });
+
     test('BarChartRodStackItem equality test', () {
       expect(barChartRodStackItem1 == barChartRodStackItem1Clone, true);
       expect(

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1617,6 +1617,7 @@ void main() {
 
       final rodDataResults = <Map<String, dynamic>>[];
       final borderResult = <Map<String, dynamic>>[];
+      final clipRectResults = <Rect>[];
 
       when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
           .thenAnswer((inv) {
@@ -1637,25 +1638,28 @@ void main() {
           'paint_color': paint.color,
         });
       });
+      when(mockCanvasWrapper.clipRect(captureAny)).thenAnswer((inv) {
+        final rect = inv.positionalArguments[0] as Rect;
+        clipRectResults.add(rect);
+      });
 
       barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
 
       expect(rodDataResults.length, 1);
       expect(borderResult.length, 1);
       expect(borderResult[0]['paint_color'], Colors.white);
-      verifyNever(mockCanvasWrapper.clipRect(any));
+      expect(clipRectResults.length, 1);
 
       final rrect = rodDataResults[0]['rrect'] as RRect;
       final borderPath = borderResult[0]['path'] as Path;
-      final pathBounds = borderPath.getBounds();
+      final expectedPath = (Path()..addRRect(rrect)).toDashedPath(null);
+      expect(HelperMethods.equalsPaths(expectedPath, borderPath), true);
 
-      expect(pathBounds.top, closeTo(rrect.top, tolerance));
-      expect(pathBounds.left, closeTo(rrect.left, tolerance));
-      expect(pathBounds.right, closeTo(rrect.right, tolerance));
-      expect(
-        pathBounds.bottom,
-        closeTo(rrect.top + 2, tolerance),
-      );
+      final clipRect = clipRectResults.single;
+      expect(clipRect.left, closeTo(rrect.left, tolerance));
+      expect(clipRect.top, closeTo(rrect.top, tolerance));
+      expect(clipRect.right, closeTo(rrect.right, tolerance));
+      expect(clipRect.bottom, closeTo(rrect.top + 2, tolerance));
     });
 
     test('uses butt stroke cap for dashed per-side border', () {

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1664,6 +1664,98 @@ void main() {
       expect(clipRect.bottom, closeTo(rrect.top + 2, tolerance));
     });
 
+    test('renders clip rect for each border side when border is provided', () {
+      const viewSize = Size(200, 100);
+
+      final barGroups = [
+        BarChartGroupData(
+          x: 0,
+          barRods: [
+            BarChartRodData(
+              fromY: 0,
+              toY: 10,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(4),
+                topRight: Radius.circular(4),
+              ),
+              border: const Border(
+                top: BorderSide(color: Colors.white, width: 2),
+                right: BorderSide(color: Colors.white, width: 2),
+                bottom: BorderSide(color: Colors.white, width: 2),
+                left: BorderSide(color: Colors.white, width: 2),
+              ),
+              color: Colors.transparent,
+            ),
+          ],
+        ),
+      ];
+
+      final data = BarChartData(
+        barGroups: barGroups,
+        minY: 0,
+        maxY: 10,
+      );
+
+      final barChartPainter = BarChartPainter();
+      final holder =
+          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final groupsX = data.calculateGroupsX(viewSize.width);
+      final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
+        viewSize,
+        groupsX,
+        barGroups,
+      );
+
+      final rodDataResults = <RRect>[];
+      final clipRectResults = <Rect>[];
+
+      when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
+          .thenAnswer((inv) {
+        final rrect = inv.positionalArguments[0] as RRect;
+        rodDataResults.add(rrect);
+      });
+      when(mockCanvasWrapper.clipRect(captureAny)).thenAnswer((inv) {
+        final rect = inv.positionalArguments[0] as Rect;
+        clipRectResults.add(rect);
+      });
+
+      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
+
+      expect(rodDataResults.length, 1);
+      expect(clipRectResults.length, 4);
+
+      final rrect = rodDataResults.single;
+
+      final topRect = clipRectResults[0];
+      expect(topRect.left, closeTo(rrect.left, tolerance));
+      expect(topRect.top, closeTo(rrect.top, tolerance));
+      expect(topRect.right, closeTo(rrect.right, tolerance));
+      expect(topRect.bottom, closeTo(rrect.top + 2, tolerance));
+
+      final rightRect = clipRectResults[1];
+      expect(rightRect.left, closeTo(rrect.right - 2, tolerance));
+      expect(rightRect.top, closeTo(rrect.top, tolerance));
+      expect(rightRect.right, closeTo(rrect.right, tolerance));
+      expect(rightRect.bottom, closeTo(rrect.bottom, tolerance));
+
+      final bottomRect = clipRectResults[2];
+      expect(bottomRect.left, closeTo(rrect.left, tolerance));
+      expect(bottomRect.top, closeTo(rrect.bottom - 2, tolerance));
+      expect(bottomRect.right, closeTo(rrect.right, tolerance));
+      expect(bottomRect.bottom, closeTo(rrect.bottom, tolerance));
+
+      final leftRect = clipRectResults[3];
+      expect(leftRect.left, closeTo(rrect.left, tolerance));
+      expect(leftRect.top, closeTo(rrect.top, tolerance));
+      expect(leftRect.right, closeTo(rrect.left + 2, tolerance));
+      expect(leftRect.bottom, closeTo(rrect.bottom, tolerance));
+    });
+
     test('uses butt stroke cap for dashed per-side border', () {
       const viewSize = Size(200, 100);
 

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1439,6 +1439,7 @@ void main() {
         borderResult.add({
           'path': path,
           'paint_color': paint.color,
+          'stroke_cap': paint.strokeCap,
         });
       });
 
@@ -1544,6 +1545,7 @@ void main() {
         borderResult.add({
           'path': path,
           'paint_color': paint.color,
+          'stroke_cap': paint.strokeCap,
         });
       });
 
@@ -1561,6 +1563,93 @@ void main() {
       final currentPath = borderResult[0]['path'] as Path;
 
       expect(HelperMethods.equalsPaths(expectedPath, currentPath), true);
+    });
+
+    test('renders top border side only when border is provided', () {
+      const viewSize = Size(200, 100);
+
+      final barGroups = [
+        BarChartGroupData(
+          x: 0,
+          barRods: [
+            BarChartRodData(
+              fromY: 0,
+              toY: 10,
+              borderRadius: const BorderRadius.only(
+                topLeft: Radius.circular(4),
+                topRight: Radius.circular(4),
+              ),
+              border: const Border(
+                top: BorderSide(color: Colors.white, width: 2),
+              ),
+              color: Colors.transparent,
+            ),
+          ],
+        ),
+      ];
+
+      final data = BarChartData(
+        barGroups: barGroups,
+        minY: 0,
+        maxY: 10,
+      );
+
+      final barChartPainter = BarChartPainter();
+      final holder =
+          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final groupsX = data.calculateGroupsX(viewSize.width);
+      final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
+        viewSize,
+        groupsX,
+        barGroups,
+      );
+
+      final rodDataResults = <Map<String, dynamic>>[];
+      final borderResult = <Map<String, dynamic>>[];
+
+      when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
+          .thenAnswer((inv) {
+        final rrect = inv.positionalArguments[0] as RRect;
+        final paint = inv.positionalArguments[1] as Paint;
+        rodDataResults.add({
+          'rrect': rrect,
+          'paint_color': paint.color,
+        });
+      });
+
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
+          .thenAnswer((inv) {
+        final path = inv.positionalArguments[0] as Path;
+        final paint = inv.positionalArguments[1] as Paint;
+        borderResult.add({
+          'path': path,
+          'paint_color': paint.color,
+        });
+      });
+
+      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
+
+      expect(rodDataResults.length, 1);
+      expect(borderResult.length, 1);
+      expect(borderResult[0]['paint_color'], Colors.white);
+      verifyNever(mockCanvasWrapper.clipRect(any));
+
+      final rrect = rodDataResults[0]['rrect'] as RRect;
+      final borderPath = borderResult[0]['path'] as Path;
+      final pathBounds = borderPath.getBounds();
+
+      expect(pathBounds.top, closeTo(rrect.top, tolerance));
+      expect(pathBounds.left, closeTo(rrect.left, tolerance));
+      expect(pathBounds.right, closeTo(rrect.right, tolerance));
+      expect(
+        pathBounds.bottom,
+        closeTo(rrect.top + 2, tolerance),
+      );
     });
 
     test('test small bar values with large border radius (issue #1757)', () {

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1391,6 +1391,7 @@ void main() {
               fromY: 0,
               toY: 15,
               borderDashArray: [4, 4],
+              // ignore: deprecated_member_use_from_same_package, keep coverage for deprecated legacy borderSide behavior.
               borderSide: const BorderSide(
                 color: Colors.white,
                 width: 2,
@@ -1497,6 +1498,7 @@ void main() {
             BarChartRodData(
               fromY: 0,
               toY: 15,
+              // ignore: deprecated_member_use_from_same_package, keep coverage for deprecated legacy borderSide behavior.
               borderSide: const BorderSide(
                 color: Colors.white,
                 width: 2,

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1678,9 +1678,9 @@ void main() {
 
       final clipRect = result.clipRects.single;
       expect(clipRect.left, closeTo(rrect.left, tolerance));
-      expect(clipRect.top, closeTo(rrect.top, tolerance));
+      expect(clipRect.top, closeTo(rrect.top - 1, tolerance));
       expect(clipRect.right, closeTo(rrect.right, tolerance));
-      expect(clipRect.bottom, closeTo(rrect.top + 2, tolerance));
+      expect(clipRect.bottom, closeTo(rrect.top + 1, tolerance));
     });
 
     test('renders clip rect for each border side when border is provided', () {
@@ -1690,10 +1690,10 @@ void main() {
           topRight: Radius.circular(4),
         ),
         border: const Border(
-          top: BorderSide(color: Colors.white, width: 2),
+          top: BorderSide(color: Colors.white),
           right: BorderSide(color: Colors.white, width: 2),
-          bottom: BorderSide(color: Colors.white, width: 2),
-          left: BorderSide(color: Colors.white, width: 2),
+          bottom: BorderSide(color: Colors.white, width: 3),
+          left: BorderSide(color: Colors.white, width: 4),
         ),
       );
 
@@ -1702,27 +1702,61 @@ void main() {
       final rrect = result.rodRRect;
 
       final topRect = result.clipRects[0];
-      expect(topRect.left, closeTo(rrect.left, tolerance));
-      expect(topRect.top, closeTo(rrect.top, tolerance));
-      expect(topRect.right, closeTo(rrect.right, tolerance));
-      expect(topRect.bottom, closeTo(rrect.top + 2, tolerance));
+      expect(topRect.left, closeTo(rrect.left - 0.5, tolerance));
+      expect(topRect.top, closeTo(rrect.top - 0.5, tolerance));
+      expect(topRect.right, closeTo(rrect.right + 0.5, tolerance));
+      expect(topRect.bottom, closeTo(rrect.top + 0.5, tolerance));
 
       final rightRect = result.clipRects[1];
-      expect(rightRect.left, closeTo(rrect.right - 2, tolerance));
-      expect(rightRect.top, closeTo(rrect.top, tolerance));
-      expect(rightRect.right, closeTo(rrect.right, tolerance));
-      expect(rightRect.bottom, closeTo(rrect.bottom, tolerance));
+      expect(rightRect.left, closeTo(rrect.right - 1, tolerance));
+      expect(rightRect.top, closeTo(rrect.top - 1, tolerance));
+      expect(rightRect.right, closeTo(rrect.right + 1, tolerance));
+      expect(rightRect.bottom, closeTo(rrect.bottom + 1, tolerance));
 
       final bottomRect = result.clipRects[2];
-      expect(bottomRect.left, closeTo(rrect.left, tolerance));
-      expect(bottomRect.top, closeTo(rrect.bottom - 2, tolerance));
-      expect(bottomRect.right, closeTo(rrect.right, tolerance));
-      expect(bottomRect.bottom, closeTo(rrect.bottom, tolerance));
+      expect(bottomRect.left, closeTo(rrect.left - 1.5, tolerance));
+      expect(bottomRect.top, closeTo(rrect.bottom - 1.5, tolerance));
+      expect(bottomRect.right, closeTo(rrect.right + 1.5, tolerance));
+      expect(bottomRect.bottom, closeTo(rrect.bottom + 1.5, tolerance));
 
       final leftRect = result.clipRects[3];
-      expect(leftRect.left, closeTo(rrect.left, tolerance));
-      expect(leftRect.top, closeTo(rrect.top, tolerance));
+      expect(leftRect.left, closeTo(rrect.left - 2, tolerance));
+      expect(leftRect.top, closeTo(rrect.top - 2, tolerance));
       expect(leftRect.right, closeTo(rrect.left + 2, tolerance));
+      expect(leftRect.bottom, closeTo(rrect.bottom + 2, tolerance));
+    });
+
+    test('renders uniform border in a single pass when border is uniform', () {
+      final result = drawSingleBorderedRod(
+        border: Border.all(color: Colors.white, width: 2),
+      );
+
+      expect(result.borderPaths.length, 1);
+      expect(result.borderColors.single, Colors.white);
+      expect(result.clipRects, isEmpty);
+    });
+
+    test('joins connected corners and avoids disconnected edge bleeding', () {
+      final result = drawSingleBorderedRod(
+        border: const Border(
+          top: BorderSide(color: Colors.white, width: 2),
+          left: BorderSide(color: Colors.white, width: 2),
+        ),
+      );
+
+      expect(result.clipRects.length, 2);
+      final rrect = result.rodRRect;
+
+      final topRect = result.clipRects[0];
+      expect(topRect.left, closeTo(rrect.left - 1, tolerance));
+      expect(topRect.top, closeTo(rrect.top - 1, tolerance));
+      expect(topRect.right, closeTo(rrect.right, tolerance));
+      expect(topRect.bottom, closeTo(rrect.top + 1, tolerance));
+
+      final leftRect = result.clipRects[1];
+      expect(leftRect.left, closeTo(rrect.left - 1, tolerance));
+      expect(leftRect.top, closeTo(rrect.top - 1, tolerance));
+      expect(leftRect.right, closeTo(rrect.left + 1, tolerance));
       expect(leftRect.bottom, closeTo(rrect.bottom, tolerance));
     });
 

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -1652,6 +1652,65 @@ void main() {
       );
     });
 
+    test('uses butt stroke cap for dashed per-side border', () {
+      const viewSize = Size(200, 100);
+
+      final barGroups = [
+        BarChartGroupData(
+          x: 0,
+          barRods: [
+            BarChartRodData(
+              fromY: 0,
+              toY: 10,
+              borderRadius: BorderRadius.zero,
+              border: const Border(
+                top: BorderSide(color: Colors.white, width: 2),
+              ),
+              borderDashArray: [4, 4],
+              color: Colors.transparent,
+            ),
+          ],
+        ),
+      ];
+
+      final data = BarChartData(
+        barGroups: barGroups,
+        minY: 0,
+        maxY: 10,
+      );
+
+      final barChartPainter = BarChartPainter();
+      final holder =
+          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final groupsX = data.calculateGroupsX(viewSize.width);
+      final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
+        viewSize,
+        groupsX,
+        barGroups,
+      );
+
+      final borderResult = <Map<String, dynamic>>[];
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
+          .thenAnswer((inv) {
+        final paint = inv.positionalArguments[1] as Paint;
+        borderResult.add({
+          'stroke_cap': paint.strokeCap,
+          'paint_color': paint.color,
+        });
+      });
+
+      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
+
+      expect(borderResult.length, 1);
+      expect(borderResult[0]['paint_color'], Colors.white);
+      expect(borderResult[0]['stroke_cap'], StrokeCap.butt);
+    });
+
     test('test small bar values with large border radius (issue #1757)', () {
       const viewSize = Size(200, 200);
 

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -755,6 +755,89 @@ void main() {
   });
 
   group('drawBars()', () {
+    ({
+      RRect rodRRect,
+      List<Path> borderPaths,
+      List<Color> borderColors,
+      List<StrokeCap> borderStrokeCaps,
+      List<Rect> clipRects,
+    }) drawSingleBorderedRod({
+      required Border border,
+      BorderRadius borderRadius = BorderRadius.zero,
+      List<int>? borderDashArray,
+    }) {
+      const viewSize = Size(200, 100);
+      final barGroups = [
+        BarChartGroupData(
+          x: 0,
+          barRods: [
+            BarChartRodData(
+              fromY: 0,
+              toY: 10,
+              borderRadius: borderRadius,
+              border: border,
+              borderDashArray: borderDashArray,
+              color: Colors.transparent,
+            ),
+          ],
+        ),
+      ];
+
+      final data = BarChartData(
+        barGroups: barGroups,
+        minY: 0,
+        maxY: 10,
+      );
+
+      final barChartPainter = BarChartPainter();
+      final holder =
+          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+
+      final groupsX = data.calculateGroupsX(viewSize.width);
+      final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
+        viewSize,
+        groupsX,
+        barGroups,
+      );
+
+      RRect? rodRRect;
+      final borderPaths = <Path>[];
+      final borderColors = <Color>[];
+      final borderStrokeCaps = <StrokeCap>[];
+      final clipRects = <Rect>[];
+
+      when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
+          .thenAnswer((inv) {
+        rodRRect ??= inv.positionalArguments[0] as RRect;
+      });
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
+          .thenAnswer((inv) {
+        final path = inv.positionalArguments[0] as Path;
+        final paint = inv.positionalArguments[1] as Paint;
+        borderPaths.add(path);
+        borderColors.add(paint.color);
+        borderStrokeCaps.add(paint.strokeCap);
+      });
+      when(mockCanvasWrapper.clipRect(captureAny)).thenAnswer((inv) {
+        final rect = inv.positionalArguments[0] as Rect;
+        clipRects.add(rect);
+      });
+
+      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
+
+      return (
+        rodRRect: rodRRect!,
+        borderPaths: borderPaths,
+        borderColors: borderColors,
+        borderStrokeCaps: borderStrokeCaps,
+        clipRects: clipRects,
+      );
+    }
+
     test('test 1', () {
       const viewSize = Size(200, 100);
 
@@ -1574,90 +1657,26 @@ void main() {
     });
 
     test('renders top border side only when border is provided', () {
-      const viewSize = Size(200, 100);
-
-      final barGroups = [
-        BarChartGroupData(
-          x: 0,
-          barRods: [
-            BarChartRodData(
-              fromY: 0,
-              toY: 10,
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(4),
-                topRight: Radius.circular(4),
-              ),
-              border: const Border(
-                top: BorderSide(color: Colors.white, width: 2),
-              ),
-              color: Colors.transparent,
-            ),
-          ],
+      final result = drawSingleBorderedRod(
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(4),
+          topRight: Radius.circular(4),
         ),
-      ];
-
-      final data = BarChartData(
-        barGroups: barGroups,
-        minY: 0,
-        maxY: 10,
+        border: const Border(
+          top: BorderSide(color: Colors.white, width: 2),
+        ),
       );
 
-      final barChartPainter = BarChartPainter();
-      final holder =
-          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
+      expect(result.borderPaths.length, 1);
+      expect(result.borderColors.single, Colors.white);
+      expect(result.clipRects.length, 1);
 
-      final mockCanvasWrapper = MockCanvasWrapper();
-      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-
-      final groupsX = data.calculateGroupsX(viewSize.width);
-      final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
-        viewSize,
-        groupsX,
-        barGroups,
-      );
-
-      final rodDataResults = <Map<String, dynamic>>[];
-      final borderResult = <Map<String, dynamic>>[];
-      final clipRectResults = <Rect>[];
-
-      when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-          .thenAnswer((inv) {
-        final rrect = inv.positionalArguments[0] as RRect;
-        final paint = inv.positionalArguments[1] as Paint;
-        rodDataResults.add({
-          'rrect': rrect,
-          'paint_color': paint.color,
-        });
-      });
-
-      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
-          .thenAnswer((inv) {
-        final path = inv.positionalArguments[0] as Path;
-        final paint = inv.positionalArguments[1] as Paint;
-        borderResult.add({
-          'path': path,
-          'paint_color': paint.color,
-        });
-      });
-      when(mockCanvasWrapper.clipRect(captureAny)).thenAnswer((inv) {
-        final rect = inv.positionalArguments[0] as Rect;
-        clipRectResults.add(rect);
-      });
-
-      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
-
-      expect(rodDataResults.length, 1);
-      expect(borderResult.length, 1);
-      expect(borderResult[0]['paint_color'], Colors.white);
-      expect(clipRectResults.length, 1);
-
-      final rrect = rodDataResults[0]['rrect'] as RRect;
-      final borderPath = borderResult[0]['path'] as Path;
+      final rrect = result.rodRRect;
+      final borderPath = result.borderPaths.single;
       final expectedPath = (Path()..addRRect(rrect)).toDashedPath(null);
       expect(HelperMethods.equalsPaths(expectedPath, borderPath), true);
 
-      final clipRect = clipRectResults.single;
+      final clipRect = result.clipRects.single;
       expect(clipRect.left, closeTo(rrect.left, tolerance));
       expect(clipRect.top, closeTo(rrect.top, tolerance));
       expect(clipRect.right, closeTo(rrect.right, tolerance));
@@ -1665,91 +1684,42 @@ void main() {
     });
 
     test('renders clip rect for each border side when border is provided', () {
-      const viewSize = Size(200, 100);
-
-      final barGroups = [
-        BarChartGroupData(
-          x: 0,
-          barRods: [
-            BarChartRodData(
-              fromY: 0,
-              toY: 10,
-              borderRadius: const BorderRadius.only(
-                topLeft: Radius.circular(4),
-                topRight: Radius.circular(4),
-              ),
-              border: const Border(
-                top: BorderSide(color: Colors.white, width: 2),
-                right: BorderSide(color: Colors.white, width: 2),
-                bottom: BorderSide(color: Colors.white, width: 2),
-                left: BorderSide(color: Colors.white, width: 2),
-              ),
-              color: Colors.transparent,
-            ),
-          ],
+      final result = drawSingleBorderedRod(
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(4),
+          topRight: Radius.circular(4),
         ),
-      ];
-
-      final data = BarChartData(
-        barGroups: barGroups,
-        minY: 0,
-        maxY: 10,
+        border: const Border(
+          top: BorderSide(color: Colors.white, width: 2),
+          right: BorderSide(color: Colors.white, width: 2),
+          bottom: BorderSide(color: Colors.white, width: 2),
+          left: BorderSide(color: Colors.white, width: 2),
+        ),
       );
 
-      final barChartPainter = BarChartPainter();
-      final holder =
-          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
+      expect(result.clipRects.length, 4);
 
-      final mockCanvasWrapper = MockCanvasWrapper();
-      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
-      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final rrect = result.rodRRect;
 
-      final groupsX = data.calculateGroupsX(viewSize.width);
-      final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
-        viewSize,
-        groupsX,
-        barGroups,
-      );
-
-      final rodDataResults = <RRect>[];
-      final clipRectResults = <Rect>[];
-
-      when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
-          .thenAnswer((inv) {
-        final rrect = inv.positionalArguments[0] as RRect;
-        rodDataResults.add(rrect);
-      });
-      when(mockCanvasWrapper.clipRect(captureAny)).thenAnswer((inv) {
-        final rect = inv.positionalArguments[0] as Rect;
-        clipRectResults.add(rect);
-      });
-
-      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
-
-      expect(rodDataResults.length, 1);
-      expect(clipRectResults.length, 4);
-
-      final rrect = rodDataResults.single;
-
-      final topRect = clipRectResults[0];
+      final topRect = result.clipRects[0];
       expect(topRect.left, closeTo(rrect.left, tolerance));
       expect(topRect.top, closeTo(rrect.top, tolerance));
       expect(topRect.right, closeTo(rrect.right, tolerance));
       expect(topRect.bottom, closeTo(rrect.top + 2, tolerance));
 
-      final rightRect = clipRectResults[1];
+      final rightRect = result.clipRects[1];
       expect(rightRect.left, closeTo(rrect.right - 2, tolerance));
       expect(rightRect.top, closeTo(rrect.top, tolerance));
       expect(rightRect.right, closeTo(rrect.right, tolerance));
       expect(rightRect.bottom, closeTo(rrect.bottom, tolerance));
 
-      final bottomRect = clipRectResults[2];
+      final bottomRect = result.clipRects[2];
       expect(bottomRect.left, closeTo(rrect.left, tolerance));
       expect(bottomRect.top, closeTo(rrect.bottom - 2, tolerance));
       expect(bottomRect.right, closeTo(rrect.right, tolerance));
       expect(bottomRect.bottom, closeTo(rrect.bottom, tolerance));
 
-      final leftRect = clipRectResults[3];
+      final leftRect = result.clipRects[3];
       expect(leftRect.left, closeTo(rrect.left, tolerance));
       expect(leftRect.top, closeTo(rrect.top, tolerance));
       expect(leftRect.right, closeTo(rrect.left + 2, tolerance));
@@ -1757,62 +1727,16 @@ void main() {
     });
 
     test('uses butt stroke cap for dashed per-side border', () {
-      const viewSize = Size(200, 100);
-
-      final barGroups = [
-        BarChartGroupData(
-          x: 0,
-          barRods: [
-            BarChartRodData(
-              fromY: 0,
-              toY: 10,
-              borderRadius: BorderRadius.zero,
-              border: const Border(
-                top: BorderSide(color: Colors.white, width: 2),
-              ),
-              borderDashArray: [4, 4],
-              color: Colors.transparent,
-            ),
-          ],
+      final result = drawSingleBorderedRod(
+        border: const Border(
+          top: BorderSide(color: Colors.white, width: 2),
         ),
-      ];
-
-      final data = BarChartData(
-        barGroups: barGroups,
-        minY: 0,
-        maxY: 10,
+        borderDashArray: [4, 4],
       );
 
-      final barChartPainter = BarChartPainter();
-      final holder =
-          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
-
-      final mockCanvasWrapper = MockCanvasWrapper();
-      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
-      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
-
-      final groupsX = data.calculateGroupsX(viewSize.width);
-      final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
-        viewSize,
-        groupsX,
-        barGroups,
-      );
-
-      final borderResult = <Map<String, dynamic>>[];
-      when(mockCanvasWrapper.drawPath(captureAny, captureAny))
-          .thenAnswer((inv) {
-        final paint = inv.positionalArguments[1] as Paint;
-        borderResult.add({
-          'stroke_cap': paint.strokeCap,
-          'paint_color': paint.color,
-        });
-      });
-
-      barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
-
-      expect(borderResult.length, 1);
-      expect(borderResult[0]['paint_color'], Colors.white);
-      expect(borderResult[0]['stroke_cap'], StrokeCap.butt);
+      expect(result.borderPaths.length, 1);
+      expect(result.borderColors.single, Colors.white);
+      expect(result.borderStrokeCaps.single, StrokeCap.butt);
     });
 
     test('test small bar values with large border radius (issue #1757)', () {

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -74,6 +74,9 @@ void main() {
       when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
         (realInvocation) => const BorderSide(color: MockData.color0),
       );
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
 
       final mockBuildContext = MockBuildContext();
       final mockCanvasWrapper = MockCanvasWrapper();
@@ -110,6 +113,9 @@ void main() {
           .thenAnswer((realInvocation) => BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
         (realInvocation) => const BorderSide(color: MockData.color0),
+      );
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
       );
     });
 
@@ -1843,6 +1849,9 @@ void main() {
       when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
         (realInvocation) => const BorderSide(color: MockData.color0),
       );
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
     });
 
     tearDown(() {
@@ -2074,6 +2083,9 @@ void main() {
       when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
       when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
       when(mockUtils.getBestInitialIntervalValue(any, any, any)).thenReturn(0);
       when(mockUtils.formatNumber(any, any, captureAny)).thenAnswer((inv) {
@@ -2271,6 +2283,9 @@ void main() {
       when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
       when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
       when(mockUtils.getBestInitialIntervalValue(any, any, any)).thenReturn(0);
       when(mockUtils.formatNumber(any, any, captureAny)).thenAnswer((inv) {
@@ -2480,6 +2495,9 @@ void main() {
       when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
       when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
       when(mockUtils.getBestInitialIntervalValue(any, any, any)).thenReturn(0);
       when(mockUtils.formatNumber(any, any, captureAny)).thenAnswer((inv) {
@@ -2642,6 +2660,9 @@ void main() {
       when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
       when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
       when(mockUtils.getBestInitialIntervalValue(any, any, any)).thenReturn(0);
       Utils.changeInstance(mockUtils);
@@ -2801,6 +2822,9 @@ void main() {
       when(mockUtils.normalizeBorderRadius(any, any))
           .thenReturn(BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenReturn(BorderSide.none);
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
       when(mockUtils.calculateRotationOffset(any, any)).thenReturn(Offset.zero);
       when(mockUtils.getBestInitialIntervalValue(any, any, any)).thenReturn(0);
       Utils.changeInstance(mockUtils);
@@ -3710,6 +3734,9 @@ void main() {
       when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
         (realInvocation) => const BorderSide(color: MockData.color0),
       );
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
+      );
 
       final mockBuildContext = MockBuildContext();
       final mockCanvasWrapper = MockCanvasWrapper();
@@ -3806,6 +3833,9 @@ void main() {
           .thenAnswer((realInvocation) => BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
         (realInvocation) => const BorderSide(color: MockData.color0),
+      );
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
       );
 
       final mockBuildContext = MockBuildContext();
@@ -3905,6 +3935,9 @@ void main() {
           .thenAnswer((realInvocation) => BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
         (realInvocation) => const BorderSide(color: MockData.color0),
+      );
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
       );
 
       final mockBuildContext = MockBuildContext();
@@ -4037,6 +4070,9 @@ void main() {
           .thenAnswer((realInvocation) => BorderRadius.zero);
       when(mockUtils.normalizeBorderSide(any, any)).thenAnswer(
         (realInvocation) => const BorderSide(color: MockData.color0),
+      );
+      when(mockUtils.normalizeBorder(any, any)).thenAnswer(
+        (realInvocation) => realInvocation.positionalArguments[0] as Border?,
       );
     });
 

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -761,6 +761,7 @@ void main() {
       List<Color> borderColors,
       List<StrokeCap> borderStrokeCaps,
       List<Rect> clipRects,
+      List<({RRect outer, RRect inner, Color color})> drRects,
     }) drawSingleBorderedRod({
       required Border border,
       BorderRadius borderRadius = BorderRadius.zero,
@@ -793,9 +794,10 @@ void main() {
       final holder =
           PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
 
+      final mockCanvas = MockCanvas();
       final mockCanvasWrapper = MockCanvasWrapper();
       when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
-      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      when(mockCanvasWrapper.canvas).thenReturn(mockCanvas);
 
       final groupsX = data.calculateGroupsX(viewSize.width);
       final barGroupsPosition = barChartPainter.calculateGroupAndBarsPosition(
@@ -809,6 +811,7 @@ void main() {
       final borderColors = <Color>[];
       final borderStrokeCaps = <StrokeCap>[];
       final clipRects = <Rect>[];
+      final drRects = <({RRect outer, RRect inner, Color color})>[];
 
       when(mockCanvasWrapper.drawRRect(captureAny, captureAny))
           .thenAnswer((inv) {
@@ -826,6 +829,13 @@ void main() {
         final rect = inv.positionalArguments[0] as Rect;
         clipRects.add(rect);
       });
+      when(mockCanvas.drawDRRect(captureAny, captureAny, captureAny))
+          .thenAnswer((inv) {
+        final outer = inv.positionalArguments[0] as RRect;
+        final inner = inv.positionalArguments[1] as RRect;
+        final paint = inv.positionalArguments[2] as Paint;
+        drRects.add((outer: outer, inner: inner, color: paint.color));
+      });
 
       barChartPainter.drawBars(mockCanvasWrapper, barGroupsPosition, holder);
 
@@ -835,6 +845,7 @@ void main() {
         borderColors: borderColors,
         borderStrokeCaps: borderStrokeCaps,
         clipRects: clipRects,
+        drRects: drRects,
       );
     }
 
@@ -1656,7 +1667,7 @@ void main() {
       expect(HelperMethods.equalsPaths(expectedPath, currentPath), true);
     });
 
-    test('renders top border side only when border is provided', () {
+    test('renders top border side inside with Container-style smooth edge', () {
       final result = drawSingleBorderedRod(
         borderRadius: const BorderRadius.only(
           topLeft: Radius.circular(4),
@@ -1667,23 +1678,23 @@ void main() {
         ),
       );
 
-      expect(result.borderPaths.length, 1);
-      expect(result.borderColors.single, Colors.white);
-      expect(result.clipRects.length, 1);
+      expect(result.borderPaths, isEmpty);
+      expect(result.clipRects, isEmpty);
+      expect(result.drRects.length, 1);
 
       final rrect = result.rodRRect;
-      final borderPath = result.borderPaths.single;
-      final expectedPath = (Path()..addRRect(rrect)).toDashedPath(null);
-      expect(HelperMethods.equalsPaths(expectedPath, borderPath), true);
-
-      final clipRect = result.clipRects.single;
-      expect(clipRect.left, closeTo(rrect.left, tolerance));
-      expect(clipRect.top, closeTo(rrect.top - 1, tolerance));
-      expect(clipRect.right, closeTo(rrect.right, tolerance));
-      expect(clipRect.bottom, closeTo(rrect.top + 1, tolerance));
+      final drRect = result.drRects.single;
+      expect(drRect.color, Colors.white);
+      expect(HelperMethods.equalsRRects(drRect.outer, rrect), true);
+      expect(drRect.inner.left, closeTo(rrect.left, tolerance));
+      expect(drRect.inner.top, closeTo(rrect.top + 2, tolerance));
+      expect(drRect.inner.right, closeTo(rrect.right, tolerance));
+      expect(drRect.inner.bottom, closeTo(rrect.bottom, tolerance));
+      expect(drRect.inner.tlRadius.x, closeTo(4, tolerance));
+      expect(drRect.inner.tlRadius.y, closeTo(2, tolerance));
     });
 
-    test('renders clip rect for each border side when border is provided', () {
+    test('renders full non-uniform border with default centered strokes', () {
       final result = drawSingleBorderedRod(
         borderRadius: const BorderRadius.only(
           topLeft: Radius.circular(4),
@@ -1697,7 +1708,9 @@ void main() {
         ),
       );
 
+      expect(result.borderPaths.length, 4);
       expect(result.clipRects.length, 4);
+      expect(result.drRects, isEmpty);
 
       final rrect = result.rodRRect;
 
@@ -1734,30 +1747,34 @@ void main() {
       expect(result.borderPaths.length, 1);
       expect(result.borderColors.single, Colors.white);
       expect(result.clipRects, isEmpty);
+      expect(result.drRects, isEmpty);
     });
 
-    test('joins connected corners and avoids disconnected edge bleeding', () {
+    test('smooths connected curved joins inside the bar body', () {
       final result = drawSingleBorderedRod(
+        borderRadius: const BorderRadius.only(
+          topLeft: Radius.circular(4),
+        ),
         border: const Border(
-          top: BorderSide(color: Colors.white, width: 2),
-          left: BorderSide(color: Colors.white, width: 2),
+          top: BorderSide(color: Colors.red, width: 2),
+          left: BorderSide(color: Colors.red, width: 4),
         ),
       );
 
-      expect(result.clipRects.length, 2);
+      expect(result.borderPaths, isEmpty);
+      expect(result.clipRects, isEmpty);
+      expect(result.drRects.length, 1);
       final rrect = result.rodRRect;
+      final drRect = result.drRects.single;
 
-      final topRect = result.clipRects[0];
-      expect(topRect.left, closeTo(rrect.left - 1, tolerance));
-      expect(topRect.top, closeTo(rrect.top - 1, tolerance));
-      expect(topRect.right, closeTo(rrect.right, tolerance));
-      expect(topRect.bottom, closeTo(rrect.top + 1, tolerance));
-
-      final leftRect = result.clipRects[1];
-      expect(leftRect.left, closeTo(rrect.left - 1, tolerance));
-      expect(leftRect.top, closeTo(rrect.top - 1, tolerance));
-      expect(leftRect.right, closeTo(rrect.left + 1, tolerance));
-      expect(leftRect.bottom, closeTo(rrect.bottom, tolerance));
+      expect(drRect.color.toARGB32(), Colors.red.shade500.toARGB32());
+      expect(HelperMethods.equalsRRects(drRect.outer, rrect), true);
+      expect(drRect.inner.left, closeTo(rrect.left + 4, tolerance));
+      expect(drRect.inner.top, closeTo(rrect.top + 2, tolerance));
+      expect(drRect.inner.right, closeTo(rrect.right, tolerance));
+      expect(drRect.inner.bottom, closeTo(rrect.bottom, tolerance));
+      expect(drRect.inner.tlRadius.x, closeTo(0, tolerance));
+      expect(drRect.inner.tlRadius.y, closeTo(2, tolerance));
     });
 
     test('uses butt stroke cap for dashed per-side border', () {
@@ -1771,6 +1788,7 @@ void main() {
       expect(result.borderPaths.length, 1);
       expect(result.borderColors.single, Colors.white);
       expect(result.borderStrokeCaps.single, StrokeCap.butt);
+      expect(result.drRects, isEmpty);
     });
 
     test('test small bar values with large border radius (issue #1757)', () {

--- a/test/chart/bar_chart/bar_chart_painter_test.mocks.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.mocks.dart
@@ -1386,6 +1386,19 @@ class MockUtils extends _i1.Mock implements _i8.Utils {
       ) as _i3.BorderSide);
 
   @override
+  _i3.Border? normalizeBorder(
+    _i3.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i3.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {

--- a/test/chart/candlestick_chart/candlestick_chart_painter_test.mocks.dart
+++ b/test/chart/candlestick_chart/candlestick_chart_painter_test.mocks.dart
@@ -1386,6 +1386,19 @@ class MockUtils extends _i1.Mock implements _i8.Utils {
       ) as _i3.BorderSide);
 
   @override
+  _i3.Border? normalizeBorder(
+    _i3.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i3.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {

--- a/test/chart/line_chart/line_chart_painter_test.mocks.dart
+++ b/test/chart/line_chart/line_chart_painter_test.mocks.dart
@@ -1421,6 +1421,19 @@ class MockUtils extends _i1.Mock implements _i8.Utils {
       ) as _i3.BorderSide);
 
   @override
+  _i3.Border? normalizeBorder(
+    _i3.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i3.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {

--- a/test/chart/pie_chart/pie_chart_painter_test.mocks.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.mocks.dart
@@ -1386,6 +1386,19 @@ class MockUtils extends _i1.Mock implements _i8.Utils {
       ) as _i3.BorderSide);
 
   @override
+  _i3.Border? normalizeBorder(
+    _i3.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i3.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {

--- a/test/chart/radar_chart/radar_chart_painter_test.mocks.dart
+++ b/test/chart/radar_chart/radar_chart_painter_test.mocks.dart
@@ -1386,6 +1386,19 @@ class MockUtils extends _i1.Mock implements _i8.Utils {
       ) as _i3.BorderSide);
 
   @override
+  _i3.Border? normalizeBorder(
+    _i3.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i3.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {

--- a/test/chart/scatter_chart/scatter_chart_painter_test.mocks.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.mocks.dart
@@ -1386,6 +1386,19 @@ class MockUtils extends _i1.Mock implements _i8.Utils {
       ) as _i3.BorderSide);
 
   @override
+  _i3.Border? normalizeBorder(
+    _i3.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i3.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {

--- a/test/utils/canvas_wrapper_test.mocks.dart
+++ b/test/utils/canvas_wrapper_test.mocks.dart
@@ -932,6 +932,19 @@ class MockUtils extends _i1.Mock implements _i6.Utils {
       ) as _i4.BorderSide);
 
   @override
+  _i4.Border? normalizeBorder(
+    _i4.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i4.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {

--- a/test/utils/utils_test.dart
+++ b/test/utils/utils_test.dart
@@ -115,6 +115,32 @@ void main() {
     expect(Utils().normalizeBorderSide(input2, 40), output2);
   });
 
+  test('normalizeBorder()', () {
+    const input1 = Border(
+      top: BorderSide(width: 4),
+      right: BorderSide(width: 8),
+      bottom: BorderSide(width: 10),
+      left: BorderSide(width: 2),
+    );
+    const output1 = input1;
+    expect(Utils().normalizeBorder(input1, 40), output1);
+
+    const input2 = Border(
+      top: BorderSide(width: 24),
+      right: BorderSide(width: 30),
+      bottom: BorderSide(width: 21),
+      left: BorderSide(),
+    );
+    const output2 = Border(
+      top: BorderSide(width: 20),
+      right: BorderSide(width: 20),
+      bottom: BorderSide(width: 20),
+      left: BorderSide(),
+    );
+    expect(Utils().normalizeBorder(input2, 40), output2);
+    expect(Utils().normalizeBorder(null, 40), isNull);
+  });
+
   test('lerp gradient', () {
     expect(
       lerpGradient(

--- a/test/utils/utils_test.mocks.dart
+++ b/test/utils/utils_test.mocks.dart
@@ -217,6 +217,19 @@ class MockUtils extends _i1.Mock implements _i5.Utils {
       ) as _i3.BorderSide);
 
   @override
+  _i3.Border? normalizeBorder(
+    _i3.Border? border,
+    double? width,
+  ) =>
+      (super.noSuchMethod(Invocation.method(
+        #normalizeBorder,
+        [
+          border,
+          width,
+        ],
+      )) as _i3.Border?);
+
+  @override
   double getEfficientInterval(
     double? axisViewSize,
     double? diffInAxis, {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a concise description of what this PR is doing. 
Keep it short and clear, as this text will be included in the permanent Git commit history.
-->
<!-- End of exclude from commit message -->
add support for per-side borders on `BarChartRodData` so users can render borders like top-only, left-only, etc.
Bar border are rendered inside - outside/centers makes bars look taller/shorter than data and can collide with nearby bars.

Resolves #1194

### API
- Added optional `Border? border` to `BarChartRodData`.
- Kept existing `borderSide` for backward compatibility.
- Rendering precedence:
  - If `border` is provided, it is used.
  - Otherwise, existing `borderSide` behavior is preserved.

### Painter updates
- Refactored bar border painting to support:
  - uniform border (`borderSide`)
  - per-side border (`border`)
  - dashed and non-dashed variants
- Added edge-based path handling for top/right/bottom/left so per-side rendering works with rounded bars as well.


<img width="351" height="339" alt="Screenshot 2026-04-19 at 22 43 19" src="https://github.com/user-attachments/assets/c4bc727f-0fc0-4df5-ad83-63878d9176e7" />

<img width="356" height="392" alt="Screenshot 2026-04-19 at 22 42 27" src="https://github.com/user-attachments/assets/8eb0432d-5090-4dc3-87b6-328952a81e5e" />

<img width="331" height="339" alt="Screenshot 2026-04-19 at 22 44 37" src="https://github.com/user-attachments/assets/68b6059b-f72d-4789-8935-4dc3ef412e10" />

<img width="336" height="336" alt="Screenshot 2026-04-19 at 23 03 02" src="https://github.com/user-attachments/assets/7709a2bf-4af4-4fca-a03e-f28305cd99ce" />

<!-- Exclude from commit message -->
## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [ ] I have followed the [Contributor Guide] when preparing my PR.
- [ ] I have updated/added tests for ALL new/updated/fixed functionality.
- [ ] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `example`.


## Breaking Change?
<!--
Would your PR require fl_chart users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version.
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1194
!-->
Closes #1194

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
