### PR TITLE
fix: Detect touches on downward (negative) BarChartRodStackItems

### DIFF
--- a/lib/src/chart/bar_chart/bar_chart_painter.dart
+++ b/lib/src/chart/bar_chart/bar_chart_painter.dart
@@ -943,7 +943,12 @@ class BarChartPainter extends AxisChartPainter<BarChartData> {
             final stackItem = nearestBarRod.rodStackItems[stackIndex];
             final fromPixel = getPixelY(stackItem.fromY, viewSize, holder);
             final toPixel = getPixelY(stackItem.toY, viewSize, holder);
-            if (touchedPoint.dy <= fromPixel && touchedPoint.dy >= toPixel) {
+            // A negative-direction stack item has fromY > toY, in which case
+            // fromPixel < toPixel (Flutter Y grows downward). Compare against
+            // the [min, max] range so the check works in either orientation.
+            final topPixel = min(fromPixel, toPixel);
+            final bottomPixel = max(fromPixel, toPixel);
+            if (touchedPoint.dy >= topPixel && touchedPoint.dy <= bottomPixel) {
               touchedStackIndex = stackIndex;
               touchedStack = stackItem;
               break;

--- a/test/chart/bar_chart/bar_chart_painter_test.dart
+++ b/test/chart/bar_chart/bar_chart_painter_test.dart
@@ -3398,6 +3398,48 @@ void main() {
         expect(result1.touchedRodDataIndex, 0);
       },
     );
+
+    test('detects touches on downward (negative) stack items', () {
+      const viewSize = Size(200, 100);
+      final barGroups = [
+        BarChartGroupData(
+          x: 0,
+          barRods: [
+            BarChartRodData(
+              fromY: 0,
+              toY: -10,
+              width: 20,
+              color: const Color(0xFF0000FF),
+              rodStackItems: [
+                BarChartRodStackItem(0, -10, const Color(0xFFFF0000)),
+              ],
+            ),
+          ],
+        ),
+      ];
+      final (minY, maxY) = BarChartHelper().calculateMaxAxisValues(barGroups);
+      final data = BarChartData(
+        barGroups: barGroups,
+        titlesData: const FlTitlesData(show: false),
+        alignment: BarChartAlignment.center,
+        barTouchData: const BarTouchData(handleBuiltInTouches: true),
+        minY: minY,
+        maxY: maxY,
+      );
+
+      final painter = BarChartPainter();
+      final holder =
+          PaintHolder<BarChartData>(data, data, TextScaler.noScaling);
+
+      // The single downward rod (fromY: 0, toY: -10) spans the full viewport
+      // height in pixels. A touch in the middle of the chart should land on
+      // the rod's only stack item.
+      final result =
+          painter.handleTouch(const Offset(100, 50), viewSize, holder);
+      expect(result, isNotNull);
+      expect(result!.touchedStackItemIndex, 0);
+      expect(result.touchedStackItem, isNotNull);
+    });
   });
 
   group('drawExtraLines()', () {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR uses the Conventional Commit prefix `fix:` per CONTRIBUTING.md.
The "exclude from commit message" markers below keep the template scaffolding (Checklist
/ Breaking Change / Related Issues) out of the squashed commit body — only "Description"
becomes part of the permanent git history.
-->

# Description
<!-- End of exclude from commit message -->
`BarChartPainter.handleTouch` iterates `rodStackItems` and checks
`dy <= fromPixel && dy >= toPixel` to decide which stack segment was touched.
That inequality silently fails for downward (negative) stack items, where
`fromY > toY` and therefore `fromPixel < toPixel` in screen space (Flutter Y
grows downward).

As a result, `BarTouchResponse.touchedStackItem` was always `null` and
`touchedStackItemIndex` was always `-1` for negative rod stacks, which breaks
tooltips and `getTooltipItem` / touch callbacks on common financial /
loss-style bar charts.

This PR makes the range check orientation-agnostic by computing
`topPixel = min(fromPixel, toPixel)` and `bottomPixel = max(fromPixel, toPixel)`,
then testing `dy >= topPixel && dy <= bottomPixel`. Upward behaviour is
unchanged (same bounds, same inclusive range); downward behaviour is now correct.

A regression test is added in the existing `handleTouch()` group: a single
group with one downward rod (`fromY: 0`, `toY: -10`) and one stack item
spanning the whole rod — a touch in the middle of the chart now returns
`touchedStackItemIndex == 0`; before the fix it returned `-1` (verified
fail-before / pass-after locally).

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation and added dartdoc comments with `///`. *(Internal-loop fix; no public API surface change.)*
- [-] I have updated/added relevant examples in `example`. *(Bug fix in existing behaviour; example app unchanged.)*

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues

Closes #2104.

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
