### PR TITLE
fix: Respect axis range when formatting K/M/B axis labels

### DIFF
--- a/lib/src/utils/utils.dart
+++ b/lib/src/utils/utils.dart
@@ -236,27 +236,33 @@ class Utils {
       axisValue = axisValue.abs();
     }
 
+    final diff = (axisMin - axisMax).abs();
+
     String resultNumber;
     String symbol;
     if (axisValue >= billion) {
-      resultNumber = (axisValue / billion).toStringAsFixed(1);
+      resultNumber = (axisValue / billion)
+          .toStringAsFixed(getFractionDigits(diff / billion));
       symbol = 'B';
     } else if (axisValue >= million) {
-      resultNumber = (axisValue / million).toStringAsFixed(1);
+      resultNumber = (axisValue / million)
+          .toStringAsFixed(getFractionDigits(diff / million));
       symbol = 'M';
     } else if (axisValue >= kilo) {
-      resultNumber = (axisValue / kilo).toStringAsFixed(1);
+      resultNumber =
+          (axisValue / kilo).toStringAsFixed(getFractionDigits(diff / kilo));
       symbol = 'K';
     } else {
-      final diff = (axisMin - axisMax).abs();
       resultNumber = axisValue.toStringAsFixed(
         getFractionDigits(diff),
       );
       symbol = '';
     }
 
-    if (resultNumber.endsWith('.0')) {
-      resultNumber = resultNumber.substring(0, resultNumber.length - 2);
+    if (resultNumber.contains('.')) {
+      resultNumber = resultNumber
+          .replaceAll(RegExp(r'0+$'), '')
+          .replaceAll(RegExp(r'\.$'), '');
     }
 
     if (isNegative) {

--- a/test/utils/utils_test.dart
+++ b/test/utils/utils_test.dart
@@ -214,25 +214,49 @@ void main() {
     expect(Utils().formatNumber(0, 10, 423), '423');
     expect(Utils().formatNumber(0, 10, -423), '-423');
     expect(Utils().formatNumber(0, 10, 1000), '1K');
-    expect(Utils().formatNumber(0, 10, 1234), '1.2K');
+    expect(Utils().formatNumber(0, 5000, 1234), '1.2K');
     expect(Utils().formatNumber(0, 10, 10000), '10K');
-    expect(Utils().formatNumber(0, 10, 41234), '41.2K');
-    expect(Utils().formatNumber(0, 10, 82349), '82.3K');
-    expect(Utils().formatNumber(0, 10, 82350), '82.3K');
-    expect(Utils().formatNumber(0, 10, 82351), '82.4K');
-    expect(Utils().formatNumber(0, 10, -82351), '-82.4K');
+    expect(Utils().formatNumber(0, 50000, 41234), '41.2K');
+    expect(Utils().formatNumber(0, 100000, 82349), '82.3K');
+    expect(Utils().formatNumber(0, 100000, 82350), '82.3K');
+    expect(Utils().formatNumber(0, 100000, 82351), '82.4K');
+    expect(Utils().formatNumber(0, 100000, -82351), '-82.4K');
     expect(Utils().formatNumber(0, 10, 100000), '100K');
     expect(Utils().formatNumber(0, 10, 101000), '101K');
-    expect(Utils().formatNumber(0, 10, 2345123), '2.3M');
-    expect(Utils().formatNumber(0, 10, 2352123), '2.4M');
-    expect(Utils().formatNumber(0, 10, -2352123), '-2.4M');
+    expect(Utils().formatNumber(0, 5000000, 2345123), '2.3M');
+    expect(Utils().formatNumber(0, 5000000, 2352123), '2.4M');
+    expect(Utils().formatNumber(0, 5000000, -2352123), '-2.4M');
     expect(Utils().formatNumber(0, 10, 521000000), '521M');
-    expect(Utils().formatNumber(0, 10, 4324512345), '4.3B');
+    expect(Utils().formatNumber(0, 5000000000, 4324512345), '4.3B');
     expect(Utils().formatNumber(0, 10, 4000000000), '4B');
     expect(Utils().formatNumber(0, 10, -4000000000), '-4B');
-    expect(Utils().formatNumber(0, 10, 823147521343), '823.1B');
-    expect(Utils().formatNumber(0, 10, 8231475213435), '8231.5B');
-    expect(Utils().formatNumber(0, 10, -8231475213435), '-8231.5B');
+    expect(Utils().formatNumber(0, 1000000000000, 823147521343), '823.1B');
+    expect(Utils().formatNumber(0, 10000000000000, 8231475213435), '8231.5B');
+    expect(
+      Utils().formatNumber(0, 10000000000000, -8231475213435),
+      '-8231.5B',
+    );
+  });
+
+  test('test formatNumber uses axis range for K/M/B fraction digits (#1584)',
+      () {
+    // Narrow range over large values: labels must stay distinguishable.
+    const min = 976405.27;
+    const max = 1135594.31;
+    expect(Utils().formatNumber(min, max, 1000000), '1M');
+    expect(
+      Utils().formatNumber(min, max, 1010000),
+      isNot(Utils().formatNumber(min, max, 1000000)),
+    );
+    expect(Utils().formatNumber(min, max, 1010000), '1.01M');
+    expect(Utils().formatNumber(min, max, 1030000), '1.03M');
+    expect(Utils().formatNumber(min, max, 1135594.31), '1.14M');
+    expect(Utils().formatNumber(min, max, 976405.27), '976.4K');
+
+    // Wide ranges keep the short single-digit form.
+    expect(Utils().formatNumber(0, 5000000, 2345123), '2.3M');
+    expect(Utils().formatNumber(0, 5000, 1234), '1.2K');
+    expect(Utils().formatNumber(0, 5000000000, 4324512345), '4.3B');
   });
 
   group('test getThemeAwareTextStyle', () {


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a concise description of what this PR is doing. 
Keep it short and clear, as this text will be included in the permanent Git commit history.
-->
<!-- End of exclude from commit message -->
`Utils.formatNumber` receives `axisMin` / `axisMax` so it can pick a sensible precision, but only the sub-thousand branch actually used them. The `K` / `M` / `B` branches called `toStringAsFixed(1)` unconditionally, so the axis range was ignored as soon as a value crossed 1000. With the reporter's data (`minY: 976405.27`, `maxY: 1135594.31`) every left title above 1M rounds to the same string and the axis reads `1.1M / 1.1M / 1.1M`.

Each branch now derives its fraction digits from the axis diff scaled by the same divisor it uses for the value — `getFractionDigits(diff / million)` for the `M` branch and so on — so precision follows how much the axis actually spans. The trailing-zero trim was also generalized: it previously only stripped a literal `.0` suffix, which would leave `1.10M` once more than one digit is produced.

Note on the test diff: some existing `formatNumber` rows passed an axis range unrelated to the value being formatted (e.g. `formatNumber(0, 10, 2345123)` — a range of 10 with a value in the millions). Those combinations cannot occur in a real chart, and with the fix they would ask for a precision the old hardcoded value silently ignored. They are updated to ranges matching the value scale (`formatNumber(0, 5000000, 2345123)`); the expected outputs are unchanged. Rows where the range was already consistent are untouched.

<!-- Exclude from commit message -->
## TestResult

Left Before, Right After

### Android

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/ebeb200e-89cd-470e-88c7-64a4012b0df4" width="40%">
    <img src="https://github.com/user-attachments/assets/4e30d5b4-8f57-451b-a488-8dd50dddab40" width="40%">
</div>

### iOS

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/134d303d-b1ff-4439-8ab6-9ec5db13eebe" width="40%">
    <img src="https://github.com/user-attachments/assets/cdffad8d-a6eb-4e98-ba55-5370a8e5eea7" width="40%">
</div>

### Chrome

<div style="dispaly:flex">
    <img src="https://github.com/user-attachments/assets/2c8306e3-54f0-4f37-b76f-d2b439ceab8f" width="40%">
    <img src="https://github.com/user-attachments/assets/ad00ce18-7721-4bd1-bcc7-583135d6c418" width="40%">
</div>

## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [-] I have updated/added relevant examples in `example`.


## Breaking Change?
<!--
Would your PR require fl_chart users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version.
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #1584

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->