### PR TITLE
fix: Add localPosition to FlPanEndEvent so panEnd gets a touch response

### DIFF
--- a/lib/src/chart/base/base_chart/fl_touch_event.dart
+++ b/lib/src/chart/base/base_chart/fl_touch_event.dart
@@ -104,6 +104,10 @@ class FlPanEndEvent extends FlTouchEvent {
 
   /// Contains information of happened touch gesture
   final DragEndDetails details;
+
+  /// Represents the position of happened touch/pointer event
+  @override
+  Offset get localPosition => details.localPosition;
 }
 
 /// When a pointer that might cause a tap has contacted the screen.

--- a/test/chart/base/fl_touch_event_test.dart
+++ b/test/chart/base/fl_touch_event_test.dart
@@ -1,0 +1,82 @@
+import 'package:fl_chart/src/chart/base/base_chart/base_chart_data.dart';
+import 'package:fl_chart/src/chart/base/base_chart/fl_touch_event.dart';
+import 'package:fl_chart/src/chart/base/base_chart/render_base_chart.dart';
+import 'package:fl_chart/src/chart/line_chart/line_chart_data.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'render_base_chart_test.mocks.dart';
+
+void main() {
+  group('FlTouchEvent.localPosition', () {
+    test('FlPanEndEvent exposes localPosition from DragEndDetails', () {
+      const position = Offset(10, 20);
+      final event = FlPanEndEvent(
+        DragEndDetails(
+          globalPosition: position,
+          localPosition: position,
+        ),
+      );
+      expect(event.localPosition, position);
+    });
+
+    test('position-less events return null', () {
+      expect(const FlPanCancelEvent().localPosition, isNull);
+      expect(const FlTapCancelEvent().localPosition, isNull);
+    });
+  });
+
+  group('RenderBaseChart pan end response', () {
+    test('touchCallback receives response on pan end', () {
+      const position = Offset(10, 20);
+      late FlTouchEvent receivedEvent;
+      LineTouchResponse? receivedResponse;
+      void callback(FlTouchEvent event, LineTouchResponse? response) {
+        receivedEvent = event;
+        receivedResponse = response;
+      }
+
+      final chart = PanEndTestRenderBaseChart(
+        MockBuildContext(),
+        PanEndTestTouchData(true, callback, null, null),
+      );
+
+      chart.panGestureRecognizer.onEnd!.call(
+        DragEndDetails(
+          globalPosition: position,
+          localPosition: position,
+        ),
+      );
+
+      expect(receivedEvent, isA<FlPanEndEvent>());
+      expect(receivedEvent.localPosition, position);
+      expect(receivedResponse, isA<LineTouchResponse>());
+      expect(receivedResponse!.touchLocation, position);
+    });
+  });
+}
+
+class PanEndTestRenderBaseChart extends RenderBaseChart<LineTouchResponse> {
+  PanEndTestRenderBaseChart(
+    BuildContext context,
+    FlTouchData<LineTouchResponse>? touchData,
+  ) : super(touchData, context, canBeScaled: false);
+
+  @override
+  LineTouchResponse getResponseAtLocation(Offset localPosition) {
+    return LineTouchResponse(
+      touchLocation: localPosition,
+      touchChartCoordinate: localPosition,
+      lineBarSpots: [],
+    );
+  }
+}
+
+class PanEndTestTouchData extends FlTouchData<LineTouchResponse> {
+  PanEndTestTouchData(
+    super.enabled,
+    super.touchCallback,
+    super.mouseCursorResolver,
+    super.longPressDuration,
+  );
+}


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a concise description of what this PR is doing. 
Keep it short and clear, as this text will be included in the permanent Git commit history.
-->
<!-- End of exclude from commit message -->
`FlPanEndEvent` was the only positional touch event without a `localPosition` override, so `RenderBaseChart._notifyTouchEvent` skipped `getResponseAtLocation` and `touchCallback` always received a `null` response on pan end (originally reported as "always gets the first spot").

This PR adds the missing override. `DragEndDetails` carries `globalPosition`/`localPosition` on all Flutter versions supported by this package, for both the fling and non-fling paths of `PanGestureRecognizer`, so no gesture plumbing changes are needed — unlike the historical attempt in #268, which had to replace the pan gesture entirely because `DragEndDetails` had no position information back in 2020. `isInterestedForInteractions` still excludes `FlPanEndEvent`, so the built-in tooltip behavior is unchanged.

Verified with unit tests and manually on Android/iOS: dragging a `LineChart` and releasing now delivers the spots under the release position to `touchCallback`.

<!-- Exclude from commit message -->
## TestResult

Left Before, Right After

### Android

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/c4dafb77-9300-49f3-9a75-22be066b4181" width="40%">
    <img src="https://github.com/user-attachments/assets/ae7255d3-2718-437e-b6ad-883fc39fb8f9" width="40%">
</div>

### iOS

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/e3db0b2f-b7f7-4f75-8dad-6f64192fbefb" width="40%">
    <img src="https://github.com/user-attachments/assets/05be0033-483e-48d9-a5d9-661b344edb90" width="40%">
</div>

### Chrome

#### Before

<img width="2400" height="1228" alt="chrome-before-pan" src="https://github.com/user-attachments/assets/cf56e2a5-2db8-4360-8333-9c283452cc74" />

#### After

<img width="2400" height="1228" alt="chrome-after-pan-PANEND-spots" src="https://github.com/user-attachments/assets/e8a9873d-b8b2-4b73-adce-18f43ce13dee" />

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `example`.


## Breaking Change?
<!--
Would your PR require fl_chart users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version.
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #265

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->