### PR TITLE
fix: Avoid RangeError when toDashedPath receives an empty dashArray

### DIFF
--- a/lib/src/extensions/path_extension.dart
+++ b/lib/src/extensions/path_extension.dart
@@ -10,7 +10,7 @@ extension DashedPath on Path {
   /// For example, the array `[5, 10]` would result in dashes 5 pixels long
   /// followed by blank spaces 10 pixels long.
   Path toDashedPath(List<int>? dashArray) {
-    if (dashArray != null) {
+    if (dashArray != null && dashArray.isNotEmpty) {
       final castedArray = dashArray.map((value) => value.toDouble()).toList();
       final dashedPath =
           dashPath(this, dashArray: CircularIntervalList<double>(castedArray));

--- a/test/extensions/path_extension_test.dart
+++ b/test/extensions/path_extension_test.dart
@@ -22,4 +22,16 @@ void main() {
 
     expect(HelperMethods.equalsPaths(path1.toDashedPath([10, 5]), path2), true);
   });
+
+  test('toDashedPath returns the original path for an empty dashArray', () {
+    // Regression test: previously, passing an empty list reached
+    // `CircularIntervalList<double>([]).next` inside `dashPath()` and threw
+    // `RangeError` for any non-empty source path. An empty `dashArray` has no
+    // dashes to repeat, so the source path is returned unchanged — mirroring
+    // the existing `null` behaviour.
+    final path = Path()
+      ..moveTo(0, 0)
+      ..lineTo(10, 0);
+    expect(path.toDashedPath([]), path);
+  });
 }


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
PR title uses `fix:` per CONTRIBUTING.md (Conventional Commits). The "exclude
from commit message" markers below keep the template scaffolding (Checklist /
Breaking Change) out of the squashed commit body so only Description ends up
in the permanent git history.
-->

# Description
<!-- End of exclude from commit message -->
`Path.toDashedPath([])` reached `CircularIntervalList<double>([]).next` inside
`dashPath()`, which indexed an empty list and threw `RangeError` for any
non-empty source path. The same crash was reachable indirectly via animation:
`lerpIntList` / `lerpList` can produce an empty list at mid-tween when
interpolating between a non-empty `dashArray` and `null`, turning a
configuration change into a paint-frame crash.

An empty dash spec has no dashes to repeat, so the source path is now returned
unchanged — mirroring the existing `null` branch's semantics and matching what
every current caller (line/bar painters, `CanvasWrapper`) expects when no dash
pattern is given.

A regression test is added next to the existing `toDashedPath` test:
`expect(path.toDashedPath([]), path)` on a non-empty source path; before the
fix this throws `RangeError`, after the fix it passes by returning `this`
(verified fail-before / pass-after locally; full test suite green: +664/664).

<!-- Exclude from commit message -->
## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation and added dartdoc comments with `///`. *(Internal-loop fix; no public API surface change.)*
- [-] I have updated/added relevant examples in `example`. *(Bug fix in existing behaviour; example app unchanged.)*

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->
