### PR TITLE
fix: Clip only the enabled FlClipData sides in line chart

### DIFF
--- a/lib/src/chart/line_chart/line_chart_painter.dart
+++ b/lib/src/chart/line_chart/line_chart_painter.dart
@@ -203,10 +203,13 @@ class LineChartPainter extends AxisChartPainter<LineChartData> {
     final clip = data.clipData;
     final border = data.borderData.show ? data.borderData.border : null;
 
-    var left = 0.0;
-    var top = 0.0;
-    var right = viewSize.width;
-    var bottom = viewSize.height;
+    // Sides that aren't enabled in [clip] must stay unclipped. We extend their
+    // boundary to infinity so [Canvas.clipRect] only clips the enabled sides
+    // (otherwise enabling any single side would clip all four).
+    var left = double.negativeInfinity;
+    var top = double.negativeInfinity;
+    var right = double.infinity;
+    var bottom = double.infinity;
 
     if (clip.left) {
       final borderWidth = border?.left.width ?? 0;

--- a/test/chart/line_chart/line_chart_painter_test.dart
+++ b/test/chart/line_chart/line_chart_painter_test.dart
@@ -351,10 +351,11 @@ void main() {
       final verifyResult = verify(mockCanvasWrapper.clipRect(captureAny));
       final rect = verifyResult.captured.single as Rect;
       verifyResult.called(1);
-      expect(rect.left, 0);
-      expect(rect.top, 0);
-      expect(rect.width, 400);
-      expect(rect.height, 400);
+      // No side is clipped, so every boundary is left unbounded.
+      expect(rect.left, double.negativeInfinity);
+      expect(rect.top, double.negativeInfinity);
+      expect(rect.right, double.infinity);
+      expect(rect.bottom, double.infinity);
     });
 
     test('test 2', () {
@@ -398,10 +399,11 @@ void main() {
       final verifyResult = verify(mockCanvasWrapper.clipRect(captureAny));
       final rect = verifyResult.captured.single as Rect;
       verifyResult.called(1);
+      // Only left and right are clipped; top and bottom stay unbounded.
       expect(rect.left, 4);
-      expect(rect.top, 0);
+      expect(rect.top, double.negativeInfinity);
       expect(rect.right, 396);
-      expect(rect.bottom, 400);
+      expect(rect.bottom, double.infinity);
     });
 
     test('test 3', () {
@@ -452,6 +454,40 @@ void main() {
       expect(rect.top, 4);
       expect(rect.right, 396);
       expect(rect.bottom, 396);
+    });
+
+    test('test 4 - enabling one side does not clip the others (#1262)', () {
+      const viewSize = Size(400, 400);
+
+      final data = LineChartData(
+        borderData: FlBorderData(show: true, border: Border.all(width: 8)),
+        clipData: const FlClipData(
+          top: false,
+          bottom: false,
+          left: true,
+          right: false,
+        ),
+      );
+
+      final lineChartPainter = LineChartPainter();
+      final holder =
+          PaintHolder<LineChartData>(data, data, TextScaler.noScaling);
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenAnswer((realInvocation) => viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      lineChartPainter.clipToBorder(
+        mockCanvasWrapper,
+        holder,
+      );
+
+      final verifyResult = verify(mockCanvasWrapper.clipRect(captureAny));
+      final rect = verifyResult.captured.single as Rect;
+      verifyResult.called(1);
+      // Only the left side is clipped; the other three stay unbounded.
+      expect(rect.left, 4);
+      expect(rect.top, double.negativeInfinity);
+      expect(rect.right, double.infinity);
+      expect(rect.bottom, double.infinity);
     });
   });
 


### PR DESCRIPTION
# Description
`LineChart`'s `clipToBorder()` built a single rect and passed it to `clipRect`, which always clips all four sides. Disabled sides were left at the canvas edge, so they still clipped overflow. As a result, enabling any single side in `FlClipData` clipped all four sides.

Disabled sides now extend to infinity, leaving them unbounded in `clipRect`; only the sides explicitly enabled in `FlClipData` get a real boundary. (`Canvas.clipRect` accepts infinite rects — its validity check only rejects `NaN`.)

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `example`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
Closes #1262

[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md