### PR TITLE
fix: Dispose gesture recognizers in RenderBaseChart

### DIFF
--- a/lib/src/chart/base/base_chart/render_base_chart.dart
+++ b/lib/src/chart/base/base_chart/render_base_chart.dart
@@ -225,4 +225,12 @@ abstract class RenderBaseChart<R extends BaseTouchResponse> extends RenderBox
     _validForMouseTracker = false;
     super.detach();
   }
+
+  @override
+  void dispose() {
+    panGestureRecognizer.dispose();
+    tapGestureRecognizer.dispose();
+    longPressGestureRecognizer.dispose();
+    super.dispose();
+  }
 }

--- a/test/chart/bar_chart/bar_chart_test.dart
+++ b/test/chart/bar_chart/bar_chart_test.dart
@@ -171,12 +171,14 @@ void main() {
 
       await tester.pumpAndSettle();
 
+      final transformationController = TransformationController();
+      addTearDown(transformationController.dispose);
       final transformationConfig = FlTransformationConfig(
         scaleAxis: FlScaleAxis.free,
         trackpadScrollCausesScale: true,
         maxScale: 10,
         minScale: 1.5,
-        transformationController: TransformationController(),
+        transformationController: transformationController,
       );
       await tester.pumpWidget(
         createTestWidget(

--- a/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
+++ b/test/chart/base/axis_chart/axis_chart_scaffold_widget_test.dart
@@ -526,6 +526,7 @@ void main() {
       );
 
       final transformationController = TransformationController();
+      addTearDown(transformationController.dispose);
       await pumpTestWidget(
         AxisChartScaffoldWidget(
           data: lineChartDataWithAllTitles,
@@ -1259,6 +1260,7 @@ void main() {
         final controller = TransformationController(
           Matrix4.identity()..scaleByDouble(3, 3, 3, 1),
         );
+        addTearDown(controller.dispose);
         Rect? chartVirtualRect;
         await tester.pumpWidget(
           MaterialApp(
@@ -1365,6 +1367,7 @@ void main() {
           expect(chartVirtualRects, actualChartVirtualRects..add(isScaled));
 
           final transformationController2 = TransformationController();
+          addTearDown(transformationController2.dispose);
 
           await tester.pumpWidget(
             createTestWidget(controller: transformationController2),
@@ -1390,6 +1393,7 @@ void main() {
         (tester) async {
           final actualChartVirtualRects = <Object?>[isNotScaled];
           final transformationController = TransformationController();
+          addTearDown(transformationController.dispose);
           await tester.pumpWidget(
             createTestWidget(controller: transformationController),
           );
@@ -1424,6 +1428,7 @@ void main() {
         (tester) async {
           final actualChartVirtualRects = <Object?>[isNotScaled];
           final transformationController = TransformationController();
+          addTearDown(transformationController.dispose);
           await tester.pumpWidget(
             createTestWidget(controller: transformationController),
           );
@@ -1435,6 +1440,7 @@ void main() {
           expect(chartVirtualRects, actualChartVirtualRects..add(isScaled));
 
           final transformationController2 = TransformationController();
+          addTearDown(transformationController2.dispose);
 
           await tester.pumpWidget(
             createTestWidget(controller: transformationController2),
@@ -1459,6 +1465,7 @@ void main() {
         (tester) async {
           final actualChartVirtualRects = <Object?>[isNotScaled];
           final transformationController = TransformationController();
+          addTearDown(transformationController.dispose);
           await tester.pumpWidget(
             createTestWidget(
               controller: transformationController,
@@ -1492,6 +1499,7 @@ void main() {
       'sets chartVirtualRect to null, when scaling is updated to 1.0',
       (tester) async {
         final transformationController = TransformationController();
+        addTearDown(transformationController.dispose);
         final chartVirtualRects = <Rect?>[];
         final actualChartVirtualRects = <Object?>[isNotScaled];
         await tester.pumpWidget(
@@ -1525,6 +1533,7 @@ void main() {
 
     testWidgets('does not dispose external controller', (tester) async {
       final controller = TransformationController();
+      addTearDown(controller.dispose);
       await tester.pumpWidget(
         MaterialApp(
           home: AxisChartScaffoldWidget(

--- a/test/chart/base/render_base_chart_test.dart
+++ b/test/chart/base/render_base_chart_test.dart
@@ -109,6 +109,21 @@ void main() {
         },
       );
 
+      test('disposes gesture recognizers on dispose (#1975)', () {
+        TestRenderBaseChart(
+          mockContext,
+          data,
+          canBeScaled: false,
+          panGestureRecognizerOverride: panGestureRecognizer,
+          tapGestureRecognizerOverride: tapGestureRecognizer,
+          longPressGestureRecognizerOverride: longPressGestureRecognizer,
+        ).dispose();
+
+        verify(panGestureRecognizer.dispose()).called(1);
+        verify(tapGestureRecognizer.dispose()).called(1);
+        verify(longPressGestureRecognizer.dispose()).called(1);
+      });
+
       test('calls touchCallback for PointerHoverEvent', () {
         late FlTouchEvent testEvent;
         late LineTouchResponse? testResponse;

--- a/test/chart/candlestick_chart/candlestick_chart_test.dart
+++ b/test/chart/candlestick_chart/candlestick_chart_test.dart
@@ -57,12 +57,14 @@ void main() {
 
       await tester.pumpAndSettle();
 
+      final transformationController = TransformationController();
+      addTearDown(transformationController.dispose);
       final transformationConfig = FlTransformationConfig(
         scaleAxis: FlScaleAxis.free,
         trackpadScrollCausesScale: true,
         maxScale: 10,
         minScale: 1.5,
-        transformationController: TransformationController(),
+        transformationController: transformationController,
       );
       await tester.pumpWidget(
         createTestWidget(

--- a/test/chart/line_chart/line_chart_test.dart
+++ b/test/chart/line_chart/line_chart_test.dart
@@ -52,12 +52,14 @@ void main() {
 
       await tester.pumpAndSettle();
 
+      final transformationController = TransformationController();
+      addTearDown(transformationController.dispose);
       final transformationConfig = FlTransformationConfig(
         scaleAxis: FlScaleAxis.free,
         trackpadScrollCausesScale: true,
         maxScale: 10,
         minScale: 1.5,
-        transformationController: TransformationController(),
+        transformationController: transformationController,
       );
       await tester.pumpWidget(
         createTestWidget(

--- a/test/chart/scatter_chart/scatter_chart_test.dart
+++ b/test/chart/scatter_chart/scatter_chart_test.dart
@@ -57,12 +57,14 @@ void main() {
 
       await tester.pumpAndSettle();
 
+      final transformationController = TransformationController();
+      addTearDown(transformationController.dispose);
       final transformationConfig = FlTransformationConfig(
         scaleAxis: FlScaleAxis.free,
         trackpadScrollCausesScale: true,
         maxScale: 10,
         minScale: 1.5,
-        transformationController: TransformationController(),
+        transformationController: transformationController,
       );
       await tester.pumpWidget(
         createTestWidget(


### PR DESCRIPTION
<!-- Exclude from commit message -->
<!--
The title of your PR on the line above should start with a [Conventional Commit] prefix
(`fix:`, `feat:`, `docs:`, `test:`, `chore:`, `refactor:`, `perf:`, `build:`, `ci:`,
`style:`, `revert:`). This title will later become an entry in the [CHANGELOG], so please
make sure that it summarizes the PR adequately.

Don't remove the "exclude from commit message" comments below. They are used to prevent
the PR description template from being included in the git log.
Only change the "Replace this text" parts.
-->

# Description
<!--
Provide a concise description of what this PR is doing. 
Keep it short and clear, as this text will be included in the permanent Git commit history.
-->
<!-- End of exclude from commit message -->
`RenderBaseChart.initGestureRecognizers` creates a `PanGestureRecognizer`, a `TapGestureRecognizer` and a `LongPressGestureRecognizer`, but nothing ever released them. With the `leak_tracker_flutter_testing` harness from the issue, `line_chart_test.dart` alone reports 70 `notDisposed` leaks for those three types.

**Where they are disposed.** The issue suggests disposing in `detach()`. That would leak-check clean but is not safe: a `RenderObject` can be detached and re-attached (for example when it moves in the tree), and the recognizers must still be usable after that — disposing them in `detach()` would leave the chart with dead recognizers on re-attach. They are disposed in `dispose()` instead, which the framework calls exactly once when the render object is really gone.

**About the TransformationController leaks.** I could not reproduce them as a library bug. Enabling creation stack traces in the leak tracker showed every leaked `TransformationController` was constructed inside the test files themselves, not by `AxisChartScaffoldWidget` or `CustomInteractiveViewer` — both of those already dispose the controller they own and correctly leave an externally provided one alone. The fix here is therefore on the test side: the tests now dispose the controllers they create (via `addTearDown`). No library change was needed for that half of the report.

With the issue's harness enabled locally, the whole suite (664 tests) runs leak-free.

<!-- Exclude from commit message -->
<!-- Exclude from commit message -->
## Test Result

Reproduced with the harness from the issue — `leak_tracker_flutter_testing` as a dev dependency plus `test/flutter_test_config.dart`. It is already a transitive dependency of `flutter_test`, so no dependency change is needed in this repo; I added it locally only to produce the reports below and reverted it afterwards.

Both runs use the exact same command on the same test file:

```
flutter test test/chart/line_chart/line_chart_test.dart
```

### Before — `main`

23 tests pass, then `tearDownAll` fails with 70 undisposed objects:

```
notDisposed:
  total: 70
  objects:
    PanGestureRecognizer:
      test: passes canBeScaled true for FlScaleAxis.free
      identityHashCode: 764283347
    TapGestureRecognizer:
      test: passes canBeScaled true for FlScaleAxis.free
      identityHashCode: 453320791
    LongPressGestureRecognizer:
      test: passes canBeScaled true for FlScaleAxis.free
      identityHashCode: 811505688
    ... (69 recognizer entries in total)
```

Full log: [leak-report-before.txt](https://github.com/user-attachments/files/30373631/leak-report-before.txt)

### After — this branch

Same 23 tests, leak-free:

```
00:01 +23: (tearDownAll)
00:01 +23: All tests passed!
```

Full log: [leak-report-after.txt](https://github.com/user-attachments/files/30373630/leak-report-after.txt)

Running the whole suite (664 tests) with the same harness is also leak-free.
<!-- End of exclude from commit message -->


## Checklist
<!--
Before you create this PR confirm that it meets all requirements listed below by checking the
relevant checkboxes with `[x]`. If some checkbox is not applicable, mark it as `[-]`.
-->

- [x] I have followed the [Contributor Guide] when preparing my PR.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation and added dartdoc comments with `///`.
- [ ] I have updated/added relevant examples in `example`.


## Breaking Change?
<!--
Would your PR require fl_chart users to update their apps following your change?

If yes, then the title of the PR should include "!" (for example, `feat!:`, `fix!:`). See
[Conventional Commit] for details. Also, for a breaking PR uncomment and fill in the "Migration
instructions" section below.
-->

- [ ] Yes, this PR is a breaking change.
- [x] No, this PR is not a breaking change.

<!--
### Migration instructions

If the PR is breaking, uncomment this header and add instructions for how to migrate from the
currently released version.
-->
<!-- End of exclude from commit message -->
<!-- Exclude from commit message -->

## Related Issues
<!--
Indicate which issues this PR resolves, if any. For example:

Closes #1234
!-->

Closes #1975

<!-- Links -->
[Contributor Guide]: https://github.com/imaNNeo/fl_chart/blob/main/CONTRIBUTING.md
[Conventional Commit]: https://conventionalcommits.org
[CHANGELOG]: https://github.com/imaNNeo/fl_chart/blob/main/CHANGELOG.md
<!-- End of exclude from commit message -->