### PR TITLE
fix: Guard signingConfigs behind key.properties existence check

### DIFF
--- a/example/android/app/build.gradle.kts
+++ b/example/android/app/build.gradle.kts
@@ -36,18 +36,22 @@ android {
         versionName = flutter.versionName
     }
 
-    signingConfigs {
-        create("release") {
-            keyAlias = keystoreProperties["keyAlias"] as String
-            keyPassword = keystoreProperties["keyPassword"] as String
-            storeFile = keystoreProperties["storeFile"]?.let { file(it) }
-            storePassword = keystoreProperties["storePassword"] as String
+    if (keystorePropertiesFile.exists()) {
+        signingConfigs {
+            create("release") {
+                keyAlias = keystoreProperties["keyAlias"] as String
+                keyPassword = keystoreProperties["keyPassword"] as String
+                storeFile = keystoreProperties["storeFile"]?.let { file(it) }
+                storePassword = keystoreProperties["storePassword"] as String
+            }
         }
     }
 
     buildTypes {
         release {
-            signingConfig = signingConfigs.getByName("release")
+            if (keystorePropertiesFile.exists()) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap `signingConfigs` and its usage in `keystorePropertiesFile.exists()` check
- Prevents `null cannot be cast to non-null type kotlin.String` error when `key.properties` is missing

## Problem
The example app's `build.gradle.kts` unconditionally accesses `keystoreProperties["keyAlias"] as String` in the `signingConfigs` block. When `key.properties` doesn't exist (fresh clone, local dev), this crashes with:
```
null cannot be cast to non-null type kotlin.String
```

## Fix
Guard both the `signingConfigs` creation and its usage in `buildTypes.release` behind `keystorePropertiesFile.exists()`.

## Test plan
- [x] Verify `flutter build apk` works without `key.properties`
- [x] Verify `flutter build apk --release` works with valid `key.properties`