### PR TITLE
fix: Keep axis title values on the interval grid for large values

### DIFF
--- a/lib/src/chart/base/axis_chart/axis_chart_helper.dart
+++ b/lib/src/chart/base/axis_chart/axis_chart_helper.dart
@@ -30,30 +30,38 @@ class AxisChartHelper {
   }) sync* {
     final initialValue = Utils()
         .getBestInitialIntervalValue(min, max, interval, baseline: baseLine);
-    var axisSeek = initialValue;
-    final firstPositionOverlapsWithMin = axisSeek == min;
-    if (!minIncluded && firstPositionOverlapsWithMin) {
-      // If initial value is equal to data minimum,
-      // move first label one interval further
-      axisSeek += interval;
-    }
-    final diff = max - min;
-    final count = diff ~/ interval;
-    final lastPosition = initialValue + (count * interval);
-    final lastPositionOverlapsWithMax = lastPosition == max;
-    final end =
-        !maxIncluded && lastPositionOverlapsWithMax ? max - interval : max;
+    final firstPositionOverlapsWithMin = initialValue == min;
+
+    // Values are computed as initialValue + index * interval instead of
+    // accumulating `+= interval`, because accumulation drifts on large
+    // values (e.g. epoch timestamps) and produces artifacts like
+    // 1698797425.999999 right next to max.
+    var index = !minIncluded && firstPositionOverlapsWithMin ? 1 : 0;
 
     final epsilon = interval / 100000;
     if (minIncluded && !firstPositionOverlapsWithMin) {
       // Data minimum shall be included and is not yet covered
       yield min;
     }
-    while (axisSeek <= end + epsilon) {
+    var reachedMax = false;
+    while (true) {
+      final axisSeek = initialValue + index * interval;
+      final overshoot = axisSeek - max;
+      if (overshoot > epsilon) {
+        break;
+      }
+      if (overshoot.abs() <= epsilon) {
+        // Landed on data maximum: snap to the exact max value
+        if (maxIncluded) {
+          yield max;
+        }
+        reachedMax = true;
+        break;
+      }
       yield axisSeek;
-      axisSeek += interval;
+      index++;
     }
-    if (maxIncluded && !lastPositionOverlapsWithMax) {
+    if (maxIncluded && !reachedMax) {
       yield max;
     }
   }

--- a/test/chart/base/axis_chart/axis_chart_helper_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_helper_test.dart
@@ -98,6 +98,33 @@ void main() {
       expect(results[2], 25);
       expect(results[3], 35);
     });
+
+    test('large values do not drift away from the interval grid (#1473)', () {
+      const min = 1698797425.0;
+      const max = 1698797426.0;
+      const interval = 0.1;
+      final results = <double>[];
+      AxisChartHelper()
+          .iterateThroughAxis(
+            min: min,
+            max: max,
+            interval: interval,
+            baseLine: 0,
+          )
+          .forEach(results.add);
+
+      expect(results.last, max);
+      // No artifact label may sit right next to max (e.g. 1698797425.999999);
+      // every neighboring pair must be roughly one interval apart.
+      for (var i = 1; i < results.length; i++) {
+        expect(
+          results[i] - results[i - 1],
+          greaterThan(interval / 2),
+          reason: 'values ${results[i - 1]} and ${results[i]} are '
+              'closer than half an interval',
+        );
+      }
+    });
   });
 
   group('calcFitInsideOffset', () {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a concise description of what this PR is doing. 
Keep it short and clear, as this text will be included in the permanent Git commit history.
-->
<!-- End of exclude from commit message -->
`AxisChartHelper.iterateThroughAxis` walked the axis with `axisSeek += interval`. Accumulating in a loop makes the floating point error grow with every step, so on large values — epoch timestamps being the common case — the last emitted value drifts slightly off the grid. With `minX: 1698797425, maxX: 1698797426` the iteration yields `1698797425.999999` instead of `1698797426`, so a `getTitlesWidget` that renders a label only when `value == meta.max` never matches and the trailing title silently disappears.

The loop now derives each value as `initialValue + index * interval`, which keeps the error bounded instead of cumulative, and snaps to the exact `max` when a step lands on it (within the interval-scaled epsilon that was already used for the loop bound). Behavior for small ranges is unchanged — the existing `iterateThroughAxis` tests pass untouched.

Added a regression test that reproduces the issue's exact numbers and asserts both that the last value equals `max` and that no artifact value sits closer than half an interval to its neighbor.

<!-- Exclude from commit message -->
## TestResult

Left Before, Right After

### Android

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/b60ac386-5dc0-4c88-a9f5-cb12618b9516" width="40%">
    <img src="https://github.com/user-attachments/assets/5a7bd36f-81ed-48e5-8a22-54d1d5640d84" width="40%">
</div>

### iOS

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/cac2955f-9db1-429d-bfb3-72201879dd15" width="40%">
    <img src="https://github.com/user-attachments/assets/f998f15a-0d98-460c-8174-56c326adff24" width="40%">
</div>

### Chrome

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/bf468dd3-e685-4f84-a897-cc3d16502f38" width="40%">
    <img src="https://github.com/user-attachments/assets/8ef5dab9-40d7-4f19-9cb5-5ace58b32d04" width="40%">
</div>

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `example`.


## Breaking Change?
<!--
Would your PR require fl_chart users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version.
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #1473

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->