### PR TITLE
fix: Clip only the enabled FlClipData sides in scatter and candlestick charts

### DIFF
--- a/lib/src/chart/candlestick_chart/candlestick_chart_painter.dart
+++ b/lib/src/chart/candlestick_chart/candlestick_chart_painter.dart
@@ -73,10 +73,13 @@ class CandlestickChartPainter extends AxisChartPainter<CandlestickChartData> {
         _clipPaint,
       );
 
-      var left = 0.0;
-      var top = 0.0;
-      var right = viewSize.width;
-      var bottom = viewSize.height;
+      // Sides that aren't enabled in [clip] must stay unclipped. We extend
+      // their boundary to infinity so [Canvas.clipRect] only clips the enabled
+      // sides (otherwise enabling any single side would clip all four).
+      var left = double.negativeInfinity;
+      var top = double.negativeInfinity;
+      var right = double.infinity;
+      var bottom = double.infinity;
 
       if (clip.left) {
         final borderWidth = border?.left.width ?? 0;

--- a/lib/src/chart/scatter_chart/scatter_chart_painter.dart
+++ b/lib/src/chart/scatter_chart/scatter_chart_painter.dart
@@ -79,10 +79,13 @@ class ScatterChartPainter extends AxisChartPainter<ScatterChartData> {
         _clipPaint,
       );
 
-      var left = 0.0;
-      var top = 0.0;
-      var right = viewSize.width;
-      var bottom = viewSize.height;
+      // Sides that aren't enabled in [clip] must stay unclipped. We extend
+      // their boundary to infinity so [Canvas.clipRect] only clips the enabled
+      // sides (otherwise enabling any single side would clip all four).
+      var left = double.negativeInfinity;
+      var top = double.negativeInfinity;
+      var right = double.infinity;
+      var bottom = double.infinity;
 
       if (clip.left) {
         final borderWidth = border?.left.width ?? 0;

--- a/test/chart/candlestick_chart/candlestick_chart_painter_test.dart
+++ b/test/chart/candlestick_chart/candlestick_chart_painter_test.dart
@@ -54,6 +54,63 @@ void main() {
       verify(mockCanvas.drawLine(any, any, any)).called(6);
       Utils.changeInstance(utilsMainInstance);
     });
+
+    test('enabling one clip side does not clip the others (#1262)', () {
+      final utilsMainInstance = Utils();
+      const viewSize = Size(400, 400);
+      final data = CandlestickChartData(
+        candlestickSpots: [
+          candlestickSpot1,
+          candlestickSpot2,
+          candlestickSpot3,
+        ],
+        borderData: FlBorderData(show: true, border: Border.all(width: 8)),
+        clipData: const FlClipData(
+          top: false,
+          bottom: false,
+          left: true,
+          right: false,
+        ),
+      );
+
+      final candlestickPainter = CandlestickChartPainter();
+      final holder = PaintHolder<CandlestickChartData>(
+        data,
+        data,
+        TextScaler.noScaling,
+      );
+
+      final mockUtils = MockUtils();
+      Utils.changeInstance(mockUtils);
+      when(mockUtils.getEfficientInterval(any, any))
+          .thenAnswer((realInvocation) => 1.0);
+      when(mockUtils.getBestInitialIntervalValue(any, any, any))
+          .thenAnswer((realInvocation) => 1.0);
+      final mockBuildContext = MockBuildContext();
+      final mockCanvas = MockCanvas();
+      final canvasWrapper = CanvasWrapper(mockCanvas, viewSize);
+      candlestickPainter.paint(
+        mockBuildContext,
+        canvasWrapper,
+        holder,
+      );
+
+      final verifyResult = verify(
+        mockCanvas.clipRect(
+          captureAny,
+          clipOp: anyNamed('clipOp'),
+          doAntiAlias: anyNamed('doAntiAlias'),
+        ),
+      );
+      final rect = verifyResult.captured.single as Rect;
+      verifyResult.called(1);
+      // Only the left side is clipped; the other three stay unbounded.
+      expect(rect.left, 4);
+      expect(rect.top, double.negativeInfinity);
+      expect(rect.right, double.infinity);
+      expect(rect.bottom, double.infinity);
+      Utils.changeInstance(utilsMainInstance);
+    });
   });
 
   group('drawAxisSpotIndicator()', () {

--- a/test/chart/scatter_chart/scatter_chart_painter_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_painter_test.dart
@@ -268,6 +268,52 @@ void main() {
 
       verify(mockCanvasWrapper.clipRect(any)).called(1);
     });
+
+    test('enabling one clip side does not clip the others (#1262)', () {
+      const viewSize = Size(100, 100);
+
+      final data = ScatterChartData(
+        minY: 0,
+        maxY: 10,
+        minX: 0,
+        maxX: 10,
+        scatterSpots: [ScatterSpot(1, 1)],
+        titlesData: const FlTitlesData(show: false),
+        borderData: FlBorderData(show: true, border: Border.all(width: 8)),
+        clipData: const FlClipData(
+          top: false,
+          bottom: false,
+          left: true,
+          right: false,
+        ),
+      );
+
+      final scatterChartPainter = ScatterChartPainter();
+      final holder = PaintHolder<ScatterChartData>(
+        data,
+        data,
+        TextScaler.noScaling,
+      );
+
+      final mockBuildContext = MockBuildContext();
+      final mockCanvasWrapper = MockCanvasWrapper();
+      when(mockCanvasWrapper.size).thenReturn(viewSize);
+      when(mockCanvasWrapper.canvas).thenReturn(MockCanvas());
+      scatterChartPainter.drawSpots(
+        mockBuildContext,
+        mockCanvasWrapper,
+        holder,
+      );
+
+      final verifyResult = verify(mockCanvasWrapper.clipRect(captureAny));
+      final rect = verifyResult.captured.single as Rect;
+      verifyResult.called(1);
+      // Only the left side is clipped; the other three stay unbounded.
+      expect(rect.left, 4);
+      expect(rect.top, double.negativeInfinity);
+      expect(rect.right, double.infinity);
+      expect(rect.bottom, double.infinity);
+    });
   });
 
   group('drawTooltips()', () {


### PR DESCRIPTION
# Description
Same bug as #1262 (fixed for `LineChart` in #2107), but in `ScatterChart` and `CandlestickChart`. The clip blocks built a single rect and passed it to `clipRect`, which always clips all four sides. Disabled sides were left at the canvas edge, so they still clipped overflow. As a result, enabling any single side in `FlClipData` clipped all four sides.

Disabled sides now extend to infinity, leaving them unbounded in `clipRect`; only the sides explicitly enabled in `FlClipData` get a real boundary. Mirrors the line chart fix in #2107.

## Checklist

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [-] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `example`.

## Breaking Change?

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

## Related Issues
Related to #1262 and #2107 (same root cause, other chart types).

[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md