### PR TITLE
feat: Add section offset to pie chart

### DIFF
--- a/example/lib/presentation/samples/chart_samples.dart
+++ b/example/lib/presentation/samples/chart_samples.dart
@@ -31,6 +31,7 @@ import 'pie/pie_chart_sample1.dart';
 import 'pie/pie_chart_sample2.dart';
 import 'pie/pie_chart_sample3.dart';
 import 'pie/pie_chart_sample4.dart';
+import 'pie/pie_chart_sample5.dart';
 import 'radar/radar_chart_sample1.dart';
 import 'scatter/scatter_chart_sample1.dart';
 import 'scatter/scatter_chart_sample2.dart';
@@ -67,6 +68,7 @@ class ChartSamples {
       PieChartSample(2, (context) => const PieChartSample2()),
       PieChartSample(3, (context) => const PieChartSample3()),
       PieChartSample(4, (context) => const PieChartSample4()),
+      PieChartSample(5, (context) => const PieChartSample5()),
     ],
     ChartType.scatter: [
       ScatterChartSample(1, (context) => ScatterChartSample1()),

--- a/example/lib/presentation/samples/pie/pie_chart_sample5.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample5.dart
@@ -1,0 +1,126 @@
+import 'package:fl_chart/fl_chart.dart';
+import 'package:fl_chart_app/presentation/resources/app_colors.dart';
+import 'package:flutter/material.dart';
+
+class PieChartSample5 extends StatefulWidget {
+  const PieChartSample5({super.key});
+
+  @override
+  State<PieChartSample5> createState() => _PieChartSample5State();
+}
+
+class _PieChartSample5State extends State<PieChartSample5> {
+  int touchedIndex = -1;
+
+  @override
+  Widget build(BuildContext context) {
+    return AspectRatio(
+      aspectRatio: 1.3,
+      child: AspectRatio(
+        aspectRatio: 1,
+        child: PieChart(
+          PieChartData(
+            pieTouchData: PieTouchData(
+              touchCallback: (FlTouchEvent event, pieTouchResponse) {
+                setState(() {
+                  if (!event.isInterestedForInteractions ||
+                      pieTouchResponse == null ||
+                      pieTouchResponse.touchedSection == null) {
+                    touchedIndex = -1;
+                    return;
+                  }
+                  touchedIndex =
+                      pieTouchResponse.touchedSection!.touchedSectionIndex;
+                });
+              },
+            ),
+            borderData: FlBorderData(show: false),
+            sectionsSpace: 3,
+            centerSpaceRadius: 24,
+            sections: showingSections(),
+          ),
+        ),
+      ),
+    );
+  }
+
+  List<PieChartSectionData> showingSections() {
+    return List.generate(4, (i) {
+      final isTouched = i == touchedIndex;
+      final radius = 56.0;
+      final sectionOffset = isTouched ? 12.0 : 0.0;
+      final fontSize = isTouched ? 18.0 : 14.0;
+      const shadows = [Shadow(color: Colors.black, blurRadius: 2)];
+
+      return switch (i) {
+        0 => PieChartSectionData(
+            color: AppColors.contentColorBlue,
+            value: 40,
+            title: '40%',
+            radius: radius,
+            sectionOffset: sectionOffset,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: AppColors.contentColorWhite,
+              shadows: shadows,
+            ),
+            segments: [
+              PieChartStackSegmentData(
+                fromRadius: 0,
+                toRadius: radius,
+                color: AppColors.contentColorBlue,
+              ),
+            ],
+          ),
+        1 => PieChartSectionData(
+            color: AppColors.contentColorOrange,
+            value: 30,
+            title: '30%',
+            radius: radius,
+            sectionOffset: sectionOffset,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: AppColors.contentColorWhite,
+              shadows: shadows,
+            ),
+          ),
+        2 => PieChartSectionData(
+            color: AppColors.contentColorPurple,
+            value: 20,
+            title: '20%',
+            radius: radius,
+            sectionOffset: sectionOffset,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: AppColors.contentColorWhite,
+              shadows: shadows,
+            ),
+            segments: [
+              PieChartStackSegmentData(
+                fromRadius: 0,
+                toRadius: radius,
+                color: AppColors.contentColorPurple,
+              ),
+            ],
+          ),
+        3 => PieChartSectionData(
+            color: AppColors.contentColorGreen,
+            value: 10,
+            title: '10%',
+            radius: radius,
+            sectionOffset: sectionOffset,
+            titleStyle: TextStyle(
+              fontSize: fontSize,
+              fontWeight: FontWeight.bold,
+              color: AppColors.contentColorWhite,
+              shadows: shadows,
+            ),
+          ),
+        _ => throw StateError('Invalid'),
+      };
+    });
+  }
+}

--- a/example/lib/presentation/samples/pie/pie_chart_sample5.dart
+++ b/example/lib/presentation/samples/pie/pie_chart_sample5.dart
@@ -48,7 +48,7 @@ class _PieChartSample5State extends State<PieChartSample5> {
     return List.generate(4, (i) {
       final isTouched = i == touchedIndex;
       final radius = 56.0;
-      final sectionOffset = isTouched ? 12.0 : 0.0;
+      final radialOffset = isTouched ? 12.0 : 0.0;
       final fontSize = isTouched ? 18.0 : 14.0;
       const shadows = [Shadow(color: Colors.black, blurRadius: 2)];
 
@@ -58,7 +58,7 @@ class _PieChartSample5State extends State<PieChartSample5> {
             value: 40,
             title: '40%',
             radius: radius,
-            sectionOffset: sectionOffset,
+            radialOffset: radialOffset,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -78,7 +78,7 @@ class _PieChartSample5State extends State<PieChartSample5> {
             value: 30,
             title: '30%',
             radius: radius,
-            sectionOffset: sectionOffset,
+            radialOffset: radialOffset,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -91,7 +91,7 @@ class _PieChartSample5State extends State<PieChartSample5> {
             value: 20,
             title: '20%',
             radius: radius,
-            sectionOffset: sectionOffset,
+            radialOffset: radialOffset,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,
@@ -111,7 +111,7 @@ class _PieChartSample5State extends State<PieChartSample5> {
             value: 10,
             title: '10%',
             radius: radius,
-            sectionOffset: sectionOffset,
+            radialOffset: radialOffset,
             titleStyle: TextStyle(
               fontSize: fontSize,
               fontWeight: FontWeight.bold,

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -157,6 +157,7 @@ class PieChartSectionData with EquatableMixin {
     Color? color,
     this.gradient,
     double? radius,
+    double? sectionOffset,
     bool? showTitle,
     this.titleStyle,
     String? title,
@@ -169,6 +170,7 @@ class PieChartSectionData with EquatableMixin {
   })  : value = value ?? 10,
         color = color ?? Colors.cyan,
         radius = (radius ?? 40).clamp(0, double.infinity).toDouble(),
+        sectionOffset = sectionOffset ?? 0,
         showTitle = showTitle ?? true,
         title = title ?? (value == null ? '' : value.toString()),
         borderSide = borderSide ?? const BorderSide(width: 0),
@@ -194,6 +196,10 @@ class PieChartSectionData with EquatableMixin {
 
   /// Defines the radius of section.
   final double radius;
+
+  /// Additional radial translation applied to the whole section (in logical pixels).
+  /// Positive values move the section outward along its center angle.
+  final double sectionOffset;
 
   /// Defines show or hide the title of section.
   final bool showTitle;
@@ -244,6 +250,7 @@ class PieChartSectionData with EquatableMixin {
     Color? color,
     Gradient? gradient,
     double? radius,
+    double? sectionOffset,
     bool? showTitle,
     TextStyle? titleStyle,
     String? title,
@@ -259,6 +266,7 @@ class PieChartSectionData with EquatableMixin {
         color: color ?? this.color,
         gradient: gradient ?? this.gradient,
         radius: radius ?? this.radius,
+        sectionOffset: sectionOffset ?? this.sectionOffset,
         showTitle: showTitle ?? this.showTitle,
         titleStyle: titleStyle ?? this.titleStyle,
         title: title ?? this.title,
@@ -283,6 +291,7 @@ class PieChartSectionData with EquatableMixin {
         color: Color.lerp(a.color, b.color, t),
         gradient: Gradient.lerp(a.gradient, b.gradient, t),
         radius: lerpDouble(a.radius, b.radius, t),
+        sectionOffset: lerpDouble(a.sectionOffset, b.sectionOffset, t),
         showTitle: b.showTitle,
         titleStyle: TextStyle.lerp(a.titleStyle, b.titleStyle, t),
         title: b.title,
@@ -313,6 +322,7 @@ class PieChartSectionData with EquatableMixin {
         color,
         gradient,
         radius,
+        sectionOffset,
         showTitle,
         titleStyle,
         title,

--- a/lib/src/chart/pie_chart/pie_chart_data.dart
+++ b/lib/src/chart/pie_chart/pie_chart_data.dart
@@ -157,7 +157,7 @@ class PieChartSectionData with EquatableMixin {
     Color? color,
     this.gradient,
     double? radius,
-    double? sectionOffset,
+    double? radialOffset,
     bool? showTitle,
     this.titleStyle,
     String? title,
@@ -170,7 +170,7 @@ class PieChartSectionData with EquatableMixin {
   })  : value = value ?? 10,
         color = color ?? Colors.cyan,
         radius = (radius ?? 40).clamp(0, double.infinity).toDouble(),
-        sectionOffset = sectionOffset ?? 0,
+        radialOffset = radialOffset ?? 0,
         showTitle = showTitle ?? true,
         title = title ?? (value == null ? '' : value.toString()),
         borderSide = borderSide ?? const BorderSide(width: 0),
@@ -199,7 +199,10 @@ class PieChartSectionData with EquatableMixin {
 
   /// Additional radial translation applied to the whole section (in logical pixels).
   /// Positive values move the section outward along its center angle.
-  final double sectionOffset;
+  ///
+  /// Note: This parameter is ignored when there is only a single section
+  /// occupying 360 degrees, as there is no meaningful direction to offset.
+  final double radialOffset;
 
   /// Defines show or hide the title of section.
   final bool showTitle;
@@ -250,7 +253,7 @@ class PieChartSectionData with EquatableMixin {
     Color? color,
     Gradient? gradient,
     double? radius,
-    double? sectionOffset,
+    double? radialOffset,
     bool? showTitle,
     TextStyle? titleStyle,
     String? title,
@@ -266,7 +269,7 @@ class PieChartSectionData with EquatableMixin {
         color: color ?? this.color,
         gradient: gradient ?? this.gradient,
         radius: radius ?? this.radius,
-        sectionOffset: sectionOffset ?? this.sectionOffset,
+        radialOffset: radialOffset ?? this.radialOffset,
         showTitle: showTitle ?? this.showTitle,
         titleStyle: titleStyle ?? this.titleStyle,
         title: title ?? this.title,
@@ -291,7 +294,7 @@ class PieChartSectionData with EquatableMixin {
         color: Color.lerp(a.color, b.color, t),
         gradient: Gradient.lerp(a.gradient, b.gradient, t),
         radius: lerpDouble(a.radius, b.radius, t),
-        sectionOffset: lerpDouble(a.sectionOffset, b.sectionOffset, t),
+        radialOffset: lerpDouble(a.radialOffset, b.radialOffset, t),
         showTitle: b.showTitle,
         titleStyle: TextStyle.lerp(a.titleStyle, b.titleStyle, t),
         title: b.title,
@@ -322,7 +325,7 @@ class PieChartSectionData with EquatableMixin {
         color,
         gradient,
         radius,
-        sectionOffset,
+        radialOffset,
         showTitle,
         titleStyle,
         title,

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -109,14 +109,13 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       }
       final sectionDegree = sectionsAngle[i];
 
-      // Compute offset for "exploded" sections
       final sectionCenterAngle = tempAngle + (sectionDegree / 2);
-      final sectionOffset = section.sectionOffset;
-      final offsetDx =
-          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
-      final offsetDy =
-          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
-      final sectionCenter = center.translate(offsetDx, offsetDy);
+      final radialOffset = _computeRadialOffset(
+        section.radialOffset,
+        sectionCenterAngle,
+        sectionDegree,
+      );
+      final sectionCenter = center + radialOffset;
 
       if (sectionDegree == 360) {
         final fullCirclePath = generateSegmentPath(
@@ -732,14 +731,15 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         }
       }
 
-      final sectionOffset = section.sectionOffset;
-      final offsetDx =
-          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
-      final offsetDy =
-          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final radialOffset = _computeRadialOffset(
+        section.radialOffset,
+        sectionCenterAngle,
+        sweepAngle,
+      );
 
       Offset sectionCenter(double percentageOffset) =>
-          center.translate(offsetDx, offsetDy) +
+          center +
+          radialOffset +
           Offset(
             math.cos(Utils().radians(sectionCenterAngle)) *
                 (centerRadius + (section.radius * percentageOffset)),
@@ -836,20 +836,19 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         break;
       }
 
-      // Account for outward offset when hit-testing
       final sectionCenterAngle = tempAngle + (sectionAngle / 2);
-      final sectionOffset = section.sectionOffset;
-      final offsetDx =
-          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
-      final offsetDy =
-          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final radialOffset = _computeRadialOffset(
+        section.radialOffset,
+        sectionCenterAngle,
+        sectionAngle,
+      );
 
       final sectionPath = generateSectionPath(
         section,
         data.sectionsSpace,
         tempAngle,
         sectionAngle,
-        center.translate(offsetDx, offsetDy),
+        center + radialOffset,
         centerRadius,
       );
 
@@ -893,14 +892,15 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       final sectionCenterAngle = startAngle + (sweepAngle / 2);
       final centerRadius = calculateCenterRadius(viewSize, holder);
 
-      final sectionOffset = section.sectionOffset;
-      final offsetDx =
-          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
-      final offsetDy =
-          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final radialOffset = _computeRadialOffset(
+        section.radialOffset,
+        sectionCenterAngle,
+        sweepAngle,
+      );
 
       Offset sectionCenter(double percentageOffset) =>
-          center.translate(offsetDx, offsetDy) +
+          center +
+          radialOffset +
           Offset(
             math.cos(Utils().radians(sectionCenterAngle)) *
                 (centerRadius + (section.radius * percentageOffset)),
@@ -917,5 +917,19 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
     }
 
     return badgeWidgetsOffsets;
+  }
+
+  /// Computes the radial offset translation for a section along its center angle.
+  /// Returns [Offset.zero] when [sectionDegree] is 360 (single full-circle section).
+  Offset _computeRadialOffset(
+    double radialOffset,
+    double sectionCenterAngle,
+    double sectionDegree,
+  ) {
+    if (sectionDegree == 360) return Offset.zero;
+    return Offset(
+      math.cos(Utils().radians(sectionCenterAngle)) * radialOffset,
+      math.sin(Utils().radians(sectionCenterAngle)) * radialOffset,
+    );
   }
 }

--- a/lib/src/chart/pie_chart/pie_chart_painter.dart
+++ b/lib/src/chart/pie_chart/pie_chart_painter.dart
@@ -109,6 +109,15 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       }
       final sectionDegree = sectionsAngle[i];
 
+      // Compute offset for "exploded" sections
+      final sectionCenterAngle = tempAngle + (sectionDegree / 2);
+      final sectionOffset = section.sectionOffset;
+      final offsetDx =
+          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final offsetDy =
+          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final sectionCenter = center.translate(offsetDx, offsetDy);
+
       if (sectionDegree == 360) {
         final fullCirclePath = generateSegmentPath(
           center,
@@ -124,7 +133,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           sectionDegree,
           centerRadius,
           0,
-          center,
+          sectionCenter,
         );
 
         _sectionPaint.blendMode = BlendMode.srcOver;
@@ -136,14 +145,14 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
           // Outer
           canvasWrapper
             ..drawCircle(
-              center,
+              sectionCenter,
               centerRadius + section.radius - (section.borderSide.width / 2),
               _sectionStrokePaint,
             )
 
             // Inner
             ..drawCircle(
-              center,
+              sectionCenter,
               centerRadius + (section.borderSide.width / 2),
               _sectionStrokePaint,
             );
@@ -158,7 +167,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         data.sectionsSpace,
         tempAngle,
         sectionDegree,
-        center,
+        sectionCenter,
         centerRadius,
       );
 
@@ -173,7 +182,7 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         sectionDegree,
         centerRadius,
         tempAngle,
-        center,
+        sectionCenter,
       );
       canvasWrapper.restore();
 
@@ -723,8 +732,14 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         }
       }
 
+      final sectionOffset = section.sectionOffset;
+      final offsetDx =
+          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final offsetDy =
+          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
+
       Offset sectionCenter(double percentageOffset) =>
-          center +
+          center.translate(offsetDx, offsetDy) +
           Offset(
             math.cos(Utils().radians(sectionCenterAngle)) *
                 (centerRadius + (section.radius * percentageOffset)),
@@ -821,12 +836,20 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
         break;
       }
 
+      // Account for outward offset when hit-testing
+      final sectionCenterAngle = tempAngle + (sectionAngle / 2);
+      final sectionOffset = section.sectionOffset;
+      final offsetDx =
+          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final offsetDy =
+          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
+
       final sectionPath = generateSectionPath(
         section,
         data.sectionsSpace,
         tempAngle,
         sectionAngle,
-        center,
+        center.translate(offsetDx, offsetDy),
         centerRadius,
       );
 
@@ -870,8 +893,14 @@ class PieChartPainter extends BaseChartPainter<PieChartData> {
       final sectionCenterAngle = startAngle + (sweepAngle / 2);
       final centerRadius = calculateCenterRadius(viewSize, holder);
 
+      final sectionOffset = section.sectionOffset;
+      final offsetDx =
+          math.cos(Utils().radians(sectionCenterAngle)) * sectionOffset;
+      final offsetDy =
+          math.sin(Utils().radians(sectionCenterAngle)) * sectionOffset;
+
       Offset sectionCenter(double percentageOffset) =>
-          center +
+          center.translate(offsetDx, offsetDy) +
           Offset(
             math.cos(Utils().radians(sectionCenterAngle)) *
                 (centerRadius + (section.radius * percentageOffset)),

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -37,6 +37,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |color| colors the section| Colors.red|
 |gradient| You can use any [Gradient](https://api.flutter.dev/flutter/dart-ui/Gradient-class.html) here. such as [LinearGradient](https://api.flutter.dev/flutter/painting/LinearGradient-class.html) or [RadialGradient](https://api.flutter.dev/flutter/painting/RadialGradient-class.html) (you have to provide either `color` or `gradient`)|null|
 |radius| the width radius of each section|40|
+|sectionOffset| radial translation (in logical pixels) applied to the whole section, moving it outward along its center angle. Useful for "exploded" pie charts|0|
 |showTitle| determines whether to show or hide the titles on each section|true|
 |titleStyle| TextStyle of the titles| TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)|
 |title| title of the section| value|

--- a/repo_files/documentations/pie_chart.md
+++ b/repo_files/documentations/pie_chart.md
@@ -37,7 +37,7 @@ When you change the chart's state, it animates to the new state internally (usin
 |color| colors the section| Colors.red|
 |gradient| You can use any [Gradient](https://api.flutter.dev/flutter/dart-ui/Gradient-class.html) here. such as [LinearGradient](https://api.flutter.dev/flutter/painting/LinearGradient-class.html) or [RadialGradient](https://api.flutter.dev/flutter/painting/RadialGradient-class.html) (you have to provide either `color` or `gradient`)|null|
 |radius| the width radius of each section|40|
-|sectionOffset| radial translation (in logical pixels) applied to the whole section, moving it outward along its center angle. Useful for "exploded" pie charts|0|
+|radialOffset| radial translation (in logical pixels) applied to the whole section, moving it outward along its center angle. Useful for "exploded" pie charts. Ignored when there is only a single section (360 degrees)|0|
 |showTitle| determines whether to show or hide the titles on each section|true|
 |titleStyle| TextStyle of the titles| TextStyle(color: Colors.white, fontSize: 16, fontWeight: FontWeight.bold)|
 |title| title of the section| value|

--- a/test/chart/pie_chart/pie_chart_data_test.dart
+++ b/test/chart/pie_chart/pie_chart_data_test.dart
@@ -274,4 +274,47 @@ void main() {
       expect(mid.toRadius, 50);
     });
   });
+
+  group('PieChartSectionData', () {
+    test('equality', () {
+      final a =
+          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 8);
+      final b =
+          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 8);
+      expect(a == b, true);
+
+      expect(
+        a ==
+            PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 0),
+        false,
+      );
+    });
+
+    test('copyWith', () {
+      final original = PieChartSectionData(value: 10, color: Colors.red);
+      expect(original.sectionOffset, 0);
+
+      final withOffset = original.copyWith(sectionOffset: 12);
+      expect(withOffset.sectionOffset, 12);
+      expect(withOffset.value, 10);
+
+      expect(original.copyWith() == original, true);
+    });
+
+    test('lerp', () {
+      final a =
+          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 0);
+      final b =
+          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 20);
+
+      final atZero = PieChartSectionData.lerp(a, b, 0);
+      expect(atZero.sectionOffset, 0);
+
+      final atOne = PieChartSectionData.lerp(a, b, 1);
+      expect(atOne.sectionOffset, 20);
+
+      final mid = PieChartSectionData.lerp(a, b, 0.5);
+      expect(mid.sectionOffset, 10);
+    });
+  });
 }

--- a/test/chart/pie_chart/pie_chart_data_test.dart
+++ b/test/chart/pie_chart/pie_chart_data_test.dart
@@ -278,24 +278,23 @@ void main() {
   group('PieChartSectionData', () {
     test('equality', () {
       final a =
-          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 8);
+          PieChartSectionData(value: 10, color: Colors.red, radialOffset: 8);
       final b =
-          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 8);
+          PieChartSectionData(value: 10, color: Colors.red, radialOffset: 8);
       expect(a == b, true);
 
       expect(
-        a ==
-            PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 0),
+        a == PieChartSectionData(value: 10, color: Colors.red, radialOffset: 0),
         false,
       );
     });
 
     test('copyWith', () {
       final original = PieChartSectionData(value: 10, color: Colors.red);
-      expect(original.sectionOffset, 0);
+      expect(original.radialOffset, 0);
 
-      final withOffset = original.copyWith(sectionOffset: 12);
-      expect(withOffset.sectionOffset, 12);
+      final withOffset = original.copyWith(radialOffset: 12);
+      expect(withOffset.radialOffset, 12);
       expect(withOffset.value, 10);
 
       expect(original.copyWith() == original, true);
@@ -303,18 +302,18 @@ void main() {
 
     test('lerp', () {
       final a =
-          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 0);
+          PieChartSectionData(value: 10, color: Colors.red, radialOffset: 0);
       final b =
-          PieChartSectionData(value: 10, color: Colors.red, sectionOffset: 20);
+          PieChartSectionData(value: 10, color: Colors.red, radialOffset: 20);
 
       final atZero = PieChartSectionData.lerp(a, b, 0);
-      expect(atZero.sectionOffset, 0);
+      expect(atZero.radialOffset, 0);
 
       final atOne = PieChartSectionData.lerp(a, b, 1);
-      expect(atOne.sectionOffset, 20);
+      expect(atOne.radialOffset, 20);
 
       final mid = PieChartSectionData.lerp(a, b, 0.5);
-      expect(mid.sectionOffset, 10);
+      expect(mid.radialOffset, 10);
     });
   });
 }

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -370,7 +370,7 @@ void main() {
       expect(results[3]['paint_style'] as PaintingStyle, PaintingStyle.fill);
     });
 
-    test('test 3 - sectionOffset translates section along center angle', () {
+    test('test 3 - radialOffset translates section along center angle', () {
       const viewSize = Size(200, 200);
       const centerRadius = 10.0;
       const offset = 20.0;
@@ -378,7 +378,7 @@ void main() {
       final section0 = PieChartSectionData(
         color: MockData.color1,
         value: 1,
-        sectionOffset: offset,
+        radialOffset: offset,
       );
       final section1 = PieChartSectionData(
         color: MockData.color2,

--- a/test/chart/pie_chart/pie_chart_painter_test.dart
+++ b/test/chart/pie_chart/pie_chart_painter_test.dart
@@ -369,6 +369,69 @@ void main() {
       );
       expect(results[3]['paint_style'] as PaintingStyle, PaintingStyle.fill);
     });
+
+    test('test 3 - sectionOffset translates section along center angle', () {
+      const viewSize = Size(200, 200);
+      const centerRadius = 10.0;
+      const offset = 20.0;
+
+      final section0 = PieChartSectionData(
+        color: MockData.color1,
+        value: 1,
+        sectionOffset: offset,
+      );
+      final section1 = PieChartSectionData(
+        color: MockData.color2,
+        value: 1,
+      );
+      final data = PieChartData(
+        sectionsSpace: 0,
+        sections: [section0, section1],
+      );
+
+      final pieChartPainter = PieChartPainter();
+      final holder =
+          PaintHolder<PieChartData>(data, data, TextScaler.noScaling);
+
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((_) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      final drawnPaths = <Path>[];
+      when(mockCanvasWrapper.drawPath(captureAny, captureAny)).thenAnswer(
+        (inv) => drawnPaths.add(inv.positionalArguments[0] as Path),
+      );
+
+      pieChartPainter.drawSections(
+        mockCanvasWrapper,
+        [180, 180],
+        centerRadius,
+        holder,
+      );
+
+      expect(drawnPaths.length, 2);
+
+      const section0Center = Offset(100, 120);
+      final expectedPath0 = pieChartPainter.generateSectionPath(
+        section0,
+        0,
+        0,
+        180,
+        section0Center,
+        centerRadius,
+      );
+      expect(HelperMethods.equalsPaths(drawnPaths[0], expectedPath0), true);
+
+      const section1Center = Offset(100, 100);
+      final expectedPath1 = pieChartPainter.generateSectionPath(
+        section1,
+        0,
+        180,
+        180,
+        section1Center,
+        centerRadius,
+      );
+      expect(HelperMethods.equalsPaths(drawnPaths[1], expectedPath1), true);
+    });
   });
 
   group('generateSectionPath()', () {


### PR DESCRIPTION
This Pull Request aims to implement the requested "exploding" pie chart sections of https://github.com/imaNNeo/fl_chart/issues/2091.

# Solution

Adding a [sectionOffset] parameter to [PieChartSectionData] and use that to calculate the offset in [drawSections] of [PieChartPainter].